### PR TITLE
chore: Re-proving withdrawals change

### DIFF
--- a/specs/experimental/fault-proof/stage-one/bridge-integration.md
+++ b/specs/experimental/fault-proof/stage-one/bridge-integration.md
@@ -2,7 +2,6 @@
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
 **Table of Contents**
 
 - [Overview](#overview)

--- a/specs/experimental/fault-proof/stage-one/bridge-integration.md
+++ b/specs/experimental/fault-proof/stage-one/bridge-integration.md
@@ -2,6 +2,7 @@
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
 **Table of Contents**
 
 - [Overview](#overview)
@@ -190,8 +191,8 @@ timestamp of re-proven withdrawals is still reset.
 
 1. **Old:** Re-proving is allowed if the output root at the proven withdrawal's `l2OutputIndex` changed in the
    `L2OutputOracle`.
-2. **New:** Re-proving is allowed if the output proposal's dispute game has resolved against the output root's favor,
-   the respected game type changed since the withdrawal was proven, or the game that was proven against was blacklisted.
+2. **New:** Re-proving is allowed at any time by the user. When a withdrawal is re-proven, its proof maturity delay is
+   reset.
 
 ### `finalizeWithdrawalTransaction` modifications
 


### PR DESCRIPTION
## Overview

Updates the spec to note that users may always re-prove a withdrawal that they've submitted their own proof for. The implementation now maps proof submitters to withdrawal proofs, removing the need to check for special cases when a withdrawal is attempted to be re-proven.
