### PR TITLE
Add DGM security properties

### DIFF
--- a/specs/experimental/security-council-safe.md
+++ b/specs/experimental/security-council-safe.md
@@ -24,8 +24,10 @@
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-The Security Council uses a specially extended Safe multisig contract to provide additional security
-guarantees on top of those provided by the Safe contract.
+The Security Council (at
+[eth:0xc2819DC788505Aac350142A7A707BF9D03E3Bd03](https://etherscan.io/address/0xc2819DC788505Aac350142A7A707BF9D03E3Bd03))
+uses a specially extended Safe multisig contract to provide additional security guarantees on top of
+those provided by the Safe contract.
 
 ## Deputy guardian module
 
@@ -76,6 +78,18 @@ interface DeputyGuardianModule {
 
 For simplicity, the `DeputyGuardianModule` module does not have functions for updating the `safe` and
 `deputyGuardian` addresses. If necessary these can be modified by swapping out with a new module.
+
+### Deputy Guardian Module Security Properties
+
+The following security properties must be upheld by the `DeputyGuardianModule`:
+
+1. The module must correctly enforce access controls so that only the Deputy Guardian can call state
+   modifying functions.
+2. The module must be safely removable.
+3. The module must not introduce any possibility of disabling the the Safe so that it can no longer
+   forward transactions.
+4. The module must format calldata correctly such that the target it calls performs the expected
+   action.
 
 ## Liveness checking mechanism
 
@@ -157,7 +171,7 @@ In the unlikely event that the signer set (`N`) is reduced below the allowed min
 owners, then (and only then) is a shutdown mechanism activated which removes the existing
 signers, and hands control of the multisig over to a predetermined entity.
 
-### Security Properties
+### Liveness Security Properties
 
 The following security properties must be upheld:
 

--- a/specs/experimental/security-council-safe.md
+++ b/specs/experimental/security-council-safe.md
@@ -5,13 +5,14 @@
 **Table of Contents**
 
 - [Deputy guardian module](#deputy-guardian-module)
+  - [Deputy Guardian Module Security Properties](#deputy-guardian-module-security-properties)
 - [Liveness checking mechanism](#liveness-checking-mechanism)
 - [Liveness checking methodology](#liveness-checking-methodology)
   - [The liveness guard](#the-liveness-guard)
   - [The liveness module](#the-liveness-module)
   - [Owner removal call flow](#owner-removal-call-flow)
   - [Shutdown](#shutdown)
-  - [Security Properties](#security-properties)
+  - [Liveness Security Properties](#liveness-security-properties)
     - [In the guard](#in-the-guard)
     - [In the module](#in-the-module)
   - [Interdependency between the guard and module](#interdependency-between-the-guard-and-module)
@@ -61,14 +62,14 @@ interface DeputyGuardianModule {
    function unpause() external;
 
    /// @dev Calls the Security Council Safe's `execTransactionFromModule()`, with the arguments
-   ///      with the arguments necessary to call `blacklistDisputeGame()` on the `DisputeGameFactory` contract.
+   ///      necessary to call `blacklistDisputeGame()` on the `OptimismPortal2` contract.
    ///      Only the deputy guardian can call this function.
    /// @param _portal The `OptimismPortal2` contract instance.
    /// @param _game The `IDisputeGame` contract instance.
    function blacklistDisputeGame(address _portal, address _game) external;
 
-   /// @dev When called, this function will call to the Security Council's `execTransactionFromModule()`
-   ///      with the arguments necessary to call `setRespectedGameType()` on the `OptimismPortal2` contract.
+   /// @dev Calls the Security Council Safe's `execTransactionFromModule()`, with the arguments
+   ///      necessary to call `setRespectedGameType()` on the `OptimismPortal2` contract.
    ///      Only the deputy guardian can call this function.
    /// @param _portal The `OptimismPortal2` contract instance.
    /// @param _gameType The `GameType` to set as the respected game type
@@ -84,11 +85,15 @@ For simplicity, the `DeputyGuardianModule` module does not have functions for up
 The following security properties must be upheld by the `DeputyGuardianModule`:
 
 1. The module must correctly enforce access controls so that only the Deputy Guardian can call state
-   modifying functions.
-2. The module must be safely removable.
-3. The module must not introduce any possibility of disabling the the Safe so that it can no longer
+   modifying functions on the `DeputyGuardianModule`.
+1. The module must be able to cause the Safe to make calls to all of the functions which the
+   Guardian role is authorized to make.
+1. The module must not be able to cause the Safe to make calls to functions which the Guardian role
+   is not authorized to make.
+1. The module must be safely removable.
+1. The module must not introduce any possibility of disabling the the Safe so that it can no longer
    forward transactions.
-4. The module must format calldata correctly such that the target it calls performs the expected
+1. The module must format calldata correctly such that the target it calls performs the expected
    action.
 
 ## Liveness checking mechanism


### PR DESCRIPTION
Adds a section on security properties to the Deputy Guardian Module specs. This already exists for the Liveness extensions.