### PR TITLE
interop: add separation for static vs. dynamic values in L1Attributes

### DIFF
--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -280,3 +280,11 @@ with `ADD_DEPENDENCY` or `REMOVE_DEPENDENCY`, respectively.
 ## Security Considerations
 
 TODO
+
+# Appendix
+
+## Static Values
+
+Static values are values that only change based on the chain operator's input, such as the gas paying token and the
+dependency set. This contrasts with dynamic values, which change automatically based on the L1 origin's updates, such
+as the sequence number and the L1 block number.

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -234,16 +234,18 @@ getters.
 
 ## L1Block
 
-| Constant | Value                                        |
-|----------|----------------------------------------------|
-| Address  | `0x4200000000000000000000000000000000000015` |
+| Constant            | Value                                        |
+|---------------------|----------------------------------------------|
+| Address             | `0x4200000000000000000000000000000000000015` |
+| `DEPOSITOR_ACCOUNT` | `0xDeaDDEaDDeAdDeAdDEAdDEaddeAddEAdDEAd0001` |
+
 
 ### Static Configuration
 
 The `L1Block` contract MUST include method `setConfig(ConfigType, bytes)` for setting the system's static values, which
 are defined as values that only change based on the chain operator's input. This function serves to reduce the size of
 the L1 Attributes transaction, as well as to reduce the need to add specific one off functions. It can only be called by
