### PR TITLE
feat/interop: rename `GAS_PAYING_TOKEN` to `SET_GAS_PAYING_TOKEN`

### DIFF
--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -272,7 +272,7 @@ The `ConfigType` enum is defined as follows:
 
 ```solidity
 enum ConfigType {
-    GAS_PAYING_TOKEN,
+    SET_GAS_PAYING_TOKEN,
     ADD_DEPENDENCY,
     REMOVE_DEPENDENCY
 }
@@ -282,7 +282,7 @@ The second argument to `setConfig` is a `bytes` value that is ABI encoded with t
 
 | ConfigType          | Value                                       |
 |---------------------|---------------------------------------------|
-| `GAS_PAYING_TOKEN`  | `abi.encode(token, decimals, name, symbol)` |
+| `SET_GAS_PAYING_TOKEN`  | `abi.encode(token, decimals, name, symbol)` |
 | `ADD_DEPENDENCY`    | `abi.encode(chainId)`                       |
 | `REMOVE_DEPENDENCY` | `abi.encode(chainId)`                       |
 

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -280,11 +280,11 @@ enum ConfigType {
 
 The second argument to `setConfig` is a `bytes` value that is ABI encoded with the necessary values for the `ConfigType`.
 
-| ConfigType          | Value                                       |
-|---------------------|---------------------------------------------|
-| `SET_GAS_PAYING_TOKEN`  | `abi.encode(token, decimals, name, symbol)` |
-| `ADD_DEPENDENCY`    | `abi.encode(chainId)`                       |
-| `REMOVE_DEPENDENCY` | `abi.encode(chainId)`                       |
+| ConfigType             | Value                                       |
+|------------------------|---------------------------------------------|
+| `SET_GAS_PAYING_TOKEN` | `abi.encode(token, decimals, name, symbol)` |
+| `ADD_DEPENDENCY`       | `abi.encode(chainId)`                       |
+| `REMOVE_DEPENDENCY`    | `abi.encode(chainId)`                       |
 
 where
 


### PR DESCRIPTION
since `ADD_DEPENDENCY` and `REMOVE_DEPENDENCY` are prefixed by a verb, changing `GAS_PAYING_TOKEN` to `SET_GAS_PAYING_TOKEN` leads to greater consistency