### PR TITLE
fix: Design Goal Verbiage

### DIFF
--- a/specs/root.md
+++ b/specs/root.md
@@ -53,29 +53,25 @@ Specifications of new features in active development.
 
 ## Design Goals
 
-Our aim is to design a protocol specification that is:
+The aim is to design a protocol specification that is:
 
-- **Fast:** When users send transactions, they get reliable confirmations with low-latency.
-  For example when swapping on Uniswap you should see that your transaction succeeds in less than 2
-  seconds.
+- **Fast:** When sending transactions, rollup clients return reliable confirmations with
+  low-latency. For example when swapping on Uniswap you should see that your transaction
+  succeeds in less than 2 seconds.
 - **Scalable:** It should be possible to handle an enormous number of transactions
-  per second which will enable the system to charge low fees.
-  V1.0 will enable Optimism to scale up to and even past the gas limit on L1.
-  Later iterations should scale much further.
-- **Modular:** Our designs will use modularity to reduce complexity and enable parallel
-  contributions. Coming up with good conceptual frameworks & composable atoms of software enables us
-  to build extremely complex software even when any one person cannot hold that much in their brain.
-- **Minimal:** Rollups should be minimal to best take advantage of the battle-tested infrastructure
-  (like Geth) that already runs Ethereum. An ideal optimistic rollup design should be representable
-  as a _diff_ against Ethereum client software.
-- **Developer Driven:** Our designs will be developer driven to ensure we are actually building
-  something that people want to use. We must constantly engage with the developers who will be using
-  our software to avoid creating a system no one wants to use.
-- **Clear and Readable:** The specs we write are written to be read. So tight feedback loop with the
-  systems team consuming the spec is also key!
-- **Secure:** This is self-evident.
-  User’s assets are at stake. Every component of the system must be incredibly secure.
-- **Decentralizable:** Optimism must be designed to avail itself of the security and
-  censorship-resistant guarantees achieved by a decentralized system.
+  per second which will enable the system to charge low fees. The gas limit should
+  scale up to and even past the gas limit on L1.
+- **Modular:** Components are modular, reducing complexity and enable parallel contributions.
+  Robust conceptual frameworks and composable atoms of software enables complex protocol design
+  that exceeds the knowledge base of any single contributor.
+- **Minimal:** Rollups should be minimal by using Ethereum’s battle-tested infrastructure. An ideal
+  optimistic rollup design should be representable as a _diff_ against Ethereum client software.
+- **Developer Driven:** Designs are driven by technical contributors so developers are
+  stakeholders. There should be a tight feedback loop between protocol design and developer use.
+- **Clear and Readable:** The specs are articulated well. Iterative technical feedback is key!
+- **Secure:** Every component of the system is incredibly secure and highly redundant. Assets
+  are at stake, so the design must be robust to mitigate risk.
+- **Decentralizable:** Designed to avail the protocol of the security and censorship-resistant
+  guarantees achieved by a decentralized system.
   Currently centralized components of the system should have a clear path towards decentralization.
   Already decentralized components of the system should be protected and preserved.


### PR DESCRIPTION
**Description**

Cleans up the top level spec `Design Goals` wording to be more inclusive to the OP Stack and less Optimism-specific.