### PR TITLE
Interop: SuperchainERC20 Standard

### DIFF
--- a/specs/interop/token-bridging.md
+++ b/specs/interop/token-bridging.md
@@ -28,7 +28,8 @@ Without a standardized security model, bridged assets may not be fungible with e
 The `SuperchainERC20` unifies ERC20 token bridging to make it fungible across the Superchain.
 It builds on top of the messaging protocol, as the most trust minimized bridging solution.
 
-Unlike other standards, such as [xERC20](https://www.xerc20.com/), where users interact with a bridge possessing mint and burn
+Unlike other standards, such as [xERC20](https://www.xerc20.com/),
+where users interact with a bridge possessing mint and burn
 privileges on cross-chain enabled tokens, this approach allows users to call methods directly on the token contract.
 
 ## Interface
@@ -52,7 +53,8 @@ sendERC20(address _to, uint256 _amount, uint256 _chainId, bytes _data)
 
 #### `relayERC20`
 
-Process incoming messages IF AND ONLY IF if they where initiated by the same contract (token) address on a different chain
+Process incoming messages IF AND ONLY IF if they where initiated
+by the same contract (token) address on a different chain
 and come from the `L2ToL2CrossChainMessenger` in the local chain.
 It will mint `_amount` to address `_to`, as defined in `sendERC20`.
 If the message contained `_data`,
@@ -137,7 +139,8 @@ function relayERC20(address _to, uint256 _amount, bytes memory _data) external {
 }
 ```
 
-Note: Some other naming options that were considered were `bridgeERC20`, `send()`, `xTransfer()`, `Transfer` (with a chainId parameter).
+Note: Some other naming options that were considered were
+`bridgeERC20`, `send()`, `xTransfer()`, `Transfer` (with a chainId parameter).
 
 ## Invariants
 
@@ -175,8 +178,10 @@ Besides the ERC20 invariants, the SuperchainERC20 will require the following int
 
 ### Factory
 
-A token factory predeploy can ensure that `SuperchainERC20` tokens can be permissionlessly and deterministically deployed.
-Without a deterministic deployment scheme, maintaining a mapping of the token addresses between all of the chains will not be scalable.
+A token factory predeploy can ensure that `SuperchainERC20`
+tokens can be permissionlessly and deterministically deployed.
+Without a deterministic deployment scheme, maintaining a mapping of the token
+addresses between all of the chains will not be scalable.
 
 ### Migration to the Standard
 
@@ -187,17 +192,21 @@ Without a deterministic deployment scheme, maintaining a mapping of the token ad
 - Tokens that are `OptimismMintableERC20Token` (corresponding to locked liquidity in L1)
   fall into the above category of already deployed and non updatable.
   They do have a special property though, which is burn/mint permissions granted to the `L2StandardBridge`.
-  This makes the convert method particularly appealing. See [Liquidity Migration](https://github.com/ethereum-optimism/design-docs/blob/098435155471ed3bcd60a50f049897495c901733/protocol/superc20/liquidity-migration.md)
-  for more context.
+  This makes the convert method particularly appealing.
 
 ## Future Considerations
 
 ### Cross Chain `transferFrom`
 
-In addition to standard locally initialized bridging, it is possible to allow contracts to be cross-chain interoperable.
-For example, a contract in chain A could send pre-approved funds from a user in chain B to a contract in chain C.
+In addition to standard locally initialized bridging,
+it is possible to allow contracts to be cross-chain interoperable.
+For example, a contract in chain A could send pre-approved funds
+from a user in chain B to a contract in chain C.
 
-For the moment, the standard will not include any specific functionality to facilitate such an action and relay on the usage of `permit2`.
-If, at some point in the future, these actions were to be included in the standard, a possible design could introduce a `remoteTransferFrom()` function.
+For the moment, the standard will not include any specific functionality
+to facilitate such an action and relay on the usage of `permit2`.
+If, at some point in the future, these actions were to be included in the standard,
+a possible design could introduce a `remoteTransferFrom()` function.
 
-Notice that this action is no longer atomic, so the contract would need a special implementation resume execution once the funds arrive in the target chain.
+Notice that this action is no longer atomic, so the contract would
+need a special implementation resume execution once the funds arrive in the target chain.

--- a/specs/interop/token-bridging.md
+++ b/specs/interop/token-bridging.md
@@ -2,42 +2,71 @@
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**
 
 - [Interface](#interface)
+- [Interface](#interface-1)
 - [Implementation](#implementation)
-- [L1 Native Tokens](#l1-native-tokens)
-- [Cross Chain `transferFrom`](#cross-chain-transferfrom)
-- [Factory](#factory)
-- [Upgrading Existing `OptimismMintableERC20Token`s](#upgrading-existing-optimismmintableerc20tokens)
+  - [Cross Chain transfers](#cross-chain-transfers)
+  - [Cross Chain `transferFrom`](#cross-chain-transferfrom)
+- [Deployment and migrations](#deployment-and-migrations)
+  - [Factory](#factory)
+  - [Migration to the Standard](#migration-to-the-standard)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-Unified ERC20 token bridging built on top of the messaging protocol
-can enable tokens to be fungible and movable across the superchain.
-An issue with bridging is that if the security model is not standardized,
-then the bridged assets are not fungible with each other depending on
-which bridge solution was used to facilitate the transfer between
-domains.
+Unified ERC20 token bridging built on the messaging protocol can make tokens fungible and movable across the superchain. An issue with bridging is that if the security model is not standardized, the bridged assets are not fungible with each other depending on which bridge solution was used to facilitate the transfer between domains.
 
 ## Interface
 
 The `ISuperchainERC20` interface creates a standard way to send tokens
-between domains. In contrast to [xERC20][xerc20] where the user calls
-a bridge that has `mint` and `burn` privileges on the cross chain enabled
+between chains in the Superchain. In contrast to [xERC20](https://www.xerc20.com/) where the user calls
+a bridge with `mint` and `burn` privileges on the cross-chain enabled
 tokens, the user instead calls methods on the token contract directly.
 
-[xerc20]: https://www.xerc20.com/
+In addition to standard bridging, these specs include functions that
+allow contracts to be cross-chain interoperable. For example, a contract in chain A
+can send pre-approved funds from a user in chain B to a contract in chain C.
 
 ```solidity
 interface ISuperchainERC20 {
-  function bridgeERC20(uint256 amount, uint256 chainId) external;
-  function bridgeERC20To(address to, uint256 amount, uint256 chainId) external;
+	// functions to bridge using interop
+  function bridgeERC20(uint256 amount, uint256 chainId) external returns (bool success);
+  function bridgeERC20To(address to, uint256 amount, uint256 chainId) external returns (bool success);
   function finalizeBridgeERC20(address to, uint256 amount) external;
+
+  // functions to handle remote transfers
+  function allowance(address _owner, address _spender, uint256 _chainId) external view returns (uint256);
+  function xApprove(address spender, uint256 chainId, uint256 amount) external returns (bool);
+  function remoteTransferFrom(
+    address owner,
+    address recipient,
+    uint256 spendChainId,
+    uint256 executeChainId,
+    uint256 amount,
+    bytes memory data
+  ) external returns (bool);
+	function relayTransferFrom(
+    address owner,
+    address spender,
+    address recipient,
+    uint256 originChainId,
+    uint256 executionChainId,
+    uint256 amount,
+    bytes memory data
+  ) external;
+  function relayAndExecute(
+    address owner,
+    address recipient,
+    address spender,
+    uint256 originChainId,
+    uint256 spenderChainId,
+    uint256 amount,
+    bytes memory _data
+  ) external;
 }
 ```
 
-## Implementation
+## Interface
 
 An example implementation that depends on deterministic deployments across chains
 for security is provided. This construction builds on top of the [L2ToL2CrossDomainMessenger][l2-to-l2]
@@ -72,26 +101,200 @@ contract OptimismSuperchainERC20 is ERC20, ISuperchainERC20 {
 }
 ```
 
-## L1 Native Tokens
+[Disclaimer]
 
-To support L1 native tokens with cross chain liquidity, the `OptimismMintableERC20Token`
-interface MUST be supported in addition to the `SuperchainERC20` interface.
+- Threat the following code as experimental. It will have errors and will change function names. The goal is to discuss functionalities.
+- Current function names are open to discussion.
 
-## Cross Chain `transferFrom`
+## Implementation
 
-Should an overloaded `approve` method be added to the interface so that a user can
-approve a contract on a remote domain to bridge on their behalf? A new `allowances`
-mapping could be added to the contract to enable this.
+### Cross Chain transfers
 
-## Factory
+The standard will include the following three external functions:
 
-A token factory predeploy can be used to ensure that `SuperchainERC20` tokens
-can be permissionlessly and deterministically deployed. If a deterministic deployment
-scheme is not used, maintaining a mapping of the token addresses between all of the
-chains will not be scalable.
+- `bridgeERC20(uint256 amount, uint256 chainId)`
+- `bridgeERC20To(address to, uint256 amount, uint256 chainId)`
+- `finalizeBridgeERC20(address to, uint256 amount)`
 
-## Upgrading Existing `OptimismMintableERC20Token`s
+The first two functions will burn `amount` tokens and initialize a message to the `L2ToL2CrossChainMessenger` to mint the `amount` in the destination (`to` address in `chainId`).
 
-An `OptimismMintableERC20Token` does not natively have the functionality
-to be sent between L2s. There are a few approaches to migrating L1 native tokens
-to L2 ERC20 tokens that support the `SuperchainERC20` interface.
+`finalizeBridgeERC20(address to, uint256 amount)` will process incoming messages from the `L2ToL2CrossChainMessenger` initiated from the same token on a different `chainId` and mint `amount` to the `to` address.
+
+A possible implementation would look like this:
+
+```solidity
+function bridgeERC20(uint256 _amount, uint256 _chainId) external returns (bool success) {
+    success = bridgeERC20To(msg.sender, _amount, _chainId);
+  }
+
+function bridgeERC20To(address _to, uint256 _amount, uint256 _chainId) public returns (bool) {
+  _burn(msg.sender, _amount);
+  bytes memory _message = abi.encodeCall(this.finalizeBridgeERC20, (_to, _amount));
+  _sendMessage(_chainId, _message);
+  return true;
+}
+
+function finalizeBridgeERC20(address _to, uint256 _amount) external onlyMessenger {
+  _mint(_to, _amount);
+}
+
+/////// Internals and modifiers ///////////
+function _sendMessage(uint256 _destination, bytes memory _data) internal virtual {
+  L2ToL2CrossDomainMessenger.sendMessage(_destination, address(this), _data);
+}
+
+modifier onlyMessenger() virtual {
+  require(msg.sender == address(L2ToL2CrossChainMessenger));
+  require(L2ToL2CrossChainMessenger.crossDomainMessageSender() == address(this));
+  _;
+}
+```
+
+Note: `send()` or `xTransfer()` can also be good fits instead of `bridgeERC20()`.
+
+### Cross Chain `transferFrom`
+
+The standard will not include a remotely initialized `transfer` implementation as we think this should be handled directly on the chain where the funds live with the `bridgeERC20()` function. `transferFrom`, on the other hand, might get initialized from a call to a contract that is localized in a different chain from the funds. To be composable, the standard will introduce a `remoteTransferFrom()` function.
+
+Notice that this action is no longer atomic, so the contract will need a special implementation to use it and resume execution once the funds arrive in the chain.
+
+**Approvals**
+
+To enable `remoteTransferFrom()`, we must include a separate `xAllowance` mapping that keeps track of the `chainId`. This allowance should be set locally using a new `xApprove()` function (the naming is open for discussion).
+
+Here is what a possible implementation could look like:
+
+```solidity
+function xApprove(address _spender, uint256 _chainId, uint256 _amount) external returns (bool) {
+  // TODO [research] _chainId wildcard as type(uint256).max (this is very risky)
+  _xAllowances[msg.sender][_spender][_chainId] = _amount;
+  emit XApproval(msg.sender, _spender, _chainId, _amount);
+  return true;
+}
+// this will override the ERC20 view function
+function allowance(address _owner, address _spender) external view returns (uint256) {
+  return allowance(_owner, _spender, block.chainid);
+}
+
+function allowance(address _owner, address _spender, uint256 _chainId) external view returns (uint256) {
+  if (_chainId == block.chainId) return _allowance[_owner][_spender];
+  return _xAllowance[_owner][_spender][_chainId];
+}
+```
+
+It is possible for the standard to also have remote approvals. This feature, however, was discarded as an address might have different owners in different chains (think of smart wallets for instance). Moreover, even if this was not an issue, switching `chainId` is not that relevant UX-wise to include a dedicated function in the token standard.
+
+**`remoteTransferFrom()`**
+
+As already mentioned, the `remoteTransferFrom()` \*\*\*\*will allow using funds on a remote chain on behalf of another party. The function should initiate a call to the `L2ToL2CrossChainMessenger` without burning anything on the origin chain.
+
+To process a `remoteTransferFrom()` on the destination, the standard should include a `relayTransferFrom()` function that checks local allowance and calls `burn()`. Then, it will check if the target lives on the same `chainId` to call `relayAndExecute()` to the corresponding contract.
+
+Finally, the standard should included a `relayAndExecute()` function that might be used to resume execution on the origin chain. This is how the atomicity lost in the `transferFrom()` gets addressed.
+
+A possible implementation for these functionalities would look like this:
+
+```solidity
+function remoteTransferFrom(
+  address _owner,
+  address _recipient,
+  uint256 _spendChainId,
+  uint256 _executeChainId,
+  uint256 _amount,
+  bytes memory _data
+) external returns (bool) {
+  bytes memory _message =
+    abi.encodeCall(this.relayTransferFrom, (_owner, msg.sender, _recipient, block.chainid, _executionChainId, _amount, _data));
+  _sendMessage(_spendChainId, _message);
+  return true;
+}
+
+function relayTransferFrom(
+  address _owner,
+  address _spender,
+  address _recipient,
+  uint256 _originChainId,
+  uint256 _executionChainId,
+  uint256 _amount,
+  bytes memory _data
+) external onlyMessenger {
+  uint256 allowed = _xAllowances[_owner][_spender][_originChainId];
+
+  if (allowed != type(uint256).max) {
+    _xAllowances[_owner][_spender][_originChainId] = allowed - _amount;
+  }
+
+  _burn(_owner, _amount);
+
+  if (block.chain == _executionChainId){
+    _relayAndExecute(_owner, _recipient, _spender, _originChainId, block.chainid, _amount, _data);
+  } else {
+    bytes memory _message =
+    abi.encodeCall(this.relayAndExecute, (_owner, _recipient, _spender, _originChainId, block.chainid, _amount, _data));
+    _sendMessage(_executionChainId, _message);
+  }
+
+  emit RelayTransferFrom(_owner, _spender, _recipient, _originChainId, _executeChainId, _amount, _data);
+}
+
+function relayAndExecute(
+  address _owner,
+  address _spender,
+  address _recipient,
+  uint256 _originChainId,
+  uint256 _spenderChainId,
+  uint256 _amount,
+  bytes memory _data
+) external onlyMessenger {
+  _relayAndExecute(_owner, _spender, _recipient, _originChainId, _spenderChainId, _amount, _data);
+}
+
+function _relayAndExecute(
+  address _owner,
+  address _spender,
+  address _recipient,
+  uint256 _originChainId,
+  uint256 _spenderChainId,
+  uint256 _amount,
+  bytes memory _data
+) internal {
+  _mint(_recipient, _amount);
+  if (_data.length > 0) {
+    IxCallback(_spender).xCallback(_owner, _recipient, _spender, _originChainId, _spenderChainId, _amount, _data);
+  }
+  emit RelayAndExecute(_owner, _spender, _recipient, _originChainId, _spenderChainId, _amount, _data);
+}
+
+/////// Internals and modifiers ///////////
+function _sendMessage(uint256 _destination, bytes memory _data) internal virtual {
+  L2ToL2CrossDomainMessenger.sendMessage(_destination, address(this), _data);
+}
+modifier onlyMessenger() virtual {
+  require(msg.sender == address(L2ToL2CrossChainMessenger));
+  require(L2ToL2CrossChainMessenger.crossDomainMessageSender() == address(this));
+  _;
+}
+```
+
+You can check a full example implementation in the following gist.
+
+https://gist.github.com/0xParticle/7ac85c7f32fa3364473f28fb9f6ebace
+
+[TODO] We will add invariants.
+
+## Deployment and migrations
+
+### Factory
+
+A token factory predeploy can ensure that `SuperchainERC20` tokens can be permissionlessly and deterministically deployed. Without a deterministic deployment scheme, maintaining a mapping of the token addresses between all of the chains will not be scalable.
+
+[TODO] We will create a design doc that covers `SuperchainERC20` factories and link it in this specs.
+
+### Migration to the Standard
+
+- New tokens should implement the `SuperchainERC20` standard from inception.
+- Tokens that are already deployed but upgradable, can update the implementation to be `SuperchainERC20` compatible.
+- Tokens that are already deployed but are not upgradable should use methods such as Mirror (see https://github.com/ethereum-optimism/design-docs/pull/36).
+  - An `OptimismMintableERC20Token` does not natively have the functionality
+    to be sent between L2s. There are a few approaches to migrating L1 native tokens to L2 ERC20 tokens that support the `SuperchainERC20` interface that were covered in https://github.com/ethereum-optimism/design-docs/pull/35. The Mirror Standard is the preferred candidate now.
+    To support L1 native tokens with cross chain liquidity, the Mirror Standard (or chosen solution) interface MUST be supported in addition to the `ISuperchainERC20` interface.

--- a/specs/interop/token-bridging.md
+++ b/specs/interop/token-bridging.md
@@ -24,17 +24,74 @@ Unlike other standards, such as [xERC20](https://www.xerc20.com/), where users i
 
 ## Implementation
 
-The standard will build on top of ERC20 and include the following five external functions:
+### Functions
 
-- `sendERC20(uint256 amount, uint256 chainId)(bool)`
-- `sendERC20(address to, uint256 amount, uint256 chainId)(bool)`
-- `sendERC20(address to, uint256 amount, uint256 chainId, bytes data)(bool)`
-- `finalizeSendERC20(address to, uint256 amount)`
-- `finalizeSendERC20(address to, uint256 amount, bytes data)`
+The standard will build on top of ERC20 and include the following functions:
 
-`sendERC20(uint256 amount, uint256 chainId)` and `sendERC20To(address to, uint256 amount, uint256 chainId)` will burn `amount` tokens and initialize a message to the `L2ToL2CrossChainMessenger` to mint the `amount` in the target address at `chainId`. `sendERC20(address to, uint256 amount, uint256 chainId, bytes data)` will do the same, but also include a message.
+#### `sendERC20`
 
-`finalizeSendERC20(address to, uint256 amount)` will process incoming messages from the `L2ToL2CrossChainMessenger` initiated from the same token on a different `chainId` and mint `amount` to the `to` address. `finalizeSendERC20(address to, uint256 amount, bytes data)` will do the same, but include an external call to address `to` with `data`.
+Transfer `_amount` amount of tokens to address `_to` in chain `_chainId`, alongside with optional data `_data`.
+
+It SHOULD burn `_amount` tokens and initialize a message to the `L2ToL2CrossChainMessenger` to mint the `_amount` in the target address `_to` at `_chainId`. The optional `_data` will be included in as part of the `L2ToL2CrossChainMessenger` message.
+
+```solidity
+sendERC20(address _to, uint256 _amount, uint256 _chainId, bytes _data)
+```
+
+#### `relayERC20`
+
+Process incoming messages IF AND ONLY IF if they where initiated by the same contract (token) address on a different chain and come from the `L2ToL2CrossChainMessenger` in the local chain.
+It will mint `_amount` to address `_to`, as defined in `sendERC20`. If the message contained `_data`, it will also include an external call to address `_to` with `_data`.
+
+```solidity
+relayERC20(address _to, uint256 _amount, bytes _data)
+```
+
+### Events
+
+#### `SendERC20`
+
+MUST trigger when a cross-chain transfer is initiated using `sendERC20`.
+
+```solidity
+event SendERC20(address indexed _from, address indexed _to, uint256 _amount, uint256 _chainId, bytes memory _data)
+```
+
+### `RelayERC20`
+
+MUST trigger when a cross-chain transfer is finalized using `relayERC20`.
+
+```solidity
+event RelayERC20(address indexed to, uint256 amount, bytes data);
+```
+
+## Diagram
+
+The following diagram depicts a cross-chain transfer.
+
+```mermaid
+sequenceDiagram
+  participant from
+  participant SuperERC20_A as SuperchainERC20 (Chain A)
+  participant Messenger_A as L2ToL2CrossDomainMessenger (Chain A)
+  participant Inbox as CrossL2Inbox
+  participant Messenger_B as L2ToL2CrossDomainMessenger (Chain B)
+  participant SuperERC20_B as SuperchainERC20 (Chain B)
+  participant Recipient as to
+
+  from->>SuperERC20_A: sendERC20To(to, amount, chainID, data)
+  SuperERC20_A->>SuperERC20_A: burn(from, amount)
+  SuperERC20_A->>Messenger_A: sendMessage(chainId, message)
+  note right of Messenger_A: relay or user calls
+  Messenger_A->>Inbox: executeMessage()
+  Inbox->>Messenger_B: relayMessage()
+  Messenger_B->>SuperERC20_B: relayERC20(to, amount, data)
+  SuperERC20_B->>SuperERC20_B: mint(to, amount)
+  note right of SuperERC20_B: Optional
+  SuperERC20_B->>Recipient: call(data)
+```
+
+## Implementation
 
 An example implementation that depends on deterministic deployments across chains
 for security is provided. This construction builds on top of the [L2ToL2CrossDomainMessenger][l2-to-l2]
@@ -42,46 +99,25 @@ for both replay protection and domain binding.
 
 [l2-to-l2]: ./predeploys.md#l2tol2crossdomainmessenger
 
-[TODO] should we add a sendERC20To specific event?
-
 ```solidity
-function sendERC20(uint256 _amount, uint256 _chainId) external returns (bool) {
-  return sendERC20(msg.sender, _amount, _chainId);
-}
-
-function sendERC20(address _to, uint256 _amount, uint256 _chainId) public returns (bool success) {
+function sendERC20(address _to, uint256 _amount, uint256 _chainId, bytes memory _data) public {
   _burn(msg.sender, _amount);
-  bytes memory _message = abi.encodeWithSignature("finalizeSendERC20(address,uint256)", _to, _amount);
-  _sendMessage(_chainId, _message);
-  return true
+  bytes memory _message = abi.encodeCall(this.relayERC20, (_to, _amount, _data));
+  L2ToL2CrossDomainMessenger.sendMessage(_chainId, address(this), _message);
+  emit SendERC20(msg.sender, _to, _amount, _chainId, _data);
 }
 
-function sendERC20(address _to, uint256 _amount, uint256 _chainId, bytes memory _data) public returns (bool success) {
-  _burn(msg.sender, _amount);
-  bytes memory _message = abi.encodeWithSignature("finalizeSendERC20(address,uint256,bytes)", _to, _amount, _data);
-  _sendMessage(_chainId, _message);
-  return true
-}
-
-function finalizeSendERC20(address _to, uint256 _amount) external {
-  // this will be a modifier, inline here for clarity
-  require(msg.sender == address(L2ToL2CrossChainMessenger));
-  require(L2ToL2CrossChainMessenger.crossDomainMessageSender() == address(this));
-  //
-  _mint(_to, _amount);
-}
-
-function finalizeSendERC20(address _to, uint256 _amount, bytes memory _data) external {
+function relayERC20(address _to, uint256 _amount, bytes memory _data) external {
   require(msg.sender == address(L2ToL2CrossChainMessenger));
   require(L2ToL2CrossChainMessenger.crossDomainMessageSender() == address(this));
   _mint(_to, _amount);
-  (bool success, ) = _to.call(_data);
-  require(success, "External call failed");
-}
 
-/////// Internal functions ///////////
-function _sendMessage(uint256 _destination, bytes memory _data) internal virtual {
-  L2ToL2CrossDomainMessenger.sendMessage(_destination, address(this), _data);
+  if (data.length > 0) {
+    (bool success, ) = _to.call(_data);
+    require(success, "External call failed");
+  }
+
+  emit RelayERC20(_to, _amount, _data)
 }
 ```
 
@@ -91,30 +127,21 @@ Note: Some other naming options that were considered were `bridgeERC20`, `send()
 
 Besides the ERC20 invariants, the SuperchainERC20 will require the following interop specific properties:
 
-- Conservation of finalized `totalSupply`: The minted `amount` in `finalizeSendERC20()` should match the `amount` that was burnt in `sendERC20()`, as long as target chain has the initiating chain in the dependency set.
-  - Corollary 1: Cross-chain transactions will conserve the sum of `totalSupply` for each chain in the Superchain across safe blocks.
-  - Corollary 2: Each initiated but not finalized message (included in initiating chain but not yet in target chain) will decrease the `totalSupply` exactly by the burnt `amount`.
-  - Corollary 2: `SuperchainERC20s` should not charge a token fee or increase the balance when moving cross-chain.
-  - Question: what should we assume for chains not in the dependency set? a rollback method could modify this invariant to also consider that case.
+- Conservation of bridged `amount`: The minted `amount` in `relayERC20()` should match the `amount` that was burnt in `sendERC20()`, as long as target chain has the initiating chain in the dependency set.
+  - Corollary 1: Finalized cross-chain transactions will conserve the sum of `totalSupply` and each user's balance for each chain in the Superchain.
+  - Corollary 2: Each initiated but not finalized message (included in initiating chain but not yet in target chain) will decrease the `totalSupply` and the initiating user balance exactly by the burnt `amount`.
+  - Corollary 3: `SuperchainERC20s` should not charge a token fee or increase the balance when moving cross-chain.
+  - Note: if the target chain is not in the initiating chain dependency set, funds will be locked similarly to sending funds to a wrong address. If the target chain decides to later include it, these could be unlocked eventually.
 - Freedom of movement: Users should be able to send tokens into any target chain that has initiating chain in its dependency set.
-  - Question: should we add "deployed" to the invariant or assume its not going to be an issue?
-- [To discuss] Unique Messenger: The `sendERC20()` functions must exclusively use the `L2toL2CrossDomainMessenger` for messaging. Similarly, the `finalizeSendERC20()` function should only process messages originating from the L2toL2CrossDomainMessenger.
+- Unique Messenger: The `sendERC20()` function must exclusively use the `L2toL2CrossDomainMessenger` for messaging. Similarly, the `relayERC20()` function should only process messages originating from the L2toL2CrossDomainMessenger.
   - Corollary: xERC20 and other standards from third party bridges should use different functions.
-- [To discuss] Locally initiated: The bridging action should be initialized from the chain where funds are located only.
+- Locally initiated: The bridging action should be initialized from the chain where funds are located only.
   - This is because same address might correspond to different users cross-chain. For example, two SAFEs with the same address in two chains might have different owners. It it possible to distiguish an EOA from a contract by checking the size of the code in the caller's address, but this will probably change with [EIP-7702](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7702.md).
   - A way to allow for remotely initiated bridging is to include remote approval, i.e. approve a certain address in a certain chainId to spend local funds.
-- [To discuss] Bridge Event: `sendERC20()` should emit a `Bridged` event.
-  - We already have a lot of events triggering from these actions. Should we include yet another one?
-
-**Desired properties**
-
-- Spatial symmetry: Same implementation and address across chains.
-
-**Open questions**
-
-- Should we define invariants for upgrades?
-- Does native minting introduce any invariant?
-  - If every factory is "equal", how do you choose which one creates the initial supply?
+- Bridge Events:
+  - `sendERC20()` should emit a `SendERC20` event. `
+  - `relayERC20()` should emit a `RelayERC20` event.
+- Same address: The SuperchainERC20 token should have the same address across chains in the Superchain.
 
 ## Deployment and migrations
 
@@ -138,162 +165,6 @@ A token factory predeploy can ensure that `SuperchainERC20` tokens can be permis
 
 In addition to standard locally initialized bridging, it is possible to allow contracts to be cross-chain interoperable. For example, a contract in chain A could send pre-approved funds from a user in chain B to a contract in chain C.
 
-The standard should not include a remotely initialized `transfer` implementation as this should be handled directly on the chain where the funds live with the `sendERC20()` function. `transferFrom`, on the other hand, might get initialized from a call to a contract that is localized in a different chain from the funds.
-
 For the moment, the standard will not include any specific functionality to facilitate such an action and relay on the usage of `permit2`. If, at some point in the future, these actions were to be included in the standard, a possible design could introduce a `remoteTransferFrom()` function.
 
 Notice that this action is no longer atomic, so the contract would need a special implementation resume execution once the funds arrive in the target chain.
-
-It would be necessary to add the following function to the interface
-
-```solidity
-function allowance(address _owner, address _spender, uint256 _chainId) external view returns (uint256);
-function xApprove(address spender, uint256 chainId, uint256 amount) external returns (bool);
-function remoteTransferFrom(
-  address owner,
-  address recipient,
-  uint256 spendChainId,
-  uint256 executeChainId,
-  uint256 amount,
-  bytes memory data
-) external returns (bool);
-function relayTransferFrom(
-  address owner,
-  address spender,
-  address recipient,
-  uint256 originChainId,
-  uint256 executionChainId,
-  uint256 amount,
-  bytes memory data
-) external;
-function relayAndExecute(
-  address owner,
-  address recipient,
-  address spender,
-  uint256 originChainId,
-  uint256 spenderChainId,
-  uint256 amount,
-  bytes memory _data
-) external;
-```
-
-#### Approvals
-
-To enable `remoteTransferFrom()`, it's necessary to include a separate `xAllowance` mapping that keeps track of the `chainId`. This allowance should be set locally using a new `xApprove()` function (the naming is open for discussion).
-
-Here is what a possible implementation could look like:
-
-```solidity
-function xApprove(address _spender, uint256 _chainId, uint256 _amount) external returns (bool) {
-  _xAllowances[msg.sender][_spender][_chainId] = _amount;
-  emit XApproval(msg.sender, _spender, _chainId, _amount);
-  return true;
-}
-// this will override the ERC20 view function
-function allowance(address _owner, address _spender) external view returns (uint256) {
-  return allowance(_owner, _spender, block.chainid);
-}
-
-function allowance(address _owner, address _spender, uint256 _chainId) external view returns (uint256) {
-  if (_chainId == block.chainId) return _allowance[_owner][_spender];
-  return _xAllowance[_owner][_spender][_chainId];
-}
-```
-
-It is technically possible for the standard to also have remote approvals (initialize in chain A and approval for funds in chain B). This feature, however, was discarded as an address might have different owners in different chains (think of smart wallets for instance). Moreover, even if this was not an issue, switching `chainId` is not that relevant UX-wise to include a dedicated function in the token standard.
-
-#### `remoteTransferFrom()`
-
-As already mentioned, the `remoteTransferFrom()` will allow using funds on a remote chain on behalf of another party. The function should initiate a call to the `L2ToL2CrossChainMessenger` without burning anything on the origin chain.
-
-To process a `remoteTransferFrom()` on the destination, the standard should include a `relayTransferFrom()` function that checks local allowance and calls `burn()`. Then, it will check if the target lives on the same `chainId` to call `relayAndExecute()` to the corresponding contract.
-
-Finally, the standard should included a `relayAndExecute()` function that might be used to resume execution on the origin chain. This is how the atomicity lost in the `transferFrom()` gets addressed.
-
-A possible implementation for these functionalities would look like this:
-
-```solidity
-function remoteTransferFrom(
-  address _owner,
-  address _recipient,
-  uint256 _spendChainId,
-  uint256 _executeChainId,
-  uint256 _amount,
-  bytes memory _data
-) external returns (bool) {
-  bytes memory _message =
-    abi.encodeCall(this.relayTransferFrom, (_owner, msg.sender, _recipient, block.chainid, _executionChainId, _amount, _data));
-  _sendMessage(_spendChainId, _message);
-  return true;
-}
-
-function relayTransferFrom(
-  address _owner,
-  address _spender,
-  address _recipient,
-  uint256 _originChainId,
-  uint256 _executionChainId,
-  uint256 _amount,
-  bytes memory _data
-) external onlyMessenger {
-  uint256 allowed = _xAllowances[_owner][_spender][_originChainId];
-
-  if (allowed != type(uint256).max) {
-    _xAllowances[_owner][_spender][_originChainId] = allowed - _amount;
-  }
-
-  _burn(_owner, _amount);
-
-  if (block.chainid == _executionChainId) {
-    _relayAndExecute(_owner, _recipient, _spender, _originChainId, block.chainid, _amount, _data);
-  } else {
-    bytes memory _message =
-    abi.encodeCall(this.relayAndExecute, (_owner, _recipient, _spender, _originChainId, block.chainid, _amount, _data));
-    _sendMessage(_executionChainId, _message);
-  }
-
-  emit RelayTransferFrom(_owner, _spender, _recipient, _originChainId, _executeChainId, _amount, _data);
-}
-
-function relayAndExecute(
-  address _owner,
-  address _spender,
-  address _recipient,
-  uint256 _originChainId,
-  uint256 _spenderChainId,
-  uint256 _amount,
-  bytes memory _data
-) external onlyMessenger {
-  _relayAndExecute(_owner, _spender, _recipient, _originChainId, _spenderChainId, _amount, _data);
-}
-
-function _relayAndExecute(
-  address _owner,
-  address _spender,
-  address _recipient,
-  uint256 _originChainId,
-  uint256 _spenderChainId,
-  uint256 _amount,
-  bytes memory _data
-) internal {
-  _mint(_recipient, _amount);
-  if (_data.length > 0) {
-    IxCallback(_spender).xCallback(_owner, _recipient, _spender, _originChainId, _spenderChainId, _amount, _data);
-  }
-  emit RelayAndExecute(_owner, _spender, _recipient, _originChainId, _spenderChainId, _amount, _data);
-}
-
-/////// Internals and modifiers ///////////
-function _sendMessage(uint256 _destination, bytes memory _data) internal virtual {
-  L2ToL2CrossDomainMessenger.sendMessage(_destination, address(this), _data);
-}
-modifier onlyMessenger() virtual {
-  require(msg.sender == address(L2ToL2CrossChainMessenger));
-  require(L2ToL2CrossChainMessenger.crossDomainMessageSender() == address(this));
-  _;
-}
-```
-
-You can check a full example implementation in the following gist.
-
-https://gist.github.com/0xParticle/7ac85c7f32fa3364473f28fb9f6ebace

--- a/specs/interop/token-bridging.md
+++ b/specs/interop/token-bridging.md
@@ -5,14 +5,20 @@
 
 - [Overview](#overview)
 - [Implementation](#implementation)
+  - [Functions](#functions)
+    - [`sendERC20`](#senderc20)
+    - [`relayERC20`](#relayerc20)
+  - [Events](#events)
+    - [`SendERC20`](#senderc20)
+  - [`RelayERC20`](#relayerc20)
+- [Diagram](#diagram)
+- [Implementation](#implementation-1)
 - [Invariants](#invariants)
 - [Deployment and migrations](#deployment-and-migrations)
   - [Factory](#factory)
   - [Migration to the Standard](#migration-to-the-standard)
 - [Future Considerations](#future-considerations)
   - [Cross Chain `transferFrom`](#cross-chain-transferfrom)
-    - [Approvals](#approvals)
-    - [`remoteTransferFrom()`](#remotetransferfrom)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 


### PR DESCRIPTION
**Description**
The `SuperchainERC20` standard allows to interact with ERC20s across the Superchain.

This is a follow-up PR to https://github.com/ethereum-optimism/specs/pull/71.

We would love to
- Hear your feedback on the design decisions. 
- Discuss function and variable naming.

We will include invariants and create a design docs to discuss Factories for `SuperchainERC20`s soon.

