### PR TITLE
fix: Justfile and Link Lints

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,22 +1,41 @@
+set positional-arguments
+
+# default recipe to display help information
+default:
+  @just --list
+
+# Install required dependencies
 deps:
     pnpm i --frozen-lockfile
 
+# Lint the workspace for all available targets
+lint: lint-specs-md-check lint-specs-toc-check lint-links
+
+# Updates all files to fix linting issues
+lint-fix: lint-specs-md-fix lint-specs-toc
+
+# Validates markdown file formatting
 lint-specs-md-check:
     npx markdownlint-cli2 "./specs/**/*.md"
 
+# Updates markdown files formatting to satisfy lints
 lint-specs-md-fix:
     npx markdownlint-cli2-fix "./specs/**/*.md"
 
+# Validates Table of Content Sections with doctoc
 lint-specs-toc-check:
-    npx doctoc '--title=**Table of Contents**' ./specs && git diff --exit-code .
+    npx doctoc '--title=**Table of Contents**' ./specs && git diff --exit-code ./specs
 
+# Updates Table of Content Sections with doctoc
 lint-specs-toc:
     npx doctoc '--title=**Table of Contents**' ./specs
 
+# Validates all hyperlinks respond with status 200
 lint-links:
     docker run --init -it -v `pwd`:/input lycheeverse/lychee --verbose --no-progress --exclude-loopback \
     		--exclude twitter.com --exclude explorer.optimism.io --exclude linux-mips.org --exclude vitalik.ca \
     		--exclude-mail /input/README.md "/input/specs/**/*.md"
 
-serve:
-    mdbook serve
+# Serves the mdbook locally
+serve *args='':
+    mdbook serve $@

--- a/specs/protocol/predeploys.md
+++ b/specs/protocol/predeploys.md
@@ -129,7 +129,7 @@ This contract is deprecated and its usage should be avoided.
 
 ## LegacyERC20ETH
 
-[Implementation](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/legacy/LegacyERC20ETH.sol)
+[Implementation](https://github.com/ethereum-optimism/optimism/blob/a4524ac152b4c9e8eb80beadc9cd772b96243aa2/packages/contracts-bedrock/src/legacy/LegacyERC20ETH.sol)
 
 Address: `0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000`
 
@@ -248,7 +248,7 @@ Following the Ecotone upgrade, the values used for L1 fee computation are:
 - l1BlobBaseFeeScalar
 - decimals
 
-[ecotone-scalars]: system_config.html#ecotone-scalar-overhead-uint256uint256-change
+[ecotone-scalars]: system_config.md#ecotone-scalar-overhead-uint256uint256-change
 
 These new scalar values are managed by the `SystemConfig` contract on the L1 by introducing a
 backwards compatible [versioned encoding scheme][ecotone-scalars] of its `scalars` storage


### PR DESCRIPTION
**Description**

Updates the `Justfile` targets with doc comments so the default `just` invocation will print out a descriptive help menu. (h/t @clabby in [kona](https://github.com/ethereum-optimism/kona/blob/main/justfile#L5))

E.g.
```
Available recipes:
    default              # default recipe to display help information
    deps                 # Install required dependencies
    lint                 # Lint the workspace for all available targets
    lint-fix             # Updates all files to fix linting issues
    lint-links           # Validates all hyperlinks respond with status 200
    lint-specs-md-check  # Validates markdown file formatting
    lint-specs-md-fix    # Updates markdown files formatting to satisfy lints
    lint-specs-toc       # Updates Table of Content Sections with doctoc
    lint-specs-toc-check # Validates Table of Content Sections with doctoc
    serve *args=''       # Serves the mdbook locally
```

Updates markdown links so the `lint-links` Justfile target and check passes.

As of [ethereum-optimism/optimism pr # 9472](https://github.com/ethereum-optimism/optimism/pull/9472), the `LegacyERC20ETH.sol` contract was removed so the link is updated to the previous commit prior to deletion.