### PR TITLE
clarify that getL1GasUsed is deprecated

### DIFF
--- a/specs/fjord/exec-engine.md
+++ b/specs/fjord/exec-engine.md
@@ -75,6 +75,6 @@ The `L1GasUsed` property on the transaction receipt is updated to take into acco
 multiplying the `estimatedSize` of the transaction from the above L1 cost formula by 16. The value of 16 assumes most
 of the bytes in the compressed data are non-zero.
 
-The `L1GasUsed` property will be deprecated due to it not accurately calculating the L1 gas used
-by a transaction. Users can continue to use the `L1Fee` field to retrieve the L1 fee for a given transaction. This field
-will be removed in a future network upgrade.
+The `L1GasUsed` property is deprecated due to it not capturing the L1 blob gas used by a transaction, and will be
+removed in a future network upgrade. Users can continue to use the `L1Fee` field to retrieve the L1 fee for a given
+transaction.

--- a/specs/fjord/predeploys.md
+++ b/specs/fjord/predeploys.md
@@ -71,7 +71,9 @@ function getL1GasUsed(bytes memory _data) public view returns (uint256) {
 }
 ```
 
-The `getL1GasUsed` method will be deprecated. This is due to it not accurately estimating the
-L1 gas used, for a transaction. In a future network upgrade this function will revert when called.
+The `getL1GasUsed` method is deprecated as of Fjord because it does not capture that there are
+two kinds of gas being consumed due to the introduction of blobs. This function will revert when
+called in a future upgrade.
 
-Users can continue to use the `getL1FeeUpperBound` or `getL1Fee` method to estimate the L1 fee for a given transaction.
+Users can continue to use the `getL1Fee` method to estimate the L1 fee for a given transaction, or the
+new `getL1FeeUpperBound` method introduced by Fjord as a lower gas alternative.


### PR DESCRIPTION
Also tweaks the language a bit to clarify a few other details.
