### PR TITLE
Remove `ClaimHash` references

### DIFF
--- a/specs/experimental/fault-proof/stage-one/fault-dispute-game.md
+++ b/specs/experimental/fault-proof/stage-one/fault-dispute-game.md
@@ -79,7 +79,7 @@ We refer to this state as the **ABSOLUTE_PRESTATE**.
 ### Claims
 
 Claims assert an [output root][g-output-root] or the state of the FPVM at a given instruction. This is represented as
-`ClaimHash`, a `bytes32` representing either an [output root][g-output-root] or a commitment to the last VM state in a
+a `Hash` type, a `bytes32` representing either an [output root][g-output-root] or a commitment to the last VM state in a
 trace. A FDG is initialized with an output root that corresponds to the state of L2 at a given L2 block number, and
 execution trace subgames at `SPLIT_DEPTH + 1` are initialized with a claim that commits to the entire execution trace
 between two consecutive output roots (a block `n -> n+1` state transition). As we'll see later, there can be multiple
@@ -159,7 +159,7 @@ Positions higher up the game tree also cover the deepest, right-most positions r
 We refer to this coverage as the **trace index** of a Position.
 
 > This means claims commit to an execution trace that terminates at the same index as their Position's trace index.
-> That is, for a given trace index $n$, its ClaimHash corresponds to the $S_n$ th state in the trace.
+> That is, for a given trace index $n$, its state witness hash corresponds to the $S_n$ th state in the trace.
 
 Note that there can be multiple positions covering the same _trace index_.
 
@@ -247,7 +247,7 @@ trace index as another Position with gindex 2. We can verify that all trace indi
 
 ![Game Tree Showing All Valid Move Positions](../../../static/assets/valid-moves.png)
 
-There may be multiple claims at the same position, so long as their `ClaimHash` are unique.
+There may be multiple claims at the same position, so long as their state witness hashes are unique.
 
 Each move adds new claims to the Game Tree at strictly increasing depth.
 Once a claim is at `MAX_GAME_DEPTH`, the only way to dispute such claims is to **step**.

--- a/specs/experimental/fault-proof/stage-one/honest-challenger-fdg.md
+++ b/specs/experimental/fault-proof/stage-one/honest-challenger-fdg.md
@@ -51,8 +51,9 @@ in the contract. This ordering ensures that a claim's ancestors are processed pr
 the honest challenger determines and tracks the set of honest responses to all claims, regardless of whether that
 response already exists in the full game state.
 
-The root claim is considered to be an honest claim if and only if it has a [ClaimHash](fault-dispute-game.md#claims)
-that agrees with the honest challenger's ClaimHash for the root claim.
+The root claim is considered to be an honest claim if and only if it has a
+[state witness Hash](fault-dispute-game.md#claims) that agrees with the honest challenger's state witness hash for the
+root claim.
 
 The honest challenger should counter a claim if and only if:
 
@@ -66,8 +67,8 @@ each claim, so an honest claim never has an honest sibling.
 ### Moves
 
 To respond to a claim with a depth in the range of `[1, MAX_DEPTH]`, the honest challenger determines if the claim
-has a valid commitment (i.e. `ClaimHash`). If the `ClaimHash` matches the honest challenger's at teh same trace index,
-then we disagree with the claim's stance by move to [defend](fault-dispute-game.md#defend).
+has a valid commitment. If the state witness hash matches the honest challenger's at teh same trace
+index, then we disagree with the claim's stance by move to [defend](fault-dispute-game.md#defend).
 Otherwise, the claim is [attacked](fault-dispute-game.md#attack).
 
 The claim that would be added as a result of the move is added to the set of honest moves being tracked.
@@ -87,7 +88,7 @@ challenger does not perform any action.
 
 Otherwise, similar to the above section, the honest challenger will issue an
 [attack step](fault-dispute-game.md#step-types) when in response to such claims with
-invalid `ClaimHash` commitments. Otherwise, it issues a _defense step_.
+invalid state witness commitments. Otherwise, it issues a _defense step_.
 
 ### Timeliness
 

--- a/specs/experimental/fault-proof/stage-one/honest-challenger-fdg.md
+++ b/specs/experimental/fault-proof/stage-one/honest-challenger-fdg.md
@@ -67,7 +67,7 @@ each claim, so an honest claim never has an honest sibling.
 ### Moves
 
 To respond to a claim with a depth in the range of `[1, MAX_DEPTH]`, the honest challenger determines if the claim
-has a valid commitment. If the state witness hash matches the honest challenger's at teh same trace
+has a valid commitment. If the state witness hash matches the honest challenger's at the same trace
 index, then we disagree with the claim's stance by move to [defend](fault-dispute-game.md#defend).
 Otherwise, the claim is [attacked](fault-dispute-game.md#attack).
 


### PR DESCRIPTION
## Overview

Removes references to the `ClaimHash` type, in favor of "state witness
hash". This is a more accurate description, and the `ClaimHash` type was
removed in https://github.com/ethereum-optimism/optimism/pull/10351