### PR TITLE
Reduce data size

### DIFF
--- a/specs/experimental/plasma.md
+++ b/specs/experimental/plasma.md
@@ -201,8 +201,8 @@ Derivation MUST skip input data such as `input_data_size > MAX_L1_TX_SIZE` where
 constant of 130872 bytes. In theory `MAX_L1_TX_SIZE` could be increased up to
 `(tx_gas_limit - fixed_resolution_cost) / dynamic_resolution_cost` based on the cost of resolving challenges in
 the contract implementation however to make challenging accessible it is capped based on geth's txMaxSize.
-130872 is chosen as 131072 - 200. Geth rejects transactions from the mempool with a total serialized size over
-131072. 200 bytes are allocated as overhead (signature, to address, metadata).
+130672 is chosen as 131072 - 400. Geth rejects transactions from the mempool with a total serialized size over
+131072. 400 bytes are allocated as overhead (signature, to address, metadata).
 
 [pipeline]: ../protocol/derivation.md#resetting-the-pipeline
 [eip4844]: https://eips.ethereum.org/EIPS/eip-4844

--- a/specs/experimental/plasma.md
+++ b/specs/experimental/plasma.md
@@ -198,9 +198,11 @@ block derived from the expired challenge's input and `r_end` the last L2 block d
 was reset.
 
 Derivation MUST skip input data such as `input_data_size > MAX_L1_TX_SIZE` where `MAX_L1_TX_SIZE` is a consensus
-constant of 131072 bytes. In theory `MAX_L1_TX_SIZE` could be increased up to
+constant of 130872 bytes. In theory `MAX_L1_TX_SIZE` could be increased up to
 `(tx_gas_limit - fixed_resolution_cost) / dynamic_resolution_cost` based on the cost of resolving challenges in
 the contract implementation however to make challenging accessible it is capped based on geth's txMaxSize.
+130872 is chosen as 131072 - 200. Geth rejects transactions from the mempool with a total serialized size over
+131072. 200 bytes are allocated as overhead (signature, to address, metadata).
 
 [pipeline]: ../protocol/derivation.md#resetting-the-pipeline
 [eip4844]: https://eips.ethereum.org/EIPS/eip-4844

--- a/specs/experimental/plasma.md
+++ b/specs/experimental/plasma.md
@@ -198,7 +198,7 @@ block derived from the expired challenge's input and `r_end` the last L2 block d
 was reset.
 
 Derivation MUST skip input data such as `input_data_size > MAX_L1_TX_SIZE` where `MAX_L1_TX_SIZE` is a consensus
-constant of 130872 bytes. In theory `MAX_L1_TX_SIZE` could be increased up to
+constant of 130672 bytes. In theory `MAX_L1_TX_SIZE` could be increased up to
 `(tx_gas_limit - fixed_resolution_cost) / dynamic_resolution_cost` based on the cost of resolving challenges in
 the contract implementation however to make challenging accessible it is capped based on geth's txMaxSize.
 130672 is chosen as 131072 - 400. Geth rejects transactions from the mempool with a total serialized size over


### PR DESCRIPTION
**Description**

This reduces the `MAX_TX_SIZE` by 400 bytes to account for the fact that the geth limit is over the entire serialized tx size while this limit is over a portion of the calldata.

