### PR TITLE
fix link to L2 output root

### DIFF
--- a/specs/experimental/fault-proof/stage-one/fault-dispute-game.md
+++ b/specs/experimental/fault-proof/stage-one/fault-dispute-game.md
@@ -38,7 +38,7 @@
 
 <!-- Glossary References -->
 
-[g-output-root]: ../../../glossary.md#L2-output-root
+[g-output-root]: ../../../glossary.md#l2-output-root
 
 ## Overview
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Fix l2 output link in specs. Very simple update. 


