### PR TITLE
interop: sequencer / block-builder spec expansion and tx-pool specs

### DIFF
--- a/specs/interop/sequencer.md
+++ b/specs/interop/sequencer.md
@@ -6,32 +6,91 @@
 
 - [Sequencer Policy](#sequencer-policy)
 - [Block Building](#block-building)
+  - [Static analysis](#static-analysis)
+  - [Dependency confirmations](#dependency-confirmations)
+    - [Pre-confirmations](#pre-confirmations)
+      - [Streaming pre-confirmations: "shreds"](#streaming-pre-confirmations-shreds)
+    - [Direct-dependency confirmation](#direct-dependency-confirmation)
+    - [Transitive-dependency confirmation](#transitive-dependency-confirmation)
 - [Sponsorship](#sponsorship)
 - [Security Considerations](#security-considerations)
   - [Cross Chain Message Latency](#cross-chain-message-latency)
-  - [Mempool](#mempool)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Sequencer Policy
 
-The sequencer can include executing messages that have corresponding initiating messages
-that only have preconfirmation levels of security if they trust the destination sequencer. Using an
-allowlist and identity turns sequencing into an interated game which increases the ability for
-sequencers to trust each other. Better preconfirmation technology will help to scale the sequencer
-set to untrusted actors.
+Sequencer Policy is the process of optimistically enacting rules outside of consensus
+(the state-transition function in this context), and the choices can then be asynchronously validated
+by [verifiers](./verifier.md) and [the fault-proof](./fault_proof.md).
+
+In the context of superchain interopability, sequencer policy is utilized to enable cross-chain message relay
+without adding additional state-transition complexity or cross-chain synchronicity to the protocol.
 
 ## Block Building
 
-The goal is to present information in a way where it is as cheap as possible for the block builder to only include
+The goal is to present information in a way where it is as efficient as possible for the block builder to only include
 executing messages that have a corresponding initiating message.
 
-The block builder SHOULD use static analysis on executing messages to verify that the initiating
-message exists. When a transaction has a top level [to][tx-to] field that is equal to the `CrossL2Inbox`
-and the 4byte selector in the calldata matches the entrypoint interface,
-the block builder should use the chain id that is encoded in the `Identifier` to know which chain includes
-the initiating transaction. The block builder MAY require cryptographic proof of the existence of the log
-that the identifier points to. The block build MAY also trust a remote RPC and use the following algorithm
+### Static analysis
+
+The block builder SHOULD use static analysis on executing messages to determine the dependency of the message.
+
+When a transaction has a top level [to][tx-to] field that is equal to the `CrossL2Inbox`
+and the 4-byte selector in the calldata matches the entrypoint interface,
+the block builder should use the chain-ID that is encoded in the `Identifier` to determine which chain includes
+the initiating transaction.
+
+### Dependency confirmations
+
+The sequencer MAY include an executing message in a block with any desired level
+of confirmation safety around the dependency of the message.
+
+Confirmation levels:
+
+- pre-confirmation: through direct signaling by the block builder of the initiating message.
+- direct-dependency confirmation: verify the inclusion of the initiating message, but not the transitive dependencies.
+- transitive-dependency confirmation: verify the message and all transitive dependencies
+  are included in canonical blocks within the specified safety-view (unsafe/safe/finalized).
+
+When operating at lower-safety confirmation levels, the block builder SHOULD re-validate included
+executing messages at an increased safety level, before the block is published.
+
+#### Pre-confirmations
+
+The block builder can include executing messages that have corresponding initiating messages
+that only have pre-confirmation levels of security if they trust the block builder that initiates.
+
+Using an allowlist and identity turns sequencing into an integrated game which increases the ability for
+block builders to trust each other. Better pre-confirmation technology will help to scale the block builder
+set to untrusted actors.
+
+Without pre-confirmations, the block builder cannot include messages of other concurrent block building work.
+
+Pre-confirmations MAY be invalidated, and assumptions around message-validity SHOULD be treated with care.
+
+##### Streaming pre-confirmations: "shreds"
+
+In the context of low-latency block building, each pre-confirmation may be communicated in the form of a "shred":
+the most minimal atomic state-change that can be communicated between actors in the system.
+
+In the context of cross-chain block-building, shreds may be used to communicate initiated cross-chain messages,
+to validate executing messages against.
+
+Shreds may be streamed, and potentially signal rewinds in case of invalidated dependencies.
+
+This block builder feature is in ongoing research,
+and may be developed and experimented with between block builders without further protocol rules changes.
+
+#### Direct-dependency confirmation
+
+By verifying the direct dependency the block-builder does not have to implement pre-confirmations,
+and can rely on its direct view of the remote chain.
+
+The block builder MAY require cryptographic proof of the existence of the log
+that the identifier points to, if it trusts the remote canonical chain but not its RPC server.
+
+The block builder MAY also trust a remote RPC and use the following algorithm
 to verify the existence of the log.
 
 The following pseudocode represents how to check existence of a log based on an `Identifier`.
@@ -45,7 +104,7 @@ if eth is None:
   return False
 
 logs = eth.getLogs(id.origin, from=id.blocknumber, to=id.blocknumber)
-log = filter(lambda x: x.index == id.logIndex)
+log = filter(lambda x: x.index == id.logIndex && x.address == id.origin)
 if len(log) == 0:
   return False
 
@@ -62,6 +121,14 @@ return True
 
 [tx-to]: https://github.com/ethereum/execution-specs/blob/1fed0c0074f9d6aab3861057e1924411948dc50b/src/ethereum/frontier/fork_types.py#L52
 
+#### Transitive-dependency confirmation
+
+When operating pessimistically, the direct-dependency validation may be applied recursively,
+to harden against unstable message guarantees at the cost of increased cross-chain latency.
+
+The transitive dependencies may also be enforced with `safe` or even `finalized` safety-views
+over the blocks of the chains in the dependency set, to further ensure increased cross-chain safety.
+
 ## Sponsorship
 
 If a user does not have ether to pay for the gas of an executing message, application layer sponsorship
@@ -76,11 +143,3 @@ The latency at which a cross chain message is relayed from the moment at which i
 the security of the preconfirmations. An initiating transaction and a executing transaction MAY have the same timestamp,
 meaning that a secure preconfirmation scheme enables atomic cross chain composability. Any sort of equivocation on
 behalf of the sequencer will result in the production of invalid blocks.
-
-### Mempool
-
-Since the validation of the execuing message relies on a remote RPC request, this introduces a denial of
-service attack vector. The cost of network access is magnitudes larger than in memory validity checks.
-The mempool SHOULD perform cheaper checks before any sort of network access is performed. The results
-of the check SHOULD be cached such that another request does not need to be performed when building the
-block although consistency is not guaranteed.

--- a/specs/interop/tx_pool.md
+++ b/specs/interop/tx_pool.md
@@ -1,0 +1,60 @@
+# Transaction pool
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**
+
+- [Message validation](#message-validation)
+- [Security Considerations](#security-considerations)
+  - [Mempool Denial of Service](#mempool-denial-of-service)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+The transaction-pool is part of the execution-engine,
+and generally replicated by the sequencer and its surrounding infrastructure.
+
+Not all messages may be included by the sequencer during [block building](./sequencer.md#block-building),
+additional transaction-pool validation is thus required to prevent non-includable
+transactions from overwhelming the network.
+
+Transactions with cross-chain messages are subject to the same transaction-pool
+validation rules as regular transactions:
+nonce, balance and fee changes need to be applied to validation so the cross-chain transaction
+is possible to include in a block in the first place.
+
+However, additional validation rules are applied to demote messages that cannot be included in a block.
+
+## Message validation
+
+Through [static-analysis](./sequencer.md#static-analysis) as performed in block building,
+the [`Identifier`] of the message is read, and used for further validation.
+
+The [messaging invariants](./messaging.md#messaging-invariants) should be enforced in the transaction pool,
+with dependency validation adapted for guarantees of the in-flight transactions:
+the executing message is not included in the chain yet,
+but the validity of the message and its initiating source is tracked.
+
+A Message with a definitively invalid message-dependency SHOULD be "demoted" from the transaction pool.
+
+Irreversible invalidation conditions:
+
+- The block at the initiating message source is finalized and does not pass the initiating-message checks.
+- The message is expired.
+
+The sequencer MAY choose to demote messages which are invalid but can still technically become valid:
+
+- The block at the initiating message source is known, but another conflicting unsafe block is canonical.
+- The block at the initiating message has invalidated message dependencies.
+
+Transactions with invalid message-dependencies MUST NOT be included in block-building,
+and should thus be dropped from the transaction-pool.
+
+## Security Considerations
+
+### Mempool Denial of Service
+
+Since the validation of the execuing message relies on a remote RPC request, this introduces a denial of
+service attack vector. The cost of network access is magnitudes larger than in memory validity checks.
+The mempool SHOULD perform low-cost checks before any sort of network access is performed.
+The results of the check SHOULD be cached such that another request does not need to be performed
+when building the block although consistency is not guaranteed.


### PR DESCRIPTION
**Description**

Expand sequencer specs to:
- improve sequencer-policy description
- expand on safety levels during block-building
- add section about shreds
- correct the code that validates executing messages against log events

And add a separate tx-pool spec (since this is not unique to block-building, but shared with any replica/infra node that works with the sequencer).

**Metadata**

Fix https://github.com/ethereum-optimism/protocol-quest/issues/145
