### PR TITLE
fjord: Add constant maximum sequencer drift spec

### DIFF
--- a/specs/fjord/derivation.md
+++ b/specs/fjord/derivation.md
@@ -1,20 +1,50 @@
-# L2 Chain Derivation
+# Fjord L2 Chain Derivation Changes
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**
 
-- [Architecture](#architecture)
-  - [L2 Chain Derivation Pipeline](#l2-chain-derivation-pipeline)
-    - [Batch Queue](#batch-queue)
+- [Protocol Parameter Changes](#protocol-parameter-changes)
+  - [Constant Maximum Sequencer Drift](#constant-maximum-sequencer-drift)
+    - [Rationale](#rationale)
+    - [Security Considerations](#security-considerations)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-# Architecture
+# Protocol Parameter Changes
 
-## L2 Chain Derivation Pipeline
+The following table gives an overview of the changes in parameters.
 
-### Batch Queue
+| Parameter | Pre-Fjord (default) value | Fjord value | Notes |
+| --------- | ------------------------- | ----------- | ----- |
+| `max_sequencer_drift` | 600 | 1800 | Was a protocol parameter since Bedrock. Now becomes a constant. |
 
-With Fjord, the `max_sequencer_drift` parameter becomes a constant of value
-`1800` _seconds_, translating to a fixed maximum sequencer drift of 30 minutes.
+## Constant Maximum Sequencer Drift
+
+With Fjord, the `max_sequencer_drift` parameter becomes a constant of value `1800` _seconds_,
+translating to a fixed maximum sequencer drift of 30 minutes.
+
+Before Fjord, this was a chain parameter that was set once at chain creation, with a default
+value of `600` seconds, i.e., 10 minutes. Most chains use this value currently.
+
+### Rationale
+
+Discussions amongst chain operators came to the unilateral conclusion that a larger value than the
+current default would be easier to work with. If a sequencer's L1 connection breaks, this drift
+value determines how long it can still produce blocks without violating the timestamp drift
+derivation rules.
+
+It was furthermore agreed that configurability after this increase is not important. So it is being
+made a constant. An alternative idea that is being considered for a future hardfork is to make this
+an L1-configurable protocol parameter via the `SystemConfig` update mechanism.
+
+### Security Considerations
+
+The rules around the activation time are deliberately being kept simple, so no other logic needs to
+be applied other than to change the parameter to a constant. The first Fjord block would in theory
+accept older L1-origin timestamps than its predecessor. However, since the L1 origin timestamp must
+also increase, the only noteworthy scenario that can happen is that the first few Fjord blocks will
+be in the same epoch as the the last pre-Fjord blocks, even if these blocks would not be allowed to
+have these L1-origin timestamps according to pre-Fjord rules. So the same L1 timestamp would be
+shared within a pre- and post-Fjord mixed epoch. This is considered a feature and is not considered
+a security issue.

--- a/specs/fjord/derivation.md
+++ b/specs/fjord/derivation.md
@@ -1,0 +1,20 @@
+# L2 Chain Derivation
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**
+
+- [Architecture](#architecture)
+  - [L2 Chain Derivation Pipeline](#l2-chain-derivation-pipeline)
+    - [Batch Queue](#batch-queue)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# Architecture
+
+## L2 Chain Derivation Pipeline
+
+### Batch Queue
+
+With Fjord, the `max_sequencer_drift` parameter becomes a constant of value
+`1800` _seconds_, translating to a fixed maximum sequencer drift of 30 minutes.

--- a/specs/fjord/overview.md
+++ b/specs/fjord/overview.md
@@ -16,3 +16,5 @@ This document is not finalized and should be considered experimental.
 - [RIP-7212: Precompile for secp256r1 Curve Support](https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md)
 
 ## Consensus Layer
+
+- [Constant maximum sequencer drift](./derivation.md#batch-queue)

--- a/specs/protocol/derivation.md
+++ b/specs/protocol/derivation.md
@@ -6,6 +6,7 @@
 
 - [Overview](#overview)
   - [Eager Block Derivation](#eager-block-derivation)
+  - [Protocol Parameters](#protocol-parameters)
 - [Batch Submission](#batch-submission)
   - [Sequencing & Batch Submission Overview](#sequencing--batch-submission-overview)
   - [Batch Submission Wire Format](#batch-submission-wire-format)
@@ -187,6 +188,15 @@ before derivation only in the very worst case where some portion of the sequence
 first block of the epoch appears in the very last L1 block of the window. Note that this only
 applies to _block_ derivation. Sequencer batches can still be derived and tentatively queued
 without deriving blocks from them.
+
+## Protocol Parameters
+
+The following table gives an overview of some protocol parameters, and how they are affected by
+protocol upgrades.
+
+| Parameter | Bedrock (default) value | Latest (default) value | Changes | Notes |
+| --------- | ----------------------- | ---------------------- | ------- | ----- |
+| `max_sequencer_drift` | 600 | 1800 | [Fjord](../fjord/derivation.md#constant-maximum-sequencer-drift) | Changed from a chain parameter to a constant with Fjord. |
 
 ---
 


### PR DESCRIPTION

**Description**

Adds spec to make `max_sequencer_drift` a constant in Fjord.

**Metadata**

- Fixes https://github.com/ethereum-optimism/protocol-quest/issues/232
