### PR TITLE
Add CI check for building book

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,9 @@ jobs:
       - run:
           name: markdown toc
           command: just lint-specs-toc-check
+      - run:
+          name: build book
+          command: just build
   lint-links:
     machine:
       image: <<pipeline.parameters.base_image>>

--- a/Justfile
+++ b/Justfile
@@ -36,6 +36,9 @@ lint-links:
     		--exclude twitter.com --exclude explorer.optimism.io --exclude linux-mips.org --exclude vitalik.ca \
     		--exclude-mail /input/README.md "/input/specs/**/*.md"
 
+build:
+    mdbook build
+
 # Serves the mdbook locally
 serve *args='':
     mdbook serve $@

--- a/Justfile
+++ b/Justfile
@@ -6,6 +6,7 @@ default:
 
 # Install required dependencies
 deps:
+    cargo install mdbook mdbook-katex mdbook-linkcheck mdbook-mermaid
     pnpm i --frozen-lockfile
 
 # Lint the workspace for all available targets


### PR DESCRIPTION
**Description**

Add CI check for building the specs book. I'll likely close out this PR and cherry pick the commit into https://github.com/ethereum-optimism/specs/pull/209

