### PR TITLE
update: root page add topic links for custom-gas-token

### DIFF
--- a/specs/root.md
+++ b/specs/root.md
@@ -47,6 +47,7 @@ Chat with us on the [discussion board!](https://github.com/ethereum-optimism/spe
 
 Specifications of new features in active development.
 
+- [Custom Gas Token](./experimental/custom-gas-token.md)
 - [Alt-DA](./experimental/alt-da.md)
 - [Interoperability](./interop/overview.md)
 - [Security Council Safe](./experimental/security-council-safe.md)


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

update: root page add topic links for custom-gas-token

**Tests**

cc.https://specs.optimism.io/root.html#experimental check
![image](https://github.com/user-attachments/assets/363a6377-ddef-45de-9f9b-aaeb803cfc47)

**Additional context**

Please check again.


**Metadata**

- Fixes #[Link to Issue] - _none_
