### PR TITLE
interop: fix sample code for L2ToL2CrossDomainMessenger

### DIFF
--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -198,7 +198,6 @@ function relayMessage(uint256 _destination, uint256 _nonce, address _sender, add
     require(msg.sender == address(CROSS_L2_INBOX));
     require(_destination == block.chainid);
     require(CROSS_L2_INBOX.origin() == address(this));
-    require(_target != address(CROSS_L2_INBOX));
 
     bytes32 messageHash = keccak256(abi.encode(_destination, _nonce, _sender, _target, _message));
     require(sentMessages[messageHash] == false);

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -198,7 +198,7 @@ function relayMessage(uint256 _destination, uint256 _nonce, address _sender, add
     require(msg.sender == address(CROSS_L2_INBOX));
     require(_destination == block.chainid);
     require(CROSS_L2_INBOX.origin() == address(this));
-    require(_target != address(this));
+    require(_target != address(CROSS_L2_INBOX));
 
     bytes32 messageHash = keccak256(abi.encode(_destination, _nonce, _sender, _target, _message));
     require(sentMessages[messageHash] == false);


### PR DESCRIPTION
on one side the document says that `CrossL2Inbox` cannot call itself through `relayMessage`. However, instead of enforcing that `_target == address(CROSS_L2_INBOX)`, the sample code shows `_target == address(this)`. This PR fixes that.