### PR TITLE
fault-proofs: Update honest challenger spec

### DIFF
--- a/specs/experimental/fault-proof/stage-one/honest-challenger-fdg.md
+++ b/specs/experimental/fault-proof/stage-one/honest-challenger-fdg.md
@@ -98,7 +98,7 @@ counter-claim from expiring.
 When the [chess clock](fault-dispute-game.md#game-clock) of a
 [subgame root](fault-dispute-game.md#resolution) has run out, the subgame can be resolved.
 The honest challenger should resolve all subgames in bottom-up order, until the subgame
-rooted at the gam root is resolved.
+rooted at the game root is resolved.
 
 The honest challenger accomplishes this by calling the `resolveClaim` function on the
 `FaultDisputeGame` contract. Once the root claim's subgame is resolved,

--- a/specs/experimental/fault-proof/stage-one/honest-challenger-fdg.md
+++ b/specs/experimental/fault-proof/stage-one/honest-challenger-fdg.md
@@ -48,16 +48,17 @@ three invariants for any game:
 
 The honest challenger determines which claims to counter by iterating through the claims in the order they are stored
 in the contract. This ordering ensures that a claim's ancestors are processed prior to the claim itself. For each claim,
-the honest challenger determines and tracks what the honest response would be, regardless of whether that response
-already exists in the full game state.
+the honest challenger determines and tracks the set of honest responses to all claims, regardless of whether that
+response already exists in the full game state.
 
 The root claim is considered to be an honest claim if and only if it has a [ClaimHash](fault-dispute-game.md#claims)
 that agrees with the honest challenger's ClaimHash for the root claim.
 
 The honest challenger should counter a claim if and only if:
 
-1. The claim is a child of an honest claim
-2. The claim has an honest sibling with a trace index greater than or equal to the claim's trace index
+1. The claim is a child of a claim in the set of honest responses
+2. The set of honest responses, contains a sibling to the claim with a trace index greater than or equal to the
+   claim's trace index
 
 Note that this implies the honest challenger never counters its own claim, since there is at most one honest counter to
 each claim, so an honest claim never has an honest sibling.

--- a/specs/experimental/fault-proof/stage-one/honest-challenger-fdg.md
+++ b/specs/experimental/fault-proof/stage-one/honest-challenger-fdg.md
@@ -5,6 +5,7 @@
 **Table of Contents**
 
 - [Overview](#overview)
+- [Invariants](#invariants)
 - [Fault Dispute Game Responses](#fault-dispute-game-responses)
   - [Moves](#moves)
   - [Steps](#steps)
@@ -33,6 +34,15 @@ For verifying the legitimacy of claims, it relies on a synced, trusted rollup no
 as well as a trace provider (ex: [Cannon](../cannon-fault-proof-vm.md)).
 The trace provider must be configured with the [ABSOLUTE_PRESTATE](fault-dispute-game.md#execution-trace)
 of the game being interacted with to generate the traces needed to make truthful claims.
+
+## Invariants
+
+To ensure an accurate and incentive compatible fault dispute system, the honest challenger behaviour must preserve
+three invariants for any game:
+
+1. The game resolves as `DefenderWins` if the root claim is correct and `ChallengerWins` if the root claim is incorrect
+2. The honest challenger is refunded the bond for every claim it posts and paid the bond of the parent of that claim
+3. The honest challenger never counters its own claim
 
 ## Fault Dispute Game Responses
 


### PR DESCRIPTION
**Description**

Updates the honest challenger spec to reflect the corrected handling of freeloader claims.

**Metadata**

- https://github.com/ethereum-optimism/client-pod/issues/103
