### PR TITLE
Specify generic DA commitment

### DIFF
--- a/specs/experimental/plasma.md
+++ b/specs/experimental/plasma.md
@@ -88,9 +88,10 @@ on the `commitment_type_byte` where [0, 128) are reserved for official implement
 The `da-service` commitment is as follows: `da_layer_byte ++ len(payload) as uvarint ++ payload`. The DA layer byte
 must be initially restricted to the range `[0, 127)`. This specification will not apportion DA layer bytes, but
 different DA layers should coordinate to ensure that the DA layer bytes do not conflict. The payload length is a
-unsigned 64 bit number, as defined in [protobuf spec]. The payload is a bytestring which is up to the DA layer to
-specify. The DA server should be able to parse the payload, find the data on the DA server, & verify that the data
-returned from the DA server matches what was committed to in the payload.
+unsigned 64 bit number, as defined in [protobuf spec]. We include the payload length so the op-node is able to pull
+out single commitment from a list of commitments that are concatenated together. The payload is a bytestring which
+is up to the DA layer to specify. The DA server should be able to parse the payload, find the data on the DA server,
+& verify that the data returned from the DA server matches what was committed to in the payload.
 
 [protobuf spec]: https://protobuf.dev/programming-guides/encoding/#varints
 

--- a/specs/experimental/plasma.md
+++ b/specs/experimental/plasma.md
@@ -85,15 +85,14 @@ on the `commitment_type_byte` where [0, 128) are reserved for official implement
 | 0                 | `keccak256(tx_payload)`         |
 | 1                 | `da-service`                     |
 
-The `da-service` commitment is as follows: `da_layer_byte ++ len(payload) as uvarint ++ payload`. The DA layer byte
-must be initially restricted to the range `[0, 127)`. This specification will not apportion DA layer bytes, but
-different DA layers should coordinate to ensure that the DA layer bytes do not conflict. The payload length is a
-unsigned 64 bit number, as defined in [protobuf spec]. We include the payload length so the op-node is able to pull
-out single commitment from a list of commitments that are concatenated together. The payload is a bytestring which
-is up to the DA layer to specify. The DA server should be able to parse the payload, find the data on the DA server,
-& verify that the data returned from the DA server matches what was committed to in the payload.
-
-[protobuf spec]: https://protobuf.dev/programming-guides/encoding/#varints
+The `da-service` commitment is as follows: `da_layer_byte ++ payload`.
+The DA layer byte must be initially restricted to the range `[0, 127)`.
+This specification will not apportion DA layer bytes, but different DA layers should coordinate to ensure that the
+DA layer bytes do not conflict. DA Layers can do so in
+[this discussion](https://github.com/ethereum-optimism/specs/discussions/135).
+The payload is a bytestring which is up to the DA layer to specify.
+The DA server should be able to parse the payload, find the data on the DA layer, and verify that the data returned
+from the DA layer matches what was committed to in the payload.
 
 The batcher SHOULD cap input payloads to the maximum L1 tx size or the input will be skipped
 during derivation. See [derivation section](#derivation) for more details.

--- a/specs/experimental/plasma.md
+++ b/specs/experimental/plasma.md
@@ -83,6 +83,16 @@ on the `commitment_type_byte` where [0, 128) are reserved for official implement
 | `commitment_type` | `commitment`                    |
 | ----------------- | ------------------------------- |
 | 0                 | `keccak256(tx_payload)`         |
+| 1                 | `da-server`                     |
+
+The `da-server` commitment is as follows: `version_byte ++ len(payload) as uvarint ++ payload`. The version byte
+must be initially restricted to the range `[0, 127)`. This specification will not apportion version bytes, but
+different DA layers should coordinate to ensure that the version bytes do not conflict. The payload length is a
+unsigned 64 bit number, as defined in [protobuf spec]. The payload is a bytestring which is up to the DA layer to
+specify. The DA server should be able to parse the payload, find the data on the DA server, & verify that the data
+returned from the DA server matches what was committed to in the payload.
+
+[protobuf spec]: https://protobuf.dev/programming-guides/encoding/#varints
 
 The batcher SHOULD cap input payloads to the maximum L1 tx size or the input will be skipped
 during derivation. See [derivation section](#derivation) for more details.

--- a/specs/experimental/plasma.md
+++ b/specs/experimental/plasma.md
@@ -83,11 +83,11 @@ on the `commitment_type_byte` where [0, 128) are reserved for official implement
 | `commitment_type` | `commitment`                    |
 | ----------------- | ------------------------------- |
 | 0                 | `keccak256(tx_payload)`         |
-| 1                 | `da-server`                     |
+| 1                 | `da-service`                     |
 
-The `da-server` commitment is as follows: `version_byte ++ len(payload) as uvarint ++ payload`. The version byte
-must be initially restricted to the range `[0, 127)`. This specification will not apportion version bytes, but
-different DA layers should coordinate to ensure that the version bytes do not conflict. The payload length is a
+The `da-service` commitment is as follows: `da_layer_byte ++ len(payload) as uvarint ++ payload`. The DA layer byte
+must be initially restricted to the range `[0, 127)`. This specification will not apportion DA layer bytes, but
+different DA layers should coordinate to ensure that the DA layer bytes do not conflict. The payload length is a
 unsigned 64 bit number, as defined in [protobuf spec]. The payload is a bytestring which is up to the DA layer to
 specify. The DA server should be able to parse the payload, find the data on the DA server, & verify that the data
 returned from the DA server matches what was committed to in the payload.


### PR DESCRIPTION
**Description**

This specifies a generic DA server commitment. This pushes the logic of decoding it to the DA server. This type is opaque & not inspecting inside the op-node.


Fixes: https://github.com/ethereum-optimism/client-pod/issues/762