### PR TITLE
specs: interop 3074 updates

### DIFF
--- a/specs/interop/messaging.md
+++ b/specs/interop/messaging.md
@@ -112,6 +112,9 @@ Both the block builder and the verifier use this information to ensure that all 
 The executing message is verified by checking if there is an existing initiating-message
 that originates at [`Identifier`] with matching [Message Payload](#message-payload).
 
+Since an executing message is defined by a log, it means that reverting calls to the `CrossL2Inbox`
+do not count as executing messages.
+
 ## Messaging Invariants
 
 - [Timestamp Invariant](#timestamp-invariant): The timestamp at the time of inclusion of the executing message MUST

--- a/specs/interop/messaging.md
+++ b/specs/interop/messaging.md
@@ -246,7 +246,7 @@ The graph is bounded in 4 ways:
   as per the [ChainID invariant](#chainid-invariant).
 - Every block cannot depend on future blocks, as per the [Timestamp invariant](#timestamp-invariant).
 - Every block has a maximum gas limit, an intrinsic cost per transaction,
-  and thus a maximum inward degree of dependencies
+  and thus a maximum inward degree of dependencies.
 - Every block cannot depend on expired messages, as per the [Message expiry invariant](#message-expiry-invariant).
 
 The verifier is responsible for filtering out non-canonical parts of the graph.

--- a/specs/interop/overview.md
+++ b/specs/interop/overview.md
@@ -13,7 +13,7 @@ network upgrade will be included in this document in the future.
 | Source Chain        | A blockchain that includes an initiating message                                                    |
 | Destination Chain   | A blockchain that includes an executing message                                                     |
 | Initiating Message  | An event emitted from a source chain                                                                |
-| Executing Message   | A transaction submitted to a destination chain that corresponds to an initiating message            |
+| Executing Message   | An event emitted from a destination chain that includes an initiating message                       |
 | Cross Chain Message | The cumulative execution and side effects of the initiating message and executing message           |
 | Dependency Set      | The set of chains that originate initiating transactions where the executing transactions are valid |
 
@@ -21,7 +21,7 @@ A total of two transactions are required to complete a cross chain message.
 The first transaction is submitted to the source chain and emits an event that can be consumed on a destination chain.
 The second transaction is submitted to a destination chain, where the block builder SHOULD only include it if they are
 certain that the first transaction was included in the source chain.
-There is no strict requirement that the execution message is ever submitted.
+There is no strict requirement that the executing message is ever submitted.
 
 The term "block builder" is used interchangeably with the term "sequencer" for the purposes of this document but
 they need not be the same entity in practice.

--- a/specs/interop/overview.md
+++ b/specs/interop/overview.md
@@ -13,7 +13,7 @@ network upgrade will be included in this document in the future.
 | Source Chain        | A blockchain that includes an initiating message                                                    |
 | Destination Chain   | A blockchain that includes an executing message                                                     |
 | Initiating Message  | An event emitted from a source chain                                                                |
-| Executing Message   | An event emitted from a destination chain that includes an initiating message                       |
+| Executing Message   | An event emitted from a destination chain's `CrossL2Inbox` that includes an initiating message                       |
 | Cross Chain Message | The cumulative execution and side effects of the initiating message and executing message           |
 | Dependency Set      | The set of chains that originate initiating transactions where the executing transactions are valid |
 

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -92,6 +92,7 @@ to `executeMessage`.
 ```solidity
 event ExecutingMessage(bytes,bytes);
 ```
+
 The data encoded in the event contains the `Identifier` and the `msg`.
 The following pseudocode shows the serialization:
 

--- a/specs/interop/sequencer.md
+++ b/specs/interop/sequencer.md
@@ -36,16 +36,9 @@ executing messages.
 
 ### Static analysis
 
-Note that static analysis is not always reliable, but it is far faster than having to perform
-execution to get the data required to validate an executing message.
-
-The block builder SHOULD use static analysis when possible on executing messages to determine
-the dependency of the message.
-
-When a transaction has a top level [to][tx-to] field that is equal to the `CrossL2Inbox`
-and the 4-byte selector in the calldata matches the entrypoint interface,
-the block builder should use the chain-ID that is encoded in the `Identifier` to determine which chain includes
-the initiating transaction.
+Note that static analysis is never reliable because even if the top level `transaction.to`
+is equal to the `CrossL2Inbox`, it is possible that there is a reentrant `CALL`. The block
+builder SHOULD NOT rely on static analysis for building blocks.
 
 ### Dependency confirmations
 

--- a/specs/interop/tx_pool.md
+++ b/specs/interop/tx_pool.md
@@ -27,7 +27,9 @@ However, additional validation rules are applied to demote messages that cannot 
 ## Message validation
 
 Through [static-analysis](./sequencer.md#static-analysis) as performed in block building,
-the [`Identifier`] of the message is read, and used for further validation.
+the [`Identifier`] of the message is read, and used for further validation. Static analysis is
+not always possible, therefore the mempool SHOULD delegate execution to another service that can
+horizontally scale validation of executing messages.
 
 The [messaging invariants](./messaging.md#messaging-invariants) should be enforced in the transaction pool,
 with dependency validation adapted for guarantees of the in-flight transactions:


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Updates the interop specs for 3074. This removes the "only eoa" invariant
and redefines an executing message to be an event emitted by the `CrossL2Inbox`
