### PR TITLE
Let CrossDomainMessenger refund the failed & non-replayable message's ETH back

### DIFF
--- a/specs/protocol/messengers.md
+++ b/specs/protocol/messengers.md
@@ -34,6 +34,7 @@ The base `CrossDomainMessenger` interface is:
 
 ```solidity
 interface CrossDomainMessenger {
+    event RefundedRelayMessage(bytes32 indexed msgHash);
     event FailedRelayedMessage(bytes32 indexed msgHash);
     event RelayedMessage(bytes32 indexed msgHash);
     event SentMessage(address indexed target, address sender, bytes message, uint256 messageNonce, uint256 gasLimit);
@@ -67,8 +68,9 @@ interface CrossDomainMessenger {
 The `sendMessage` function is used to send a cross domain message. To trigger
 the execution on the other side, the `relayMessage` function is called.
 Successful messages have their hash stored in the `successfulMessages` mapping
-while unsuccessful messages have their hash stored in the `failedMessages`
-mapping.
+while unsuccessful but replayable messages have their hash stored in the `failedMessages`
+mapping. For the unsuccessful and non-replayable messages, their whole ETH amounts are
+sent back to the sender on the source chain.
 
 The user experience when sending from L1 to L2 is a bit different than when
 sending a transaction from L2 to L1. When going into L1 from L2, the user does


### PR DESCRIPTION
### Purpose

Let `CrossDomainMessenger` send-back the failed & non-replayable message’s ETH to the sender on the source chain. 

### Description

The cross domain messengers provide a higher level API for sending cross domain messages. When it receives a message from a source contract/chain, it triggers `relayMessage` to relay the user message with the ETH being transferred.

When `CrossDomainMessenger.relayMessage` is called, the possible outcomes are:
- (1) the transaction succeeds with the successful relay with `successfulMessages[mshHash] = True`
- (2) the transaction succeeds with the unsuccessful relay with `failedMessages[msgHash] = True` so that it is replayable
- (3) the transaction reverts

The OP’s smart contract suite handles the (1) and (2) cases well. However, for (3) where the message has failed to be relayed and won’t be replayable, any ETH being delivered is stuck forever.



### An example of unsuccessful & non-replayable message

While the best practice is to prevent these unsuccessful & non-replayable messages from being issued from the origin contract and chain, there have been missed cases due to the nature of cross-chain environments where the contexts between the origin and destination chains are disconnected.

The `L2CrossDomainMessenger.sendMessage` encodes the user's message from L2 to L1 as the withdrawal by calling `L2ToL1MessagePasser.initiateWithdrawal`. Then, the message passer relays the message to the corresponding cross domain messenger deployed at the target L1.

While users are expected to send the message via the proxy contract (`0x4200…0007`), a user can send a message from L2 to L1 via the implementation contract without being reverted. Then, the relay of the message on the destination chain will revert due to the failed sanity check at `CrossDomainMessenger.relayMessage`since the`sender` is not the whitelisted system address and`msg.value` is non-zero value.

Let's look into the smart contract code where the sanity check fails in the above case. The if-else branch statement on `_isOtherMessenger()` at `CrossDomainMessenger.relayMessage`. It performs sanity checks: (1) if the `sender` is whitelisted, (2) if it is a valid call for replay. However, as mentioned above, there have been cases when (1) the `sender` is not whitelisted system address (because `sender` is the implementation contract, not the proxy) and (2) the call is not for replay. The aforementioned example falls on it and the revert leads to the ETH getting stuck.


```
function relayMessage(
    uint256 _nonce,
    address _sender,
    address _target,
    uint256 _value,
    uint256 _minGasLimit,
    bytes calldata _message
)
    external
    payable
{
  ...

  if (_isOtherMessenger()) {
      // These properties should always hold when the message is first submitted (as
      // opposed to being replayed).
      assert(msg.value == _value);
      assert(!failedMessages[versionedHash]);
  } else {
      require(msg.value == 0, "CrossDomainMessenger: value must be zero unless message is from a system address");

      require(failedMessages[versionedHash], "CrossDomainMessenger: message cannot be replayed");
  }
  
  ...
}
```

### Proposed Smart Contract Implementation

The if-else branch now considers the unsuccessful & nonreplayable message and falls back into `sendMessage` back to the sender on the source chain.

```
function relayMessage(
    uint256 _nonce,
    address _sender,
    address _target,
    uint256 _value,
    uint256 _minGasLimit,
    bytes calldata _message
)
    external
    payable
{
  ...

  if (_isOtherMessenger()) {
      // These properties should always hold when the message is first submitted (as
      // opposed to being replayed).
      assert(msg.value == _value);
      assert(!failedMessages[versionedHash]);
  } else if (failedMessages[versionedHash]) {
      require(msg.value == 0, "CrossDomainMessenger: value must be zero unless message is from a system address");
  } else {
      // If the message was not from the valid system address nor it is the failed message, just return the fund back
      // fallback to sendMessage call to refund and return shortly after
      _sendMessage(_sender, "", uint32(RELAY_RESERVED_GAS));
      emit RefundedRelayMessage(versionedHash);
      return;
  }
  
  ...
}
```

Here is the link to the PoC implementation PR https://github.com/ethereum-optimism/optimism/pull/10675
The relevant tests will be updated after further discussion!