### PR TITLE
fjord: Clarify that seq drift change activates with L1 origin

### DIFF
--- a/specs/fjord/derivation.md
+++ b/specs/fjord/derivation.md
@@ -32,6 +32,7 @@ Fjord, like other network upgrades, is activated at a timestamp.
 Changes to the L2 Block execution rules are applied when the `L2 Timestamp >= activation time`.
 Changes to derivation are applied when it is considering data from a L1 Block whose timestamp
 is greater than or equal to the activation timestamp.
+The change of the `max_sequencer_drift` parameter activates with the L1 origin block timestamp.
 
 ## Constant Maximum Sequencer Drift
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

The seq drift change activation was ambiguous.

- Fixes https://github.com/ethereum-optimism/protocol-quest/issues/255
