### PR TITLE
fix: removing compression ratio from policy configs.

### DIFF
--- a/specs/protocol/configurability.md
+++ b/specs/protocol/configurability.md
@@ -52,8 +52,7 @@ There are four categories of OP Stack configuration options:
 | Config Property                       | Description                                                                                                                  | Administrator                       |
 |---------------------------------------|------------------------------------------------------------------------------------------------------------------------------|-------------------------------------|
 | Data Availability Type        | Batcher can currently be configured to use blobs or calldata (See [Data Availability Provider](../glossary.md#data-availability-provider)).             | [Batch submitter address](#service-roles)                 |
-| Batch submission frequency            | Frequency with which batches are submitted to L1 (see [Batcher Transaction](../glossary.md#batcher-transaction)).            | [Batch submitter address](#service-roles)                 |
-| Compression ratio                     | How much compression the batch submitter applies to batches before submission (see [Channel](../glossary.md#channel)).       |  [Batch submitter address](#service-roles)                        |
+| Batch submission frequency            | Frequency with which batches are submitted to L1 (see [Batcher Transaction](../glossary.md#batcher-transaction)).            | [Batch submitter address](#service-roles)                 |                   |
 | [Output frequency](https://github.com/ethereum-optimism/optimism/blob/c927ed9e8af501fd330349607a2b09a876a9a1fb/packages/contracts-bedrock/src/L1/L2OutputOracle.sol#L104)                      | Frequency with which output roots are submitted to L1.                                                                       | [L1 Proxy Admin](#admin-roles)                      |
 
 ## Admin Roles


### PR DESCRIPTION
Removing compression ratio from policy parameters in `configurability.md` file. 

This parameter has no bearing on the 'standard-ness' of a chain in the superchain. 

> approx compression ratio parameter is irrelevant for prod batchers, as it's only a parameter for the ratio compressor, and it doesn't configure the compression in itself. In prod, only the shadow compressor should be used, which is the default (for singular batches). Span batches use an internal compressor, so also irrelevant here.

### Capturing some conversations on this decision for posterity: 

Axel on compression ratio:
> This field is implicit/not a parameter -- as batches are processed, a compressor is used. We have several flavors of compressor for different performance reasons, but none of them support a configurable compression amount.
> 	return uint64(float64(t.config.TargetOutputSize) / t.config.ApproxComprRatio)
> This line from the PR discussion is in relation to the Ratio Compressor , which is designed with this ApproxComprRatio as an optimization -- the approximation is used to decide what the compressed payload size would be. And in this case it's used to calculate the target size.
> the Ratio Compressor is generally not used anymore -- for Singular Batches, the Shadow Compressor is used, while for Span Batches there is an embedded Zlib Writer, skipping all the compressor interfaces.
> In all cases the compressors are set to use "Best" compression quality.

> If you are using Singular Batches, you can choose which compressor you use. But they all do the same underlying compression work, just with different optimizations.
> If you've chosen Ratio Compressor, you also choose this ApproxComprRatio, which like I mentioned does not affect the compression activity/quality, but affects whether the compressor considers itself "full" or not.
> If you are using Span Batches, you can't choose which compressor you use at all.
> In all cases you can set the maximum channel size, which is more a channel configuration, but affects the compressors (in the sense that the compressors are "full" when they meet the target)
> TLDR: Technically yes you can choose to configure your compression in slight and limited ways. But Practically there is no configuration that matters. All compressors will use Zlib BestCompression, and will target your Channel Size.
> At most, you can choose SingularBatches + RatioCompressor and change the ApproxComprRatio to make it to do a better/worse job of hitting that target.
> [Compressor Config](https://github.com/ethereum-optimism/optimism/blob/d7afde1da4cea381089cc028aebdcdf459fd0f87/op-batcher/compressor/config.go#L7) mentions some of the applicabilities of the configuration


Marks on compression ratio: 

> I don't think it makes sense to define any particular compression config as standard as its in everybody's best interest to compress the best for the txs their chain receives

> Its completely policy and has no impact on consensus, just impacts revenue, which is incentive compatible with coordination around optimizing

Blaine on compression ratio: 

> Okay, given that this is policy and that it's configurability wouldn't really impact chain 'standard-ness' (e.g. if an inefficient compression ratio config was used, that wouldn't necessarily mean the chain isn't standard.).
> I'm going to suggest that 'Compression Ratio' is removed from: https://specs.optimism.io/protocol/configurability.html#policy-parameters 

Seb on compression ratio: 

> tldr; Remove the parameter from policy :+1::skin-tone-2:
> Just summing up some of the above, the approx compression ratio parameter is irrelevant for prod batchers, as it's only a parameter for the ratio compressor, and it doesn't configure the compression in itself. In prod, only the shadow compressor should be used, which is the default (for singular batches). Span batches use an internal compressor, so also irrelevant here.
> Note also that the current description "How much compression the batch submitter applies to batches before submission" is wrong, as the compression itself is fixed to zlib best.



