### PR TITLE
Update custom-gas-token.md

### DIFF
--- a/specs/experimental/custom-gas-token.md
+++ b/specs/experimental/custom-gas-token.md
@@ -120,9 +120,6 @@ the `GAS_PAYING_TOKEN_SLOT` slot for `SystemConfig` is not `address(0)`, the sys
 gas paying token, and the getter returns the address in the slot.
 
 ```mermaid
----
-title: Custom Gas Token Configuration
----
 flowchart LR
     subgraph Layer One
         OP[OptimismPortal]
@@ -360,9 +357,6 @@ The following diagram shows the control flow for when a user attempts to send `e
 the `StandardBridge`, either on L1 or L2.
 
 ```mermaid
----
-title: Control Flow for Custom Gas Token Chain
----
 flowchart TD
     A1(User) -->|Attempts to deposit/withdraw ether| A2(StandardBridge or CrossDomainMessenger)
     A2 -->|Is chain using custom gas token?| A3{SystemConfig or L1Block}


### PR DESCRIPTION
Remove `title` for `mermaid` since it's not supported

![image](https://github.com/ethereum-optimism/specs/assets/16250688/a9686235-36b9-4c0f-9d24-b8b9726a4e80)
