### PR TITLE
chore: add ERC-4337 EntryPoint v0.7.0 to preinstall list

### DIFF
--- a/specs/protocol/preinstalls.md
+++ b/specs/protocol/preinstalls.md
@@ -47,8 +47,8 @@ The following table includes each of the preinstalls.
 | Permit2                                   | 0x000000000022D473030F116dDEE9F6B43aC78BA3 |
 | ERC-4337 v0.6.0 EntryPoint                | 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789 |
 | ERC-4337 v0.6.0 SenderCreator             | 0x7fc98430eaedbb6070b35b39d798725049088348 |
-| ERC-4337 v0.7.0 EntryPoint                | 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789 |
-| ERC-4337 v0.7.0 SenderCreator             | 0x7fc98430eaedbb6070b35b39d798725049088348 |
+| ERC-4337 v0.7.0 EntryPoint                | 0x0000000071727De22E5E9d8BAf0edAc6f37da032 |
+| ERC-4337 v0.7.0 SenderCreator             | 0xEFC2c1444eBCC4Db75e7613d20C6a62fF67A167C |
 
 ## Safe
 

--- a/specs/protocol/preinstalls.md
+++ b/specs/protocol/preinstalls.md
@@ -14,8 +14,10 @@
 - [Create2Deployer](#create2deployer)
 - [Arachnid's Deterministic Deployment Proxy](#arachnids-deterministic-deployment-proxy)
 - [Permit2](#permit2)
-- [ERC-4337 EntryPoint](#erc-4337-entrypoint)
-- [ERC-4337 SenderCreator](#erc-4337-sendercreator)
+- [ERC-4337 v0.6.0 EntryPoint](#erc-4337-v060-entrypoint)
+- [ERC-4337 v0.6.0 SenderCreator](#erc-4337-v060-sendercreator)
+- [ERC-4337 v0.7.0 EntryPoint](#erc-4337-v070-entrypoint)
+- [ERC-4337 v0.7.0 SenderCreator](#erc-4337-v070-sendercreator)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -43,8 +45,10 @@ The following table includes each of the preinstalls.
 | create2Deployer                           | 0x13b0D85CcB8bf860b6b79AF3029fCA081AE9beF2 |
 | Arachnid's Deterministic Deployment Proxy | 0x4e59b44847b379578588920cA78FbF26c0B4956C |
 | Permit2                                   | 0x000000000022D473030F116dDEE9F6B43aC78BA3 |
-| ERC-4337 EntryPoint                       | 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789 |
-| ERC-4337 SenderCreator                    | 0x7fc98430eaedbb6070b35b39d798725049088348 |
+| ERC-4337 v0.6.0 EntryPoint                | 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789 |
+| ERC-4337 v0.6.0 SenderCreator             | 0x7fc98430eaedbb6070b35b39d798725049088348 |
+| ERC-4337 v0.7.0 EntryPoint                | 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789 |
+| ERC-4337 v0.7.0 SenderCreator             | 0x7fc98430eaedbb6070b35b39d798725049088348 |
 
 ## Safe
 
@@ -180,20 +184,38 @@ Address: `0x000000000022D473030F116dDEE9F6B43aC78BA3`
 Permit2 introduces a low-overhead, next-generation token approval/meta-tx system to make token approvals easier,
 more secure, and more consistent across applications.
 
-## ERC-4337 EntryPoint
+## ERC-4337 v0.6.0 EntryPoint
 
 [Implementation](https://github.com/eth-infinitism/account-abstraction/blob/v0.6.0/contracts/core/EntryPoint.sol)
 
 Address: `0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789`
 
-This contract verifies and executes the bundles of ERC-4337
+This contract verifies and executes the bundles of ERC-4337 v0.6.0
 [UserOperations](https://www.erc4337.io/docs/understanding-ERC-4337/user-operation) sent to it.
 
-## ERC-4337 SenderCreator
+## ERC-4337 v0.6.0 SenderCreator
 
 [Implementation](https://github.com/eth-infinitism/account-abstraction/blob/v0.6.0/contracts/core/SenderCreator.sol)
 
 Address: `0x7fc98430eaedbb6070b35b39d798725049088348`
 
-Helper contract for [EntryPoint](#erc-4337-entrypoint), to call `userOp.initCode` from a "neutral" address,
+Helper contract for [EntryPoint](#erc-4337-v060-entrypoint) v0.6.0, to call `userOp.initCode` from a "neutral" address,
+which is explicitly not `EntryPoint` itself.
+
+## ERC-4337 v0.7.0 EntryPoint
+
+[Implementation](https://github.com/eth-infinitism/account-abstraction/blob/v0.7.0/contracts/core/EntryPoint.sol)
+
+Address: `0x0000000071727De22E5E9d8BAf0edAc6f37da032`
+
+This contract verifies and executes the bundles of ERC-4337 v0.7.0
+[UserOperations](https://www.erc4337.io/docs/understanding-ERC-4337/user-operation) sent to it.
+
+## ERC-4337 v0.7.0 SenderCreator
+
+[Implementation](https://github.com/eth-infinitism/account-abstraction/blob/v0.7.0/contracts/core/SenderCreator.sol)
+
+Address: `0xEFC2c1444eBCC4Db75e7613d20C6a62fF67A167C`
+
+Helper contract for [EntryPoint](#erc-4337-v070-entrypoint) v0.7.0, to call `userOp.initCode` from a "neutral" address,
 which is explicitly not `EntryPoint` itself.


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Add ERC-4337 EntryPoint v0.7.0 to preinstall list.

**Tests**

N/A

**Additional context**

N/A

**Metadata**

Associated PR: https://github.com/ethereum-optimism/optimism/pull/10763
