### PR TITLE
specs: lint links

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ that maintains 1:1 compatibility with Ethereum.
 - [Withdrawals](specs/withdrawals.md)
 - [Execution Engine](specs/exec-engine.md)
 - [L2 Output Root Proposals](specs/proposals.md)
-- [Rollup Node](specs/rollup-node.mdode.md)
+- [Rollup Node](specs/rollup-node.md)
 - [Rollup Node P2p](specs/rollup-node-p2p.md)
 - [L2 Chain Derivation](specs/derivation.md)
 - [Superchain Upgrades](specs/superchain-upgrades.md)

--- a/specs/deposits.md
+++ b/specs/deposits.md
@@ -370,7 +370,7 @@ The contract has the following solidity interface, and can be interacted with ac
 
 A reference implementation of the L1 Attributes predeploy contract can be found in [L1Block.sol].
 
-[L1Block.sol]: ../packages/contracts-bedrock/src/L2/L1Block.sol
+[L1Block.sol]: https://github.com/ethereum-optimism/optimism/blob/d48b45954c381f75a13e61312da68d84e9b41418/packages/contracts-bedrock/src/L2/L1Block.sol
 
 After running `pnpm build` in the `packages/contracts-bedrock` directory, the bytecode to add to
 the genesis file will be located in the `deployedBytecode` field of the build artifacts file at
@@ -455,4 +455,4 @@ it possible for users to interact with contracts on L2 even when the Sequencer i
 
 A reference implementation of the deposit contract can be found in [OptimismPortal.sol].
 
-[OptimismPortal.sol]: ../packages/contracts-bedrock/src/L1/OptimismPortal.sol
+[OptimismPortal.sol]: https://github.com/ethereum-optimism/optimism/blob/d48b45954c381f75a13e61312da68d84e9b41418/packages/contracts-bedrock/src/L1/OptimismPortal.sol

--- a/specs/proposals.md
+++ b/specs/proposals.md
@@ -23,7 +23,9 @@ After processing one or more blocks the outputs will need to be synchronized wit
 for trustless execution of L2-to-L1 messaging, such as withdrawals.
 These output proposals act as the bridge's view into the L2 state.
 Actors called "Proposers" submit the output roots to the settlement layer (L1) and can be contested with a fault proof,
-with a bond at stake if the proof is wrong. The [op-proposer](../op-proposer/) in one such implementation of a proposer.
+with a bond at stake if the proof is wrong. The [op-proposer][op-proposer] in one such implementation of a proposer.
+
+[op-proposer]: https://github.com/ethereum-optimism/optimism/tree/d48b45954c381f75a13e61312da68d84e9b41418/op-proposer
 
 _Note_: Fault proofs on Optimism are not fully specified at this time. Although fault proof
 construction and verification [is implemented in Cannon][cannon],
@@ -45,7 +47,7 @@ submits it to the `L2OutputOracle` contract on the settlement layer (L1).
 The submission of output proposals is permissioned to a single account. It is expected that this
 account will continue to submit output proposals over time to ensure that user withdrawals do not halt.
 
-The [L2 output proposer](../op-proposer) is expected to submit output roots on a deterministic
+The [L2 output proposer][op-proposer] is expected to submit output roots on a deterministic
 interval based on the configured `SUBMISSION_INTERVAL` in the `L2OutputOracle`. The larger
 the `SUBMISSION_INTERVAL`, the less often L1 transactions need to be sent to the `L2OutputOracle`
 contract, but L2 users will need to wait a bit longer for an output root to be included in L1 (the settlement layer)


### PR DESCRIPTION
**Description**

When migrating to the new repo (https://github.com/ethereum-optimism/specs)
some links became broken. This commit fixes the links so that the
lint-links command exits with a success.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

