### PR TITLE
fix: get site building again

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,4 +72,4 @@ To lint links:
 just lint-links
 ```
 
-[lychee][lychee] is used for linting links.
+[lychee](https://github.com/lycheeverse/lychee) is used for linting links.

--- a/specs/SUMMARY.md
+++ b/specs/SUMMARY.md
@@ -18,7 +18,6 @@
       - [Derivation](./protocol/derivation.md)
       - [Span Batches](./protocol/span-batches.md)
     - [Batch Submitter](./protocol/batcher.md)
-  - [Safe Liveness Checking](./protocol/safe-liveness-checking.md)
   - [Predeploys](./protocol/predeploys.md)
   - [Preinstalls](./protocol/preinstalls.md)
   - [Superchain]()

--- a/specs/SUMMARY.md
+++ b/specs/SUMMARY.md
@@ -46,4 +46,5 @@
     - [Rollup Node P2P](./interop/rollup_node_p2p.md)
     - [Fault Proof](./interop/fault_proof.md)
     - [Upgrade](./interop/upgrade.md)
+  - [Security Council Safe](./experimental/security-council-safe.md)
 - [Glossary](./glossary.md)

--- a/specs/protocol/safe-liveness-checking.md
+++ b/specs/protocol/safe-liveness-checking.md
@@ -1,1 +1,0 @@
-# Safe Liveness Checking

--- a/specs/protocol/safe-liveness-checking.md
+++ b/specs/protocol/safe-liveness-checking.md
@@ -1,0 +1,1 @@
+# Safe Liveness Checking


### PR DESCRIPTION
A couple of observations: 

1. We don't run sufficient checks on PRs to ensure the site will build successfully when the PR is merged. This means your beautiful new contribution to the specs may be missing from the public site, and any other contributions until we realise it isn't working and fix it. **Suggestion**: we could have a job which runs on Ci which builds the site, but doesn't deploy it, or we could use something like Netlify to generate deploy previews for PRs.
2. We don't have any alerting for `Book Deployment` action. **Suggestion**: perhaps a slack ping is in order if it fails?
