### PR TITLE
feat/interop: add reverts for manipulating dependency set

### DIFF
--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -300,7 +300,10 @@ Calls to `setConfig` MUST originate from `SystemConfig` and are forwarded to `L1
 ### Dependency Set
 
 `L1Block` is updated to include the set of allowed chains. These chains are added and removed through `setConfig` calls
-with `ADD_DEPENDENCY` or `REMOVE_DEPENDENCY`, respectively.
+with `ADD_DEPENDENCY` or `REMOVE_DEPENDENCY`, respectively. The maximum size of the dependency is `type(uint256).max`, 
+and adding a chain id when the dependency set size is at its maximum MUST revert. If a chain id not in the dependency
+set is attempted to be removed, the call MUST revert. If the chain's chain id is attempted to be removed, the call also
+MUST revert.
 
 `L1Block` MUST provide a public getter to check if a particular chain is in the dependency set called
 `isInDependencySet(uint256)`. This function MUST return true when a chain id in the dependency set, or the chain's chain

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -300,7 +300,7 @@ Calls to `setConfig` MUST originate from `SystemConfig` and are forwarded to `L1
 ### Dependency Set
 
 `L1Block` is updated to include the set of allowed chains. These chains are added and removed through `setConfig` calls
-with `ADD_DEPENDENCY` or `REMOVE_DEPENDENCY`, respectively. The maximum size of the dependency set is `type(uint256).max`,
+with `ADD_DEPENDENCY` or `REMOVE_DEPENDENCY`, respectively. The maximum size of the dependency set is `type(uint8).max`,
 and adding a chain id when the dependency set size is at its maximum MUST revert. If a chain id not in the dependency
 set is attempted to be removed, the call MUST revert. If the chain's chain id is attempted to be removed, the call also
 MUST revert.

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -300,7 +300,7 @@ Calls to `setConfig` MUST originate from `SystemConfig` and are forwarded to `L1
 ### Dependency Set
 
 `L1Block` is updated to include the set of allowed chains. These chains are added and removed through `setConfig` calls
-with `ADD_DEPENDENCY` or `REMOVE_DEPENDENCY`, respectively. The maximum size of the dependency is `type(uint256).max`, 
+with `ADD_DEPENDENCY` or `REMOVE_DEPENDENCY`, respectively. The maximum size of the dependency is `type(uint256).max`,
 and adding a chain id when the dependency set size is at its maximum MUST revert. If a chain id not in the dependency
 set is attempted to be removed, the call MUST revert. If the chain's chain id is attempted to be removed, the call also
 MUST revert.

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -300,7 +300,7 @@ Calls to `setConfig` MUST originate from `SystemConfig` and are forwarded to `L1
 ### Dependency Set
 
 `L1Block` is updated to include the set of allowed chains. These chains are added and removed through `setConfig` calls
-with `ADD_DEPENDENCY` or `REMOVE_DEPENDENCY`, respectively. The maximum size of the dependency is `type(uint256).max`,
+with `ADD_DEPENDENCY` or `REMOVE_DEPENDENCY`, respectively. The maximum size of the dependency set is `type(uint256).max`,
 and adding a chain id when the dependency set size is at its maximum MUST revert. If a chain id not in the dependency
 set is attempted to be removed, the call MUST revert. If the chain's chain id is attempted to be removed, the call also
 MUST revert.


### PR DESCRIPTION
these reverts specify what happens when trying to add a chain id when the dependency set is at it's maximum, and trying to remove the current chain's chain id or a non-dependency from the dependency set.