### PR TITLE
upgrade naming: Igneous -> Isthmus

### DIFF
--- a/specs/protocol/isthmus/overview.md
+++ b/specs/protocol/isthmus/overview.md
@@ -1,4 +1,4 @@
-# Igneous Network Upgrade
+# Isthmus Network Upgrade
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->


### PR DESCRIPTION
**Description**

The Granite/Holocene plans are out, which puts Interop tentatively at the "I" upgrade name.
Now we could just pick "Interop" as name, and regardless of upgrade name we probably will in many contexts.
But to stick to the nature/land theme, I propose we rename the upgrade to "Isthmus".

> An isthmus is a narrow piece of land connecting two larger areas across an expanse of water by which they are otherwise separated. 

Or in other words: we are building a land bridge.

A solid bridge between two lands, at the protocol layer, improving on existing bridges, which you could think of as less reliable shipping routes turning into land-supported highways.
