### PR TITLE
Fix the count of the game tree items

### DIFF
--- a/specs/experimental/fault-proof/stage-one/fault-dispute-game.md
+++ b/specs/experimental/fault-proof/stage-one/fault-dispute-game.md
@@ -133,7 +133,7 @@ The Game Tree is a binary tree of positions. Every claim in the DAG references a
 The Game Tree has a split depth and maximum depth, `SPLIT_DEPTH` and `MAX_GAME_DEPTH` respectively, that are both
 preset to an FDG implementation. The split depth defines the maximum depth at which claims about
 [output roots][g-output-root] can occur, and below it, execution trace bisection occurs. Thus, the Game Tree contains
-$2^{d-1}$ positions, where $d$ is the `MAX_GAME_DEPTH` (unless $d=0$, in which case there's only 1 position).
+$2^{d} - 1$ positions, where $d$ is the `MAX_GAME_DEPTH` (unless $d=0$, in which case there's only 1 position).
 
 The full game tree, with a layer of the tree allocated to output bisection, and sub-trees after an arbitrary split
 depth, looks like:


### PR DESCRIPTION
**Description**

The game tree is a binary tree, so the number of items it contains depends on its depth, `d`. A binary tree with depth `d` would have $2^d - 1$ items. The current documentation has wrongly calculated it as $2^{d-1}$.

**Tests**

N/A

**Additional context**

N/A

**Metadata**

N/A