-the special depositor account.
+`DEPOSITOR_ACCOUNT`.
 
 The `ConfigType` enum is defined as follows:
 

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -22,8 +22,6 @@
   - [Static Configuration](#static-configuration)
   - [Dependency Set](#dependency-set)
 - [Security Considerations](#security-considerations)
-- [Appendix](#appendix)
-  - [Static Values](#static-values)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -247,8 +247,9 @@ The interop upgrade block itself MUST include a call to `setL1BlockValuesEcotone
 
 ### L1Attributes
 
-The L1 Atrributes transaction is updated to include the dependency set. Since the dependency set is dynamically sized,
-a `uint8` "interopSetSize" parameter prefixes tightly packed `uint256` values that represent each chain id.
+The L1 Attributes transaction is updated to only include dynamic values. Static values, such as `batcherHash` and
+the interop dependency set, are set through the `setConfig` method.
+
 
 | Input arg         | Type                     | Calldata bytes          | Segment |
 |-------------------|--------------------------|-------------------------|---------|
@@ -261,9 +262,6 @@ a `uint8` "interopSetSize" parameter prefixes tightly packed `uint256` values th
 | basefee           | uint256                  | 36-67                   | 2       |
 | blobBaseFee       | uint256                  | 68-99                   | 3       |
 | l1BlockHash       | bytes32                  | 100-131                 | 4       |
-| batcherHash       | bytes32                  | 132-163                 | 5       |
-| interopSetSize    | uint8                    | 164-165                 | 6       |
-| chainIds          | uint256\[interopSetSize] | 165-(32*interopSetSize) | 6+      |
 
 ## Security Considerations
 

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -254,11 +254,9 @@ enum ConfigType {
 }
 ```
 
-The second argument of `setConfig` is the encoded value being set:
+For `GAS_PAYING_TOKEN`, let `token` be the gas paying token's address (type `address`), `decimals` be the token's decimals (type `uint8`),  `name` be the token's name (type `bytes32`), and `symbol` be the token's symbol (type `bytes32`). The value passed to `setConfig` as the second argument would then be `abi.encode(token, decimals, name, symbol)`.
 
-- For `GAS_PAYING_TOKEN`, this value contains the address of the gas paying token, its decimals, name, and symbol.
-
-- For `ADD_DEPENDENCY` and `REMOVE_DEPENDENCY`, this value contains the chain id being added or removed.
+On the other hand, for `ADD_DEPENDENCY` and `REMOVE_DEPENDENCY`, let `chainId` be the chain id intended to be added or removed from the dependency set. The value passed to `setConfig` as the second argument would be `abi.encode(chainId)`.
 
 Calls to `setConfig` MUST originate from `SystemConfig` and are forwarded to `L1Block` by `OptimismPortal`.
 

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -242,9 +242,9 @@ getters.
 
 ### Static Configuration
 
-The `L1Block` contract MUST include method `setConfig(ConfigType, bytes)` for setting static values that are used by the
-system. This function serves to reduce the size of the L1 Attributes transaction, as well as to reduce the need to add
-specific one off functions.
+The `L1Block` contract MUST include method `setConfig(ConfigType, bytes)` for setting the system's static values, which
+are defined as values that only change based on the chain operator's input. This function serves to reduce the size of
+the L1 Attributes transaction, as well as to reduce the need to add specific one off functions.
 
 The `ConfigType` enum is defined as follows:
 
@@ -293,11 +293,3 @@ MUST return the length of the dependency set array.
 ## Security Considerations
 
 TODO
-
-## Appendix
-
-### Static Values
-
-Static values are values that only change based on the chain operator's input, such as the gas paying token and the
-dependency set. This contrasts with dynamic values, which change automatically based on the L1 origin's updates, such
-as the sequence number and the L1 block number.

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -287,7 +287,7 @@ with `ADD_DEPENDENCY` or `REMOVE_DEPENDENCY`, respectively.
 `isInDependencySet(uint256)`. This function MUST return true when a chain id in the dependency set, or the chain's chain
 id, is passed in as an argument, and false otherwise. Additionally, `L1Block` MUST provide a public getter to return the
 dependency set called `dependencySet()`. This function MUST return the array of chain ids that are in the dependency set.
-`L1Block` MUST also provide a public getter to get the dependency set size called `dependencySetSize()`. This function 
+`L1Block` MUST also provide a public getter to get the dependency set size called `dependencySetSize()`. This function
 MUST return the length of the dependency set array.
 
 ## Security Considerations

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -239,7 +239,6 @@ getters.
 | Address             | `0x4200000000000000000000000000000000000015` |
 | `DEPOSITOR_ACCOUNT` | `0xDeaDDEaDDeAdDeAdDEAdDEaddeAddEAdDEAd0001` |
 
-
 ### Static Configuration
 
 The `L1Block` contract MUST include method `setConfig(ConfigType, bytes)` for setting the system's static values, which

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -238,26 +238,26 @@ getters.
 |----------|----------------------------------------------|
 | Address  | `0x4200000000000000000000000000000000000015` |
 
-The `setL1BlockValuesHolocene()` function MUST be called on every block after the interop upgrade block.
-The interop upgrade block itself MUST include a call to `setL1BlockValuesEcotone`.
-
-### Static Values
+### setConfig
 
 The `L1Block` contract MUST include method `setConfig(ConfigType, bytes)` for setting static values that are used
-by the system. The `ConfigType` enum is defined as follows:
+by the system. This function serves to reduce the size of the L1 Attributes transaction, as well as to reduce the
+need to add specific one off functions.
+
+The `ConfigType` enum is defined as follows:
 
 ```solidity
 enum ConfigType {
     GAS_PAYING_TOKEN,
-    BASE_FEE_SCALAR,
-    BLOB_BASE_FEE_SCALAR,
-    BATCHER_HASH,
     ADD_DEPENDENCY,
     REMOVE_DEPENDENCY
 }
 ```
 
-The second argument of `setConfig` is the encoded value being set.
+The second argument of `setConfig` is the encoded value being set:
+- For `GAS_PAYING_TOKEN`, this value contains the address of the gas paying token, its decimals, name, and symbol.
+- For `ADD_DEPENDENCY` and `REMOVE_DEPENDENCY`, this value contains the chain id being added or removed.
+
 Calls to `setConfig` MUST originate from `SystemConfig` and are forwarded to `L1Block` by `OptimismPortal`.
 
 ### Dependency Set

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -240,9 +240,9 @@ getters.
 
 ### setConfig
 
-The `L1Block` contract MUST include method `setConfig(ConfigType, bytes)` for setting static values that are used
-by the system. This function serves to reduce the size of the L1 Attributes transaction, as well as to reduce the
-need to add specific one off functions.
+The `L1Block` contract MUST include method `setConfig(ConfigType, bytes)` for setting static values that are used by the
+system. This function serves to reduce the size of the L1 Attributes transaction, as well as to reduce the need to add
+specific one off functions.
 
 The `ConfigType` enum is defined as follows:
 
@@ -254,16 +254,20 @@ enum ConfigType {
 }
 ```
 
-For `GAS_PAYING_TOKEN`, let `token` be the gas paying token's address (type `address`), `decimals` be the token's decimals (type `uint8`),  `name` be the token's name (type `bytes32`), and `symbol` be the token's symbol (type `bytes32`). The value passed to `setConfig` as the second argument would then be `abi.encode(token, decimals, name, symbol)`.
+For `GAS_PAYING_TOKEN`, let `token` be the gas paying token's address (type `address`), `decimals` be the token's
+decimals (type `uint8`), `name` be the token's name (type `bytes32`), and `symbol` be the token's symbol (type
+`bytes32`). The value passed to `setConfig` as the second argument would then be
+`abi.encode(token, decimals, name, symbol)`.
 
-On the other hand, for `ADD_DEPENDENCY` and `REMOVE_DEPENDENCY`, let `chainId` be the chain id intended to be added or removed from the dependency set. The value passed to `setConfig` as the second argument would be `abi.encode(chainId)`.
+On the other hand, for `ADD_DEPENDENCY` and `REMOVE_DEPENDENCY`, let `chainId` be the chain id intended to be added or
+removed from the dependency set. The value passed to `setConfig` as the second argument would be `abi.encode(chainId)`.
 
 Calls to `setConfig` MUST originate from `SystemConfig` and are forwarded to `L1Block` by `OptimismPortal`.
 
 ### Dependency Set
 
-`L1Block` is updated to include the set of allowed chains. These chains are added and removed through `setConfig`
-calls with `ADD_DEPENDENCY` or `REMOVE_DEPENDENCY`, respectively.
+`L1Block` is updated to include the set of allowed chains. These chains are added and removed through `setConfig` calls
+with `ADD_DEPENDENCY` or `REMOVE_DEPENDENCY`, respectively.
 
 `L1Block` MUST provide a public getter to check if a particular chain is in the dependency set called
 `isInDependencySet(uint256)`. This function MUST return true when the chain's chain id is passed in as an argument.

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -284,7 +284,9 @@ Calls to `setConfig` MUST originate from `SystemConfig` and are forwarded to `L1
 with `ADD_DEPENDENCY` or `REMOVE_DEPENDENCY`, respectively.
 
 `L1Block` MUST provide a public getter to check if a particular chain is in the dependency set called
-`isInDependencySet(uint256)`. This function MUST return true when the chain's chain id is passed in as an argument.
+`isInDependencySet(uint256)`. This function MUST return true when the chain's chain id is passed in as an argument. 
+Additionally, `L1Block` MUST provide a public getter to return the dependency set called `dependencySet()`. This
+function MUST return the array of chain ids that are in the dependency set.
 
 ## Security Considerations
 

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -238,7 +238,7 @@ getters.
 |----------|----------------------------------------------|
 | Address  | `0x4200000000000000000000000000000000000015` |
 
-### setConfig
+### Static Configuration
 
 The `L1Block` contract MUST include method `setConfig(ConfigType, bytes)` for setting static values that are used by the
 system. This function serves to reduce the size of the L1 Attributes transaction, as well as to reduce the need to add

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -237,12 +237,28 @@ getters.
 |----------|----------------------------------------------|
 | Address  | `0x4200000000000000000000000000000000000015` |
 
-The `L1Block` contract is updated to include the set of allowed chains. The L1 Attributes transaction
-sets the set of allowed chains. The `L1Block` contract MUST provide a public getter to check if a particular
-chain is in the dependency set called `isInDependencySet(uint256)`. This function MUST return true when
-the chain's chain id is passed in as an argument.
+The `L1Block` contract MUST include method `setConfig(ConfigType, bytes)` for setting static values that are used
+by the system. The `ConfigType` enum is defined as follows:
 
-The `setL1BlockValuesInterop()` function MUST be called on every block after the interop upgrade block.
+```solidity
+enum ConfigType {
+    GAS_PAYING_TOKEN,
+    BATCHER_HASH,
+    ADD_DEPENDENCY,
+    REMOVE_DEPENDENCY
+}
+```
+
+The second argument of `setConfig` is the encoded value being set.
+Calls to `setConfig` MUST originate from `SystemConfig` and are forwarded to `L1Block` by `OptimismPortal`.
+
+`L1Block` is updated to include the set of allowed chains. These chains are added and removed through `setConfig`
+calls with `ADD_DEPENDENCY` or `REMOVE_DEPENDENCY`, respectively.
+
+`L1Block` MUST provide a public getter to check if a particular chain is in the dependency set called
+`isInDependencySet(uint256)`. This function MUST return true when the chain's chain id is passed in as an argument.
+
+The `setL1BlockValuesHolocene()` function MUST be called on every block after the interop upgrade block.
 The interop upgrade block itself MUST include a call to `setL1BlockValuesEcotone`.
 
 ### L1Attributes

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -21,7 +21,6 @@
 - [L1Block](#l1block)
   - [Static Values](#static-values)
   - [Dependency Set](#dependency-set)
-  - [L1Attributes](#l1attributes)
 - [Security Considerations](#security-considerations)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -273,7 +273,7 @@ where
 
 - `symbol` is the gas paying token's symbol (type `bytes32`)
 
-- `chainId` is the chain id intended to be added or removed from the dependency set
+- `chainId` is the chain id intended to be added or removed from the dependency set (type `uint256`)
 
 Calls to `setConfig` MUST originate from `SystemConfig` and are forwarded to `L1Block` by `OptimismPortal`.
 

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -19,7 +19,7 @@
     - [Sending Messages](#sending-messages)
     - [Relaying Messages](#relaying-messages)
 - [L1Block](#l1block)
-  - [Static Values](#static-values)
+  - [setConfig](#setconfig)
   - [Dependency Set](#dependency-set)
 - [Security Considerations](#security-considerations)
 

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -266,7 +266,6 @@ The interop upgrade block itself MUST include a call to `setL1BlockValuesEcotone
 The L1 Attributes transaction is updated to only include dynamic values. Static values, such as `batcherHash` and
 the interop dependency set, are set through the `setConfig` method.
 
-
 | Input arg         | Type                     | Calldata bytes          | Segment |
 |-------------------|--------------------------|-------------------------|---------|
 | {0x760ee04d}      | bytes4                   | 0-3                     | n/a     |

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -248,6 +248,8 @@ by the system. The `ConfigType` enum is defined as follows:
 ```solidity
 enum ConfigType {
     GAS_PAYING_TOKEN,
+    BASE_FEE_SCALAR,
+    BLOB_BASE_FEE_SCALAR,
     BATCHER_HASH,
     ADD_DEPENDENCY,
     REMOVE_DEPENDENCY
@@ -273,14 +275,12 @@ the interop dependency set, are set through the `setConfig` method.
 | Input arg         | Type                     | Calldata bytes          | Segment |
 |-------------------|--------------------------|-------------------------|---------|
 | {0x760ee04d}      | bytes4                   | 0-3                     | n/a     |
-| baseFeeScalar     | uint32                   | 4-7                     | 1       |
-| blobBaseFeeScalar | uint32                   | 8-11                    |         |
-| sequenceNumber    | uint64                   | 12-19                   |         |
-| l1BlockTimestamp  | uint64                   | 20-27                   |         |
-| l1BlockNumber     | uint64                   | 28-35                   |         |
-| basefee           | uint256                  | 36-67                   | 2       |
-| blobBaseFee       | uint256                  | 68-99                   | 3       |
-| l1BlockHash       | bytes32                  | 100-131                 | 4       |
+| sequenceNumber    | uint64                   | 4-11                    | 1       |
+| l1BlockTimestamp  | uint64                   | 12-19                   |         |
+| l1BlockNumber     | uint64                   | 20-27                   |         |
+| basefee           | uint256                  | 28-59                   | 2       |
+| blobBaseFee       | uint256                  | 60-91                   | 3       |
+| l1BlockHash       | bytes32                  | 92-123                  | 4       |
 
 ## Security Considerations
 

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -237,6 +237,11 @@ getters.
 |----------|----------------------------------------------|
 | Address  | `0x4200000000000000000000000000000000000015` |
 
+The `setL1BlockValuesHolocene()` function MUST be called on every block after the interop upgrade block.
+The interop upgrade block itself MUST include a call to `setL1BlockValuesEcotone`.
+
+### Static Values
+
 The `L1Block` contract MUST include method `setConfig(ConfigType, bytes)` for setting static values that are used
 by the system. The `ConfigType` enum is defined as follows:
 
@@ -252,14 +257,13 @@ enum ConfigType {
 The second argument of `setConfig` is the encoded value being set.
 Calls to `setConfig` MUST originate from `SystemConfig` and are forwarded to `L1Block` by `OptimismPortal`.
 
+### Dependency Set
+
 `L1Block` is updated to include the set of allowed chains. These chains are added and removed through `setConfig`
 calls with `ADD_DEPENDENCY` or `REMOVE_DEPENDENCY`, respectively.
 
 `L1Block` MUST provide a public getter to check if a particular chain is in the dependency set called
 `isInDependencySet(uint256)`. This function MUST return true when the chain's chain id is passed in as an argument.
-
-The `setL1BlockValuesHolocene()` function MUST be called on every block after the interop upgrade block.
-The interop upgrade block itself MUST include a call to `setL1BlockValuesEcotone`.
 
 ### L1Attributes
 

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -4,24 +4,24 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**
 
-  - [CrossL2Inbox](#crossl2inbox)
-    - [Message execution arguments](#message-execution-arguments)
-      - [`_msg`](#_msg)
-      - [`_id`](#_id)
-      - [`_target`](#_target)
-    - [Reference implementation](#reference-implementation)
-    - [`Identifier` Getters](#identifier-getters)
-  - [L2ToL2CrossDomainMessenger](#l2tol2crossdomainmessenger)
-    - [`relayMessage` Invariants](#relaymessage-invariants)
-    - [Message Versioning](#message-versioning)
-    - [No Native Support for Cross Chain Ether Sends](#no-native-support-for-cross-chain-ether-sends)
-    - [Interfaces](#interfaces)
-      - [Sending Messages](#sending-messages)
-      - [Relaying Messages](#relaying-messages)
-  - [L1Block](#l1block)
-    - [Static Configuration](#static-configuration)
-    - [Dependency Set](#dependency-set)
-  - [Security Considerations](#security-considerations)
+- [CrossL2Inbox](#crossl2inbox)
+  - [Message execution arguments](#message-execution-arguments)
+    - [`_msg`](#_msg)
+    - [`_id`](#_id)
+    - [`_target`](#_target)
+  - [Reference implementation](#reference-implementation)
+  - [`Identifier` Getters](#identifier-getters)
+- [L2ToL2CrossDomainMessenger](#l2tol2crossdomainmessenger)
+  - [`relayMessage` Invariants](#relaymessage-invariants)
+  - [Message Versioning](#message-versioning)
+  - [No Native Support for Cross Chain Ether Sends](#no-native-support-for-cross-chain-ether-sends)
+  - [Interfaces](#interfaces)
+    - [Sending Messages](#sending-messages)
+    - [Relaying Messages](#relaying-messages)
+- [L1Block](#l1block)
+  - [Static Configuration](#static-configuration)
+  - [Dependency Set](#dependency-set)
+- [Security Considerations](#security-considerations)
 - [Appendix](#appendix)
   - [Static Values](#static-values)
 
@@ -290,9 +290,9 @@ with `ADD_DEPENDENCY` or `REMOVE_DEPENDENCY`, respectively.
 
 TODO
 
-# Appendix
+## Appendix
 
-## Static Values
+### Static Values
 
 Static values are values that only change based on the chain operator's input, such as the gas paying token and the
 dependency set. This contrasts with dynamic values, which change automatically based on the L1 origin's updates, such

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -242,7 +242,8 @@ getters.
 
 The `L1Block` contract MUST include method `setConfig(ConfigType, bytes)` for setting the system's static values, which
 are defined as values that only change based on the chain operator's input. This function serves to reduce the size of
-the L1 Attributes transaction, as well as to reduce the need to add specific one off functions.
+the L1 Attributes transaction, as well as to reduce the need to add specific one off functions. It can only be called by
+the special depositor account.
 
 The `ConfigType` enum is defined as follows:
 

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -4,24 +4,26 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**
 
-- [CrossL2Inbox](#crossl2inbox)
-  - [Message execution arguments](#message-execution-arguments)
-    - [`_msg`](#_msg)
-    - [`_id`](#_id)
-    - [`_target`](#_target)
-  - [Reference implementation](#reference-implementation)
-  - [`Identifier` Getters](#identifier-getters)
-- [L2ToL2CrossDomainMessenger](#l2tol2crossdomainmessenger)
-  - [`relayMessage` Invariants](#relaymessage-invariants)
-  - [Message Versioning](#message-versioning)
-  - [No Native Support for Cross Chain Ether Sends](#no-native-support-for-cross-chain-ether-sends)
-  - [Interfaces](#interfaces)
-    - [Sending Messages](#sending-messages)
-    - [Relaying Messages](#relaying-messages)
-- [L1Block](#l1block)
-  - [setConfig](#setconfig)
-  - [Dependency Set](#dependency-set)
-- [Security Considerations](#security-considerations)
+  - [CrossL2Inbox](#crossl2inbox)
+    - [Message execution arguments](#message-execution-arguments)
+      - [`_msg`](#_msg)
+      - [`_id`](#_id)
+      - [`_target`](#_target)
+    - [Reference implementation](#reference-implementation)
+    - [`Identifier` Getters](#identifier-getters)
+  - [L2ToL2CrossDomainMessenger](#l2tol2crossdomainmessenger)
+    - [`relayMessage` Invariants](#relaymessage-invariants)
+    - [Message Versioning](#message-versioning)
+    - [No Native Support for Cross Chain Ether Sends](#no-native-support-for-cross-chain-ether-sends)
+    - [Interfaces](#interfaces)
+      - [Sending Messages](#sending-messages)
+      - [Relaying Messages](#relaying-messages)
+  - [L1Block](#l1block)
+    - [Static Configuration](#static-configuration)
+    - [Dependency Set](#dependency-set)
+  - [Security Considerations](#security-considerations)
+- [Appendix](#appendix)
+  - [Static Values](#static-values)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -273,7 +275,6 @@ where
 - `symbol` is the gas paying token's symbol (type `bytes32`)
 
 - `chainId` is the chain id intended to be added or removed from the dependency set
-
 
 Calls to `setConfig` MUST originate from `SystemConfig` and are forwarded to `L1Block` by `OptimismPortal`.
 

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -262,9 +262,17 @@ The second argument to `setConfig` is a `bytes` value that is ABI encoded with t
 | `ADD_DEPENDENCY`    | `abi.encode(chainId)`                       |
 | `REMOVE_DEPENDENCY` | `abi.encode(chainId)`                       |
 
-where `token` is the gas paying token's address (type `address`), `decimals` is the token's decimals (type `uint8`),
-`name` is the token's name (type `bytes32`), `symbol` is the token's symbol (type `bytes32`), and `chainId` is the chain
-id intended to be added or removed from the dependency set.
+where
+
+- `token` is the gas paying token's address (type `address`)
+
+- `decimals` is the gas paying token's decimals (type `uint8`)
+
+- `name` is the gas paying token's name (type `bytes32`)
+
+- `symbol` is the gas paying token's symbol (type `bytes32`)
+
+- `chainId` is the chain id intended to be added or removed from the dependency set
 
 
 Calls to `setConfig` MUST originate from `SystemConfig` and are forwarded to `L1Block` by `OptimismPortal`.

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -255,7 +255,9 @@ enum ConfigType {
 ```
 
 The second argument of `setConfig` is the encoded value being set:
+
 - For `GAS_PAYING_TOKEN`, this value contains the address of the gas paying token, its decimals, name, and symbol.
+
 - For `ADD_DEPENDENCY` and `REMOVE_DEPENDENCY`, this value contains the chain id being added or removed.
 
 Calls to `setConfig` MUST originate from `SystemConfig` and are forwarded to `L1Block` by `OptimismPortal`.

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -269,21 +269,6 @@ calls with `ADD_DEPENDENCY` or `REMOVE_DEPENDENCY`, respectively.
 `L1Block` MUST provide a public getter to check if a particular chain is in the dependency set called
 `isInDependencySet(uint256)`. This function MUST return true when the chain's chain id is passed in as an argument.
 
-### L1Attributes
-
-The L1 Attributes transaction is updated to only include dynamic values. Static values, such as `batcherHash` and
-the interop dependency set, are set through the `setConfig` method.
-
-| Input arg         | Type                     | Calldata bytes          | Segment |
-|-------------------|--------------------------|-------------------------|---------|
-| {0x760ee04d}      | bytes4                   | 0-3                     | n/a     |
-| sequenceNumber    | uint64                   | 4-11                    | 1       |
-| l1BlockTimestamp  | uint64                   | 12-19                   |         |
-| l1BlockNumber     | uint64                   | 20-27                   |         |
-| basefee           | uint256                  | 28-59                   | 2       |
-| blobBaseFee       | uint256                  | 60-91                   | 3       |
-| l1BlockHash       | bytes32                  | 92-123                  | 4       |
-
 ## Security Considerations
 
 TODO

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -19,6 +19,8 @@
     - [Sending Messages](#sending-messages)
     - [Relaying Messages](#relaying-messages)
 - [L1Block](#l1block)
+  - [Static Values](#static-values)
+  - [Dependency Set](#dependency-set)
   - [L1Attributes](#l1attributes)
 - [Security Considerations](#security-considerations)
 

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -254,13 +254,18 @@ enum ConfigType {
 }
 ```
 
-For `GAS_PAYING_TOKEN`, let `token` be the gas paying token's address (type `address`), `decimals` be the token's
-decimals (type `uint8`), `name` be the token's name (type `bytes32`), and `symbol` be the token's symbol (type
-`bytes32`). The value passed to `setConfig` as the second argument would then be
-`abi.encode(token, decimals, name, symbol)`.
+The second argument to `setConfig` is a `bytes` value that is ABI encoded with the necessary values for the `ConfigType`.
 
-On the other hand, for `ADD_DEPENDENCY` and `REMOVE_DEPENDENCY`, let `chainId` be the chain id intended to be added or
-removed from the dependency set. The value passed to `setConfig` as the second argument would be `abi.encode(chainId)`.
+| ConfigType          | Value                                       |
+|---------------------|---------------------------------------------|
+| `GAS_PAYING_TOKEN`  | `abi.encode(token, decimals, name, symbol)` |
+| `ADD_DEPENDENCY`    | `abi.encode(chainId)`                       |
+| `REMOVE_DEPENDENCY` | `abi.encode(chainId)`                       |
+
+where `token` is the gas paying token's address (type `address`), `decimals` is the token's decimals (type `uint8`),
+`name` is the token's name (type `bytes32`), `symbol` is the token's symbol (type `bytes32`), and `chainId` is the chain
+id intended to be added or removed from the dependency set.
+
 
 Calls to `setConfig` MUST originate from `SystemConfig` and are forwarded to `L1Block` by `OptimismPortal`.
 

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -284,9 +284,11 @@ Calls to `setConfig` MUST originate from `SystemConfig` and are forwarded to `L1
 with `ADD_DEPENDENCY` or `REMOVE_DEPENDENCY`, respectively.
 
 `L1Block` MUST provide a public getter to check if a particular chain is in the dependency set called
-`isInDependencySet(uint256)`. This function MUST return true when the chain's chain id is passed in as an argument. 
-Additionally, `L1Block` MUST provide a public getter to return the dependency set called `dependencySet()`. This
-function MUST return the array of chain ids that are in the dependency set.
+`isInDependencySet(uint256)`. This function MUST return true when a chain id in the dependency set, or the chain's chain
+id, is passed in as an argument, and false otherwise. Additionally, `L1Block` MUST provide a public getter to return the
+dependency set called `dependencySet()`. This function MUST return the array of chain ids that are in the dependency set.
+`L1Block` MUST also provide a public getter to get the dependency set size called `dependencySetSize()`. This function 
+MUST return the length of the dependency set array.
 
 ## Security Considerations
 


### PR DESCRIPTION
context: https://github.com/ethereum-optimism/specs/issues/122