### PR TITLE
Added details about the ERC20 Withdrawal Back to Domain function?

### DIFF
--- a/specs/experimental/custom-gas-token.md
+++ b/specs/experimental/custom-gas-token.md
@@ -335,6 +335,7 @@ meaning that "sending to the other domain" indicates it can be used for both dep
 | Native Asset Deposit | `OptimismPortal.depositTransaction(address,uint256,uint64,bool,bytes) payable` | None |
 | ERC20 Send to Other Domain | `L1StandardBridge.bridgeERC20(address,address,uint256,uint32,bytes)` | Approve `L1StandardBridge` for ERC20 |
 | Native Asset Withdrawal | `L2ToL1MessagePasser.initiateWithdrawal(address,uint256,bytes) payable` | None |
+| ERC20 Withdrawal Back to Domain | `L2StandardBridge.withdraw(address,uint256,uint32,bytes)` | Approve `L2StandardBridge` for ERC20 |
 
 There are multiple APIs for users to deposit or withdraw `ether`. Depending on the usecase, different APIs should be
 preferred. For a simple send of just `ether` with no calldata, the `OptimismPortal` or `L2ToL1MessagePasser` should
@@ -348,6 +349,7 @@ should be used. Using the `StandardBridge` is the most expensive and has no real
 | Native Asset Deposit | `OptimismPortal.depositERC20Transaction(address,uint256,uint256,uint64,bool,bytes)` | Approve `OptimismPortal` for ERC20 |
 | ERC20 Send to Other Domain | `L1StandardBridge.bridgeERC20(address,address,uint256,uint32,bytes)` | Approve `L1StandardBridge` for ERC20 |
 | Native Asset Withdrawal | `L2ToL1MessagePasser.initiateWithdrawal(address,uint256,bytes) payable` | None |
+| ERC20 Withdrawal Back to Domain | `L2StandardBridge.bridgeERC20(address,address,uint256,uint32,bytes)` | Approve `L2StandardBridge` for ERC20 |
 
 Users should deposit native asset by calling `depositERC20Transaction` on the `OptimismPortal` contract.
 Users must first `approve` the address of the `OptimismPortal` so that the `OptimismPortal` can use


### PR DESCRIPTION
**Description**

Added details about the `ERC20 Withdrawal Back to Domain` function? Please consider this.
cc. https://specs.optimism.io/experimental/custom-gas-token.html#user-flow

- For When ETH is the Native Asset
should call the function `L2StandardBridge`.**withdraw**`(address,uint256,uint32,bytes)`
cc. https://github.com/ethereum-optimism/optimism/blob/op-contracts/v2.0.0-beta.2/packages/contracts-bedrock/src/L2/L2StandardBridge.sol#L93-L106

- For When an ERC20 Token is the Native Asset
should call the function `L2StandardBridge`.**bridgeERC20**`(address,address,uint256,uint32,bytes)`
cc. https://github.com/ethereum-optimism/optimism/blob/op-contracts/v2.0.0-beta.2/packages/contracts-bedrock/src/L2/L2StandardBridge.sol#L86-L88

**_Please consider this._**


