### PR TITLE
feat(engine.queue): consistent safe head progression on failures

### DIFF
--- a/specs/SUMMARY.md
+++ b/specs/SUMMARY.md
@@ -35,6 +35,7 @@
         - [Bond Incentives](./experimental/fault-proof/stage-one/bond-incentives.md)
       - [Bridge Integration](./experimental/fault-proof/stage-one/bridge-integration.md)
   - [Plasma](./experimental/plasma.md)
+  - [Engine Queue Block Derivation](./experimental/engine_queue_block_derivation.md)
   - [Interoperability](./interop/overview.md)
     - [Dependency Set](./interop/dependency_set.md)
     - [Messaging](./interop/messaging.md)

--- a/specs/experimental/engine_queue_block_derivation.md
+++ b/specs/experimental/engine_queue_block_derivation.md
@@ -4,44 +4,34 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**
 
-- [Overview](#overview)
-- [Motivation](#motivation)
-- [Solution](#solution)
+- [Consistent Safe Head Progression](#consistent-safe-head-progression)
+- [Rationale](#rationale)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-## Overview
+# Consistent Safe Head Progression
 
-The Engine Queue stage pulls the latest derived `PayloadAttributes` to be processed by the execution
-engine. If the execution engine reports an error with the provided payload (i.e invalid transaction
-or state transition in the block), the Engine Queue currently drops the payload without progessing
-the safe head and will attempt to use the next batch available for the same timestamp. If no valid
-batches are found within the sequencing window, the rollup node will create a deposits-only empty
-payload.
-
-## Motivation
-
-In implementation of low-latency interop, we want to minimize the effects of cascading reorgs
-and the need to wind back & rebuild chain state when executing messages have been invalidated. The
-looping behavior between the engine and attributes queue presents a challenge for fault proofs as
-many different block candidates can be prepared depending on the available batch data after invalidation.
-
-We can significantly reduce this complexity by generally revisiting this looping behavior in block derivation.
-
-## Solution
-
-The looping behavior between the engine and attributes queue can be eliminated by always ensuring
+In the current spec, the engine queue will attempt to find a replacement batch if the parsed attributes are
+invalid. The looping behavior between the engine and attributes queue can be eliminated by always ensuring
 the progression of the safe head when processing payloads. We propose that the engine queue replace
 any invalidated payloads with a deposits-only empty one. In other words, when provided `PayloadAttributes`,
 there will always be two possible block candidates:
 
 1. Always Valid (empty deposits-only block)
-2. A proper L2 block created from the provided payload.
+2. A proper L2 block created from the provided payload attributes.
 
    > For span batches, this implies the engine queue will process every payload from the span and does not drop
    > it in its entirety. In the worst case, every block after the first invalidated one also becomes an empty
-   > deposits-only block. And in the best case, the encoded txs the future payloads are unrelated and succesfully
-   > processed.
+   > deposits-only block. And in the best case, the following payload attributesi in the span are unrelated and
+   > succesfully processed.
 
 This change allows block derivation to be optimistically completed in a single step rather than waiting for
 either a replacement batch or full seqeuencing window to elapse to force the production of empty blocks.
+
+# Rationale
+
+In implementation of low-latency interop, we want to minimize the effects of cascading reorgs and the need
+to wind back & rebuild chain state when executing messages have been invalidated. The looping behavior between
+behavior between the engine and attributes queue presents a challenge for fault proofs, especially for
+for intra-block building that may contain cycles. Since replacement batches can also themselves be invalid,
+prepetuating expensive looping behavior.

--- a/specs/experimental/engine_queue_block_derivation.md
+++ b/specs/experimental/engine_queue_block_derivation.md
@@ -32,7 +32,7 @@ We can significantly reduce this complexity by generally revisiting this looping
 
 The looping behavior between the engine and attributes queue can be eliminated by always ensuring
 the progression of the safe head when processing payloads. We propose that the engine queue replace
-invalidated payloads with a deposits-only empty one. In other words, when provided `PayloadAttributes`,
+any invalidated payloads with a deposits-only empty one. In other words, when provided `PayloadAttributes`,
 there will always be two possible block candidates:
 
 1. Always Valid (empty deposits-only block)

--- a/specs/experimental/engine_queue_block_derivation.md
+++ b/specs/experimental/engine_queue_block_derivation.md
@@ -1,0 +1,47 @@
+# Engine Queue Block Derivation
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**
+
+- [Overview](#overview)
+- [Motivation](#motivation)
+- [Solution](#solution)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Overview
+
+The Engine Queue stage pulls the latest derived `PayloadAttributes` to be processed by the execution
+engine. If the execution engine reports an error with the provided payload (i.e invalid transaction
+or state transition in the block), the Engine Queue currently drops the payload without progessing
+the safe head and will attempt to use the next batch available for the same timestamp. If no valid
+batches are found within the sequencing window, the rollup node will create a deposits-only empty
+payload.
+
+## Motivation
+
+In implementation of low-latency interop, we want to minimize the effects of cascading reorgs
+and the need to wind back & rebuild chain state when executing messages have been invalidated. The
+looping behavior between the engine and attributes queue presents a challenge for fault proofs as
+many different block candidates can be prepared depending on the available batch data after invalidation.
+
+We can significantly reduce this complexity by generally revisiting this looping behavior in block derivation.
+
+## Solution
+
+The looping behavior between the engine and attributes queue can be eliminated by always ensuring
+the progression of the safe head when processing payloads. We propose that the engine queue replace
+invalidated payloads with a deposits-only empty one. In other words, when provided `PayloadAttributes`,
+there will always be two possible block candidates:
+
+1. Always Valid (empty deposits-only block)
+2. A proper L2 block created from the provided payload.
+
+   > For span batches, this implies the engine queue will process every payload from the span and does not drop
+   > it in its entirety. In the worst case, every block after the first invalidated one also becomes an empty
+   > deposits-only block. And in the best case, the encoded txs the future payloads are unrelated and succesfully
+   > processed.
+
+This change allows block derivation to be optimistically completed in a single step rather than waiting for
+either a replacement batch or full seqeuencing window to elapse to force the production of empty blocks.

--- a/specs/root.md
+++ b/specs/root.md
@@ -45,6 +45,7 @@ Specifications of new features in active development.
       - [Honest Challenger Behavior](./experimental/fault-proof/stage-one/honest-challenger-fdg.md)
   - [Cannon VM](./experimental/fault-proof/cannon-fault-proof-vm.md)
 - [Plasma](./experimental/plasma.md)
+- [Engine Queue Block Derivation](./experimental/engine_queue_block_derivation.md)
 - [Interoperability](./interop/overview.md)
 
 ## Design Goals


### PR DESCRIPTION
We can simplify derivation by having the pipeline always ensure safe head progression
when processing payloads pulled from L1.

1. Always Valid (empty deposits-only block)
3. A proper L2 block created from the provided payload.

This simplifies the back & forth between the engine and attributes queue upon failures
when producing batches. Rather than wait for the sequencer window to create empty batches,
we do it right away and move onto the next batch.