### PR TITLE
specs: add link to github discussions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 This repository contains the [Specs Book](https://static.optimism.io/specs).
 
+Please chat with us on the [discussion board](https://github.com/ethereum-optimism/specs/discussions).
+
 ## Contributing
 
 We welcome your contributions. 

--- a/specs/root.md
+++ b/specs/root.md
@@ -3,6 +3,8 @@
 This directory contains the plain english specs for Optimism, a minimal optimistic rollup protocol
 that maintains 1:1 compatibility with Ethereum.
 
+Chat with us on the [discussion board!](https://github.com/ethereum-optimism/specs/discussions)
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Adds simple link to github discussions board to the specs
readme + website.
