### PR TITLE
chore: update OP Stack Manager deploy sig

### DIFF
--- a/specs/experimental/op-stack-manager.md
+++ b/specs/experimental/op-stack-manager.md
@@ -76,9 +76,9 @@ struct Roles {
 
 function deploy(
   uint256 l2ChainId,
-  Roles roles,
   uint32 basefeeScalar,
-  uint32 blobBasefeeScalar
+  uint32 blobBasefeeScalar,
+  Roles roles
 ) external returns (SystemConfig)
 ```
 


### PR DESCRIPTION
Rearranges deploy sig paramers per the discussion in https://github.com/ethereum-optimism/optimism/pull/11274#discussion_r1696862554

Even though `Roles` must live in memory or calldata, I've intentionally avoided specifying one here because that is a solidity implementation detail that does not affect the function signature and therefore does not need to be part of the spec