### PR TITLE
Add github and edit buttons to the docs

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -12,6 +12,8 @@ after = ["links"]
 command = "mdbook-mermaid"
 
 [output.html]
+git-repository-url = "https://github.com/ethereum-optimism/specs"
+edit-url-template = "https://github.com/ethereum-optimism/specs/edit/main/{path}"
 default-theme = "ayu"
 additional-js = ["specs/static/solidity.min.js", "specs/static/mermaid.min.js", "specs/static/mermaid-init.js"]
 


### PR DESCRIPTION
Makes it easier for readers to find the repo and edit pages but adding the github and edit buttons to the top right of the page.

## Before

<img width="1310" alt="image" src="https://github.com/ethereum-optimism/specs/assets/17163988/ff524867-7836-442f-aa7c-8eb50511c8c4">


## After
<img width="1040" alt="image" src="https://github.com/ethereum-optimism/specs/assets/17163988/2df77020-dd2e-480e-bce7-48ff605253dc">
