### PR TITLE
specs: lint fault proof specs

### DIFF
--- a/specs/experimental/fault-proof/bond-incentives.md
+++ b/specs/experimental/fault-proof/bond-incentives.md
@@ -1,5 +1,18 @@
 # Bond Incentives
 
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**
+
+- [Overview](#overview)
+- [Moves](#moves)
+- [Subgame Resolution](#subgame-resolution)
+  - [Leftmost Claim Incentives](#leftmost-claim-incentives)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Overview
+
 Bonds is an add-on to the core [Fault Dispute Game](./fault-dispute-game.md). The core game mechanics are
 designed to ensure honesty as the best response to winning subgames. By introducing financial incentives,
 Bonds makes it worthwhile for honest challengers to participate.

--- a/specs/experimental/fault-proof/fault-dispute-game.md
+++ b/specs/experimental/fault-proof/fault-dispute-game.md
@@ -15,7 +15,7 @@
   - [Game Tree](#game-tree)
   - [Position](#position)
   - [GAME_DURATION](#game_duration)
-- [Game Mechanics](#game-mechanics)
+- [Core Game Mechanics](#core-game-mechanics)
   - [Actors](#actors)
   - [Moves](#moves)
     - [Attack](#attack)

--- a/specs/experimental/fault-proof/honest-challenger-fdg.md
+++ b/specs/experimental/fault-proof/honest-challenger-fdg.md
@@ -7,7 +7,8 @@
 - [Overview](#overview)
 - [FDG Responses](#fdg-responses)
   - [Root Claims](#root-claims)
-  - [Counter Claims](#counter-claims)
+  - [Countering Invalid Claims](#countering-invalid-claims)
+  - [Countering Freeloaders](#countering-freeloaders)
   - [Steps](#steps)
 - [Resolution](#resolution)
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Lints the fault proof specs. CI isn't properly enforcing linting right now
