### PR TITLE
Add ecotone fields to L1 block data description...

### DIFF
--- a/specs/protocol/deposits.md
+++ b/specs/protocol/deposits.md
@@ -304,6 +304,8 @@ The predeploy stores the following values:
   - `overhead` (`uint256`): The L1 fee overhead to apply to L1 cost computation of transactions in this L2 block.
   - `scalar` (`uint256`): The L1 fee scalar to apply to L1 cost computation of transactions in this L2 block.
 - With the Ecotone upgrade, the predeploy additionally stores:
+  - `blobBaseFee`: the L1 blob base fee.
+  - `blobBaseFeeScaler`: The scalar value applied to the L1 blob base fee portion of the L1 cost computation
 
 The contract implements an authorization scheme, such that it only accepts state-changing calls from
 the [depositor account][depositor-account].


### PR DESCRIPTION
previously the listing trailed off

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

PR adds blob base fee and scalar fields to the documented data fields of the L1 attributes predeploy.

**Tests**

(none)

**Additional context**

Previous doc trailed off after `With the Ecotone upgrade, the predeploy additionally stores:`

**Metadata**

Contribution from non-expect in OP stack. Seems right to me, but could be wrong!

Info sourced from manual inspection of https://github.com/ethereum-optimism/optimism/blob/b123e13a1e4b2b216722b98141dc81d5d8ce4ed4/packages/contracts-bedrock/src/L2/L1Block.sol