### PR TITLE
Adding RollbackInbox and upgrading Messenger & Bridge

### DIFF
--- a/specs/protocol/bridges.md
+++ b/specs/protocol/bridges.md
@@ -6,6 +6,7 @@
 
 - [Overview](#overview)
 - [Token Depositing](#token-depositing)
+- [ERC20 Unlocking](#erc20-unlocking)
 - [Upgradability](#upgradability)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -29,15 +30,19 @@ interface StandardBridge {
     event ERC20BridgeInitiated(address indexed localToken, address indexed remoteToken, address indexed from, address to, uint256 amount, bytes extraData);
     event ETHBridgeFinalized(address indexed from, address indexed to, uint256 amount, bytes extraData);
     event ETHBridgeInitiated(address indexed from, address indexed to, uint256 amount, bytes extraData);
+    event ERC20Unlocked(address indexed localToken, address indexed remotetoken, address indexed from, uint256 amount, bytes32 messageHash);
 
     function bridgeERC20(address _localToken, address _remoteToken, uint256 _amount, uint32 _minGasLimit, bytes memory _extraData) external;
     function bridgeERC20To(address _localToken, address _remoteToken, address _to, uint256 _amount, uint32 _minGasLimit, bytes memory _extraData) external;
     function bridgeETH(uint32 _minGasLimit, bytes memory _extraData) payable external;
     function bridgeETHTo(address _to, uint32 _minGasLimit, bytes memory _extraData) payable external;
     function deposits(address, address) view external returns (uint256);
+    function processedMessages(bytes32 _messageHashes) view external returns (uint256);
+    function unlockERC20s(address _localToken, address _remoteToken, address _from, address _to, uint256 _amount, bytes calldata _extraData, uint240 _nonce, uint32 _minGasLimit) external;
     function finalizeBridgeERC20(address _localToken, address _remoteToken, address _from, address _to, uint256 _amount, bytes memory _extraData) external;
     function finalizeBridgeETH(address _from, address _to, uint256 _amount, bytes memory _extraData) payable external;
     function messenger() view external returns (address);
+    function ROLLBACK_INBOX() view external returns (address);
     function OTHER_BRIDGE() view external returns (address);
 }
 ```
@@ -48,6 +53,9 @@ The `bridgeERC20` function is used to send a token from one domain to another
 domain. An `OptimismMintableERC20` token contract must exist on the remote
 domain to be able to deposit tokens to that domain. One of these tokens can be
 deployed using the `OptimismMintableERC20Factory` contract.
+
+## ERC20 Unlocking
+The `ERC20Unlocked` function is used to unlock tokens stuck due to failure in relaying prior ERC20 bridging actions. A `messageHash` must exist in the `ROLLBACK_INBOX` contract to certify the message hash corresponding to an ERC20 bridging action started from the standard bridged failed on the other domain.
 
 ## Upgradability
 

--- a/specs/protocol/bridges.md
+++ b/specs/protocol/bridges.md
@@ -55,7 +55,11 @@ domain to be able to deposit tokens to that domain. One of these tokens can be
 deployed using the `OptimismMintableERC20Factory` contract.
 
 ## ERC20 Unlocking
-The `ERC20Unlocked` function is used to unlock tokens stuck due to failure in relaying prior ERC20 bridging actions. A `messageHash` must exist in the `ROLLBACK_INBOX` contract to certify the message hash corresponding to an ERC20 bridging action started from the standard bridged failed on the other domain.
+
+The `ERC20Unlocked` function is used to unlock tokens stuck due to failure in
+relaying prior ERC20 bridging actions. A `messageHash` must exist in the `ROLLBACK_INBOX`
+contract to certify the message hash corresponding to an ERC20 bridging action started
+from the standard bridged failed on the other domain.
 
 ## Upgradability
 

--- a/specs/protocol/messengers.md
+++ b/specs/protocol/messengers.md
@@ -6,6 +6,7 @@
 
 - [Overview](#overview)
 - [Message Passing](#message-passing)
+- [Rolling a Message Back](#rolling-a-message-back)
 - [Upgradability](#upgradability)
 - [Message Versioning](#message-versioning)
   - [Message Version 0](#message-version-0)

--- a/specs/protocol/messengers.md
+++ b/specs/protocol/messengers.md
@@ -85,7 +85,14 @@ on the OptimismPortal, which calls `relayMessage` on the
 `L1CrossDomainMessenger` to finalize the withdrawal.
 
 ## Rolling a Message Back
-The `sendHashToRollbackInbox` function is used to send the hashes of failed and unsuccesful messages to the `ROLLBACK_INBOX` contract on the other domain after a given delay, ensuring the message corresponding to the rolled back hash is never processed in the current domain. The main purpose of this function is to inform the other domain of failed messages so contracts living in this other domain can handle the message failure. This allows functionalities such as unlocking stuck ERC20s.
+
+The `sendHashToRollbackInbox` function is used to send the hashes of failed
+and unsuccesful messages to the `ROLLBACK_INBOX` contract on the other domain
+after a given delay, ensuring the message corresponding to the rolled back hash
+is never processed in the current domain. The main purpose of this function
+is to inform the other domain of failed messages so contracts living in
+this other domain can handle the message failure. This allows functionalities
+such as unlocking stuck ERC20s.
 
 ## Upgradability
 

--- a/specs/protocol/rollback-inboxes.md
+++ b/specs/protocol/rollback-inboxes.md
@@ -12,7 +12,7 @@
 
 ## Overview
 
-The rollback inbox contracts are responsible for storing the hashes of messages that failed on the other domain. They are built with the purpose of allowing contracts on the same domain to have the capability of handling what actions to perform when one of the messages they sent failed on the other domain.
+The rollback inbox contracts are responsible for storing the hashes of messages that failed on the other domain. They are built with the purpose of allowing contracts on the same domain to have the capability of handling what actions to perform when a message failed on the other domain and was rolled-back to it's origin domain.
 
 ```solidity
 interface RollbackInbox {

--- a/specs/protocol/rollback-inboxes.md
+++ b/specs/protocol/rollback-inboxes.md
@@ -14,6 +14,8 @@
 
 The rollback inbox contracts are responsible for storing the hashes of messages that failed on the other domain. They are built with the purpose of allowing contracts on the same domain to have the capability of handling what actions to perform when a message failed on the other domain and was rolled-back to it's origin domain.
 
+The `L2RollbackInbox` is a predeploy contract located at TO BE DEFINED.
+
 ```solidity
 interface RollbackInbox {
     event MessageHashReceived(bytes32 indexed messageHash, uint256 indexed timestamp);

--- a/specs/protocol/rollback-inboxes.md
+++ b/specs/protocol/rollback-inboxes.md
@@ -12,7 +12,10 @@
 
 ## Overview
 
-The rollback inbox contracts are responsible for storing the hashes of messages that failed on the other domain. They are built with the purpose of allowing contracts on the same domain to have the capability of handling what actions to perform when a message failed on the other domain and was rolled-back to it's origin domain.
+The rollback inbox contracts are responsible for storing the hashes of messages
+that failed on the other domain. They are built with the purpose of allowing contracts
+on the same domain to have the capability of handling what actions to perform when a
+message failed on the other domain and was rolled-back to it's origin domain.
 
 The `L2RollbackInbox` is a predeploy contract located at TO BE DEFINED.
 
@@ -29,7 +32,9 @@ interface RollbackInbox {
 
 ## Message Hash Reception
 
-The `receiveMessageHash` function is used to receive message hashes from the other domain. It must ensure the caller is the `CrossDomainMessenger` from this domain, and that the sender is the `CrossDomainMessenger` from the other domain.
+The `receiveMessageHash` function is used to receive message hashes from the other domain.
+It must ensure the caller is the `CrossDomainMessenger` from this domain, and that the
+sender is the `CrossDomainMessenger` from the other domain.
 
 ## Upgradability
 

--- a/specs/protocol/rollback-inboxes.md
+++ b/specs/protocol/rollback-inboxes.md
@@ -1,0 +1,34 @@
+# Rollback Inboxes
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**
+
+- [Overview](#overview)
+- [Message Hash Reception](#message-hash-reception)
+- [Upgradability](#upgradability)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Overview
+
+The rollback inbox contracts are responsible for storing the hashes of messages that failed on the other domain. They are built with the purpose of allowing contracts on the same domain to have the capability of handling what actions to perform when one of the messages they sent failed on the other domain.
+
+```solidity
+interface RollbackInbox {
+    event MessageHashReceived(bytes32 indexed messageHash, uint256 indexed timestamp);
+
+    function receiveMessageHash(bytes32 _messageHash, address _sender) external;
+    function messenger() view external returns (address);
+    function otherMessenger() view external returns (address);
+    function messageHashes(bytes32 _messageHash) view external returns (uint256);
+}
+```
+
+## Message Hash Reception
+
+The `receiveMessageHash` function is used to receive message hashes from the other domain. It must ensure the caller is the `CrossDomainMessenger` from this domain, and that the sender is the `CrossDomainMessenger` from the other domain.
+
+## Upgradability
+
+Both the L1 and L2 rollback inboxes should be behind upgradable proxies.


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Adds a way for the `CrossDomainMessenger` to "send-back" failed messages.
These failed messages are stored on the origin domain in a `RollbackInbox` contract.
This enables smart contracts to handle "failed" messages.
e.g. the `StandardBridge` can safely recover stuck funds by validating that a message was indeed NOT successful on the other domain.

For this proposal, we've also prepared a detailed Notion document, found [here](https://defi-wonderland.notion.site/RollbackInbox-V1-c5dc38b62cf64b51807427012c991bb3), that goes through the rationale and need of the `RollbackInbox` and accompanying functionality on the `CrossDomainMessenger` &  `StandardBridge`.

We also believe this would be an important primitive for Interop.

Would love to hear your thoughts and any feedback you might have on this proposal :)

**Tests**

N/A

**Additional context**

https://defi-wonderland.notion.site/RollbackInbox-V1-c5dc38b62cf64b51807427012c991bb3
L2ToL2CrossDomainMessenger alternative: https://github.com/ethereum-optimism/specs/pull/203

**Metadata**

N/A

This proposal was developed as an internal research project at @defi-wonderland lead by @0xng.
