### PR TITLE
fix: typo

### DIFF
--- a/specs/interop/messaging.md
+++ b/specs/interop/messaging.md
@@ -89,7 +89,7 @@ exact state of the block templates between multiple chains together.
 [log]: https://github.com/ethereum/go-ethereum/blob/5c67066a050e3924e1c663317fd8051bc8d34f43/core/types/log.go#L29
 
 Each [Log][log] (also known as `event` in solidity) forms an initiating message.
-The raw log data froms the [Message Payload](#message-payload).
+The raw log data forms the [Message Payload](#message-payload).
 
 Messages are *broadcast*: the protocol does not enshrine address-targeting within messages.
 


### PR DESCRIPTION
**Description**

Update 'froms' typo to 'forms' on messaging section.