### PR TITLE
Fjord: update Fjord spec for brotli compression feature

### DIFF
--- a/specs/fjord/derivation.md
+++ b/specs/fjord/derivation.md
@@ -8,6 +8,7 @@
   - [Constant Maximum Sequencer Drift](#constant-maximum-sequencer-drift)
     - [Rationale](#rationale)
     - [Security Considerations](#security-considerations)
+  - [Brotli Channel Compression](#brotli-channel-compression)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -48,3 +49,25 @@ be in the same epoch as the the last pre-Fjord blocks, even if these blocks woul
 have these L1-origin timestamps according to pre-Fjord rules. So the same L1 timestamp would be
 shared within a pre- and post-Fjord mixed epoch. This is considered a feature and is not considered
 a security issue.
+
+# Brotli Channel Compression
+
+[legacy-channel-format]: ../protocol/derivation.md#channel-format
+
+Fjord introduces a new versioned channel encoding format to support alternate compression
+algorithms, with the [legacy channel format][legacy-channel-format] remaining supported. The
+versioned format is as follows:
+
+```text
+channel_encoding = `channel_version_byte ++ compress(rlp_batches)`
+```
+
+The `channel_version_byte` must never have its 4 lower order bits set to `0b1000 = 8` or `0b1111 =
+15`, which are reserved for usage by the header byte of zlib encoded data (see page 5 of
+[RFC-1950][rfc1950]). This allows a channel decoder to determine if a channel encoding is legacy or
+versioned format by testing for these bit values. If the channel encoding is determined to be
+versioned format, the only valid `channel_version_byte` is `1`, which indicates `compress()` is the
+Brotli compression algorithm (as specified in [RFC-7932][rfc7932]) with no custom dictionary.
+
+[rfc7932]: https://datatracker.ietf.org/doc/html/rfc7932
+[rfc1950]: https://www.rfc-editor.org/rfc/rfc1950.html

--- a/specs/fjord/derivation.md
+++ b/specs/fjord/derivation.md
@@ -8,7 +8,7 @@
   - [Constant Maximum Sequencer Drift](#constant-maximum-sequencer-drift)
     - [Rationale](#rationale)
     - [Security Considerations](#security-considerations)
-  - [Brotli Channel Compression](#brotli-channel-compression)
+- [Brotli Channel Compression](#brotli-channel-compression)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/specs/fjord/overview.md
+++ b/specs/fjord/overview.md
@@ -17,6 +17,5 @@ This document is not finalized and should be considered experimental.
 
 ## Consensus Layer
 
-- [Constant maximum sequencer drift](./derivation.md#batch-queue)
-
-- [Channel encoding format](./derivation.md#channel-format)
+- [Constant maximum sequencer drift](./derivation.md#constant-maximum-sequencer-drift)
+- [Brotli channel compression](./derivation.md#brotli-channel-compression)

--- a/specs/fjord/overview.md
+++ b/specs/fjord/overview.md
@@ -18,3 +18,5 @@ This document is not finalized and should be considered experimental.
 ## Consensus Layer
 
 - [Constant maximum sequencer drift](./derivation.md#batch-queue)
+
+- [Channel encoding format](./derivation.md#channel-format)

--- a/specs/protocol/span-batches.md
+++ b/specs/protocol/span-batches.md
@@ -225,11 +225,10 @@ Deposit transactions are excluded in batches and are never written at L1 so excl
 
 ### Adjust `txs` Data Layout for Better Compression
 
-There are (8 choose 2) \* 6! = 20160 permutations of ordering fields of `txs`.
-It is not 8! because `contract_creation_bits` must be first decoded in order to decode `tx_tos`.
-We experimented to find out the best layout for compression.
-It turned out placing random data together(`TxSigs`, `TxTos`, `TxDatas`),
-then placing leftovers helped gzip to gain more size reduction.
+There are (8 choose 2) \* 6! = 20160 permutations of ordering fields of `txs`.  It is not 8!
+because `contract_creation_bits` must be first decoded in order to decode `tx_tos`.  We
+experimented with different data layouts and found that segregating random data (`tx_sigs`,
+`tx_tos`, `tx_datas`) from the rest most improved the zlib compression ratio.
 
 ### `fee_recipients` Encoding Scheme
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Update spec for the Fjord upgrade's introduction of versioned channel_encodings & Brotli-based channel compression.
