### PR TITLE
Fix fee vault anchor links

### DIFF
--- a/specs/protocol/exec-engine.md
+++ b/specs/protocol/exec-engine.md
@@ -86,9 +86,9 @@ The proxies are backed by vault contract deployments, based on `FeeVault`, to ro
 
 | Vault Name          | Predeploy                                              |
 | ------------------- | ------------------------------------------------------ |
-| Sequencer Fee Vault | [`SequencerFeeVault`](predeploys.md#sequencerFeeVault) |
-| Base Fee Vault      | [`BaseFeeVault`](predeploys.md#baseFeeVault)           |
-| L1 Fee Vault        | [`L1FeeVault`](predeploys.md#l1FeeVault)               |
+| Sequencer Fee Vault | [`SequencerFeeVault`](predeploys.md#sequencerfeevault) |
+| Base Fee Vault      | [`BaseFeeVault`](predeploys.md#basefeevault)           |
+| L1 Fee Vault        | [`L1FeeVault`](predeploys.md#l1feevault)               |
 
 ### Priority fees (Sequencer Fee Vault)
 

--- a/specs/protocol/exec-engine.md
+++ b/specs/protocol/exec-engine.md
@@ -86,9 +86,9 @@ The proxies are backed by vault contract deployments, based on `FeeVault`, to ro
 
 | Vault Name          | Predeploy                                              |
 | ------------------- | ------------------------------------------------------ |
-| Sequencer Fee Vault | [`SequencerFeeVault`](predeploys.md#SequencerFeeVault) |
-| Base Fee Vault      | [`BaseFeeVault`](predeploys.md#BaseFeeVault)           |
-| L1 Fee Vault        | [`L1FeeVault`](predeploys.md#L1FeeVault)               |
+| Sequencer Fee Vault | [`SequencerFeeVault`](predeploys.md#sequencerFeeVault) |
+| Base Fee Vault      | [`BaseFeeVault`](predeploys.md#baseFeeVault)           |
+| L1 Fee Vault        | [`L1FeeVault`](predeploys.md#l1FeeVault)               |
 
 ### Priority fees (Sequencer Fee Vault)
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

The fee vault anchor links had capital letters, which did not deep link properly. The anchors are alllower case letters, made the fix.

Example:
- Old (doesn't scroll): https://specs.optimism.io/protocol/predeploys.html#SequencerFeeVault
- New (scrolls): https://specs.optimism.io/protocol/predeploys.html#sequencerfeevault

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
