### PR TITLE
chore: Update description of txs compression

### DIFF
--- a/specs/span-batches.md
+++ b/specs/span-batches.md
@@ -227,8 +227,8 @@ Deposit transactions are excluded in batches and are never written at L1 so excl
 
 ### Adjust `txs` Data Layout for Better Compression
 
-There are (7 choose 2) * 5! = 2520 permutations of ordering fields of `txs`.
-It is not 7! because `contract_creation_bits` must be first decoded in order to decode `tx_tos`.
+There are (8 choose 2) * 6! = 20160 permutations of ordering fields of `txs`.
+It is not 8! because `contract_creation_bits` must be first decoded in order to decode `tx_tos`.
 We experimented to find out the best layout for compression.
 It turned out placing random data together(`TxSigs`, `TxTos`, `TxDatas`),
 then placing leftovers helped gzip to gain more size reduction.


### PR DESCRIPTION
`protected_bits` was added in [commit](https://github.com/ethereum-optimism/optimism/commit/a35425c52387f354ba2f6b586d81f8e6defd9633)

the description of txs compression should be updated