### PR TITLE
feat/interop: add revert for attempting to add chain id already in dependency set

### DIFF
--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -304,9 +304,10 @@ Calls to `setConfig` MUST originate from `SystemConfig` and are forwarded to `L1
 
 `L1Block` is updated to include the set of allowed chains. These chains are added and removed through `setConfig` calls
 with `ADD_DEPENDENCY` or `REMOVE_DEPENDENCY`, respectively. The maximum size of the dependency set is `type(uint8).max`,
-and adding a chain id when the dependency set size is at its maximum MUST revert. If a chain id not in the dependency
-set is attempted to be removed, the call MUST revert. If the chain's chain id is attempted to be removed, the call also
-MUST revert.
+and adding a chain id when the dependency set size is at its maximum MUST revert. If a chain id already in the
+dependency set, such as the chain's chain id, is attempted to be added, the call MUST revert. If a chain id that is not
+in the dependency set is attempted to be removed, the call MUST revert. If the chain's chain id is attempted to be
+removed, the call also MUST revert.
 
 `L1Block` MUST provide a public getter to check if a particular chain is in the dependency set called
 `isInDependencySet(uint256)`. This function MUST return true when a chain id in the dependency set, or the chain's chain


### PR DESCRIPTION
this makes the behavior explicit for attempting to add a chain id already in the dependency set