### PR TITLE
chore: fix chain ID type

### DIFF
--- a/specs/experimental/op-stack-manager.md
+++ b/specs/experimental/op-stack-manager.md
@@ -75,7 +75,7 @@ struct Roles {
 }
 
 function deploy(
-  uint64 l2ChainId,
+  uint256 l2ChainId,
   Roles roles,
   uint32 basefeeScalar,
   uint32 blobBasefeeScalar


### PR DESCRIPTION
This was intended to be a uint256