### PR TITLE
Fix SWS typo in glossary.md

### DIFF
--- a/specs/glossary.md
+++ b/specs/glossary.md
@@ -233,7 +233,7 @@ A sequencing window is a range of L1 blocks from which a [sequencing epoch][sequ
 A sequencing window whose first L1 block has number `N` contains [batcher transactions][batcher-transaction] for epoch
 `N`. The window contains blocks `[N, N + SWS)` where `SWS` is the sequencer window size.
 
-The current default `sws` is 3600 epochs.
+The current default `sws` is 3600 blocks.
 
 Additionally, the first block in the window defines the [depositing transactions][depositing-tx] which determine the
 [deposits] to be included in the first L2 block of the epoch.


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Glossary was stating that the default Sequencer Window Size was measured in "epochs" instead of blocks

**Tests**

N/A

**Additional context**

N/A

**Metadata**

N/A
