### PR TITLE
Add Buffer for Extra Data

### DIFF
--- a/specs/protocol/exec-engine.md
+++ b/specs/protocol/exec-engine.md
@@ -164,7 +164,7 @@ Where:
   header of the latest registered L1 origin block.
 
 Conceptually what the above function captures is the formula below, where `compressedTxSize =
-(zeroes*4 + ones*16) / 16` can be thought of as a rough approximation of how many bytes the
+(zeroes*4 + ones*16 + 68*16) / 16` can be thought of as a rough approximation of how many bytes the
 transaction occupies in a compressed batch.
 
 `(compressedTxSize) * (16*l1BaseFee*lBaseFeeScalar + l1BlobBaseFee*l1BlobBaseFeeScalar) / 1e6`


### PR DESCRIPTION
Add buffer in `compressed tx size` for extra data, per: https://github.com/ethereum-optimism/optimism/blob/dad21c03834a3164ae7fbba2850dfd29b5e4dea7/packages/contracts-bedrock/src/L2/GasPriceOracle.sol#L159

cc @K-Ho 