### PR TITLE
Change Plasma Mode to Alt-DA Mode

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -26,5 +26,6 @@ additional-js = ["specs/static/solidity.min.js", "specs/static/mermaid.min.js", 
 "/experimental/fault-proof/stage-one/dispute-game-interface.html" = "/fault-proof/stage-one/dispute-game-interface.html"
 "/experimental/fault-proof/stage-one/fault-dispute-game.html" = "/fault-proof/stage-one/fault-dispute-game.html"
 "/experimental/fault-proof/stage-one/honest-challenger-fdg.html" = "/fault-proof/stage-one/honest-challenger-fdg.html"
+"/experimental/plasma.html" = "/experimental/alt-da.html"
 
 [output.linkcheck]

--- a/specs/SUMMARY.md
+++ b/specs/SUMMARY.md
@@ -45,7 +45,7 @@
   - [Configurability](./protocol/configurability.md)
 - [Experimental]()
   - [Custom Gas Token](./protocol/granite/custom-gas-token.md)
-  - [Plasma](./experimental/plasma.md)
+  - [Alt-DA](./experimental/alt-da.md)
   - [Interoperability](./interop/overview.md)
     - [Dependency Set](./interop/dependency_set.md)
     - [Messaging](./interop/messaging.md)

--- a/specs/experimental/alt-da.md
+++ b/specs/experimental/alt-da.md
@@ -1,4 +1,4 @@
-# Plasma Mode
+# Alt-DA Mode
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -18,13 +18,13 @@
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-Note: Plasma Mode is a Beta feature of the MIT licensed OP Stack.
+Note: Alt-DA Mode is a Beta feature of the MIT licensed OP Stack.
 While it has received initial review from core contributors, it is still undergoing testing,
 and may have bugs or other issues.
 
 ## Overview
 
-Using [Plasma][vitalikblog] mode means switching to an offchain data availability provider.
+Using [Alt-DA][vitalikblog] mode means switching to an offchain data availability provider.
 The protocol guarantees availability with a challenge contract on L1 where users
 can challenge the availability of input data used to derive the chain.
 Challenging an input commitment means forcing providers to submit the input data on chain
@@ -197,7 +197,7 @@ we've extracted the commitment from L1 DA.
 
 Similarly to L1 based DA, for each L1 block we open a calldata source to retrieve the input commitments
 from the transactions and use each commitment with its l1 origin block number to resolve
-the input data from the storage service. To enable smooth transition between plasma and rollup mode, any L1 data
+the input data from the storage service. To enable smooth transition between alt-da and rollup mode, any L1 data
 retrieved from the batcher inbox that is not prefixed with `txDataVersion1` is forwarded downstream
 to be parsed as input frames or skipped as invalid data.
 
@@ -274,7 +274,7 @@ The input data stored on the DA storage for the given `<commitment>`.
 The status of the challenge for the given `<commitment>` at the given `<blocknumber>` on the L1
 DataAvailabilityChallenge contract.
 
-[faultproofs]: ../fault-proof/index.md
+[faultproofs]: ./fault-proof/index.md
 
 ## Safety and Finality
 
@@ -282,14 +282,14 @@ Similarly to rollup mode, the engine queue labels any new blocks derived from in
 on the L1 chain as “safe”. Although labeled as “safe”, the chain might still reorg in case of a faulty DA provider
 and users must use the “finalized” label for a guarantee that their state cannot revert.
 
-With Plasma mode on, the engine queue does receives finality signals from the L1 RPC AND
+With Alt-DA mode on, the engine queue does receives finality signals from the L1 RPC AND
 from the DA manager that keeps track of challenges.
 The DA manager maintains an internal state of all the input commitments in the current `challengeWindow`
 as they are validated by the derivation pipeline.
 
 The L2 chain can be marked as finalized when the L1 block in which commitments can no longer be invalidated
-becomes finalized. Without Plasma Mode, L2 blocks are safe when the batch is on L1. Plasma commitments are
-only "optimistically safe" when the commitment is found in a L1 block. Plasma commitments then become safe
+becomes finalized. Without Alt-DA Mode, L2 blocks are safe when the batch is on L1. Plasma commitments are
+only "optimistically safe" when the commitment is found in a L1 block. Commitments then become safe
 when that commitment can no longer be invalidated. Then finalization can proceed as normal: when the L1 block
 that an L2 block is derived from becomes finalized, the L2 block can be marked as finalized.
 

--- a/specs/experimental/alt-da.md
+++ b/specs/experimental/alt-da.md
@@ -274,7 +274,7 @@ The input data stored on the DA storage for the given `<commitment>`.
 The status of the challenge for the given `<commitment>` at the given `<blocknumber>` on the L1
 DataAvailabilityChallenge contract.
 
-[faultproofs]: ./fault-proof/index.md
+[faultproofs]: ../fault-proof/index.md
 
 ## Safety and Finality
 

--- a/specs/protocol/derivation.md
+++ b/specs/protocol/derivation.md
@@ -331,7 +331,7 @@ Batcher transactions are encoded as `version_byte ++ rollup_payload` (where `++`
 | `version_byte` | `rollup_payload`                               |
 | -------------- | ---------------------------------------------- |
 | 0              | `frame ...` (one or more frames, concatenated) |
-| 1    | `plasma_commitment` (experimental, see [alt-da](../experimental/alt-da.md#input-commitment-submission)) |
+| 1    | `da_commitment` (experimental, see [alt-da](../experimental/alt-da.md#input-commitment-submission)) |
 
 Unknown versions make the batcher transaction invalid (it must be ignored by the rollup node).
 All frames in a batcher transaction must be parseable. If any one frame fails to parse, the all frames in the

--- a/specs/protocol/derivation.md
+++ b/specs/protocol/derivation.md
@@ -331,7 +331,7 @@ Batcher transactions are encoded as `version_byte ++ rollup_payload` (where `++`
 | `version_byte` | `rollup_payload`                               |
 | -------------- | ---------------------------------------------- |
 | 0              | `frame ...` (one or more frames, concatenated) |
-| 1    | `plasma_commitment` (experimental, see [op-plasma](../experimental/plasma.md#input-commitment-submission) |
+| 1    | `plasma_commitment` (experimental, see [alt-da](../experimental/alt-da.md#input-commitment-submission)) |
 
 Unknown versions make the batcher transaction invalid (it must be ignored by the rollup node).
 All frames in a batcher transaction must be parseable. If any one frame fails to parse, the all frames in the

--- a/specs/root.md
+++ b/specs/root.md
@@ -47,7 +47,7 @@ Chat with us on the [discussion board!](https://github.com/ethereum-optimism/spe
 
 Specifications of new features in active development.
 
-- [Plasma](./experimental/plasma.md)
+- [Alt-DA](./experimental/alt-da.md)
 - [Interoperability](./interop/overview.md)
 - [Security Council Safe](./experimental/security-council-safe.md)
 


### PR DESCRIPTION
`plasma.md` was renamed `alt-da.md`, and all references to "Plasma Mode" were changed to "Alt-DA Mode"