### PR TITLE
interop: keep predeploy addresses sequention

### DIFF
--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -119,7 +119,7 @@ properties about the `_msg`.
 
 | Constant          | Value                                        |
 |-------------------|----------------------------------------------|
-| Address           | `0x4200000000000000000000000000000000000024` |
+| Address           | `0x4200000000000000000000000000000000000023` |
 | `MESSAGE_VERSION` | `uint256(0)`                                 |
 | `INITIAL_BALANCE` | `type(uint248).max`                          |
 


### PR DESCRIPTION
There was no predeploy at `0x42...23`, which @protolambda said may have been previously used for an obsoleted predeploy. So this shifts L2ToL2CrossDomainMessenger down to `0x42...23` to keep addresses sequential