### PR TITLE
Refactor the Security Council Safe specs into Admin and Auth model specs

### DIFF
--- a/specs/experimental/admin-and-auth.md
+++ b/specs/experimental/admin-and-auth.md
@@ -86,7 +86,9 @@ extensions.
 
 ## Ownership model diagram
 
-The following diagram outlines the control relationships between the contracts in the
+The following diagram outlines the control relationships between the contracts in the system.
+
+
 
 ```mermaid
 flowchart LR

--- a/specs/experimental/admin-and-auth.md
+++ b/specs/experimental/admin-and-auth.md
@@ -129,9 +129,7 @@ flowchart LR
 
    %% Declare a class to make the outer boxes somewhat transparent to provide some contrast
    classDef outer fill:#ffffff44
-   class SuperchainSystem outer
-   class GuardianSystem outer
-   class UpgradeSystem outer
+   class SuperchainSystem,GuardianSystem,UpgradeSystem outer
 ```
 
 The remainder of this document outlines each safe, including its key configuration parameters, and

--- a/specs/experimental/admin-and-auth.md
+++ b/specs/experimental/admin-and-auth.md
@@ -1,9 +1,13 @@
-# Safe contract configuration
+# Superchain Administration and Authorization Model
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**
 
+- [Overview](#overview)
+- [List of Safes](#list-of-safes)
+- [Ownership model diagram](#ownership-model-diagram)
+- [Guardian Safe](#guardian-safe)
 - [Deputy guardian module](#deputy-guardian-module)
   - [Deputy Guardian Module Security Properties](#deputy-guardian-module-security-properties)
 - [Liveness checking mechanism](#liveness-checking-mechanism)
@@ -27,9 +31,13 @@
 
 ## Overview
 
-Administrative actions in the Superchain are managed by a system of multisignature Safe contracts,
- as well as custom extensions to those Safe contracts which provide additional functionality. This
-document describes the system of Safe's and their purposes.
+Authorization of administrative actions in the Superchain are managed by a system of multisignature
+ Safe contracts, as well as custom extensions to those Safe contracts which provide additional
+functionality. This document describes the system of Safe's and their purposes.
+
+## List of Safes
+
+This list outlines the various Safes, including thresholds, ownership and extensions.
 
 1. **The ProxyAdminOwner Safe:** The name of this Safe is slightly misleading. While it does control
    the `ProxyAdmin` contract, can therefore upgrade contracts in the system, more generally it is
@@ -71,6 +79,8 @@ document describes the system of Safe's and their purposes.
    This Safe has a threshold of 5 and has the same 7 owners as the Foundation Upgrade Safe.
 
 ## Ownership model diagram
+
+The following diagram outlines the control relationships between the contracts in the
 
 ```mermaid
 flowchart LR

--- a/specs/experimental/admin-and-auth.md
+++ b/specs/experimental/admin-and-auth.md
@@ -7,7 +7,6 @@
 - [Overview](#overview)
 - [List of Safes](#list-of-safes)
 - [Ownership model diagram](#ownership-model-diagram)
-- [Guardian Safe](#guardian-safe)
 - [Deputy guardian module](#deputy-guardian-module)
   - [Deputy Guardian Module Security Properties](#deputy-guardian-module-security-properties)
 - [Liveness checking mechanism](#liveness-checking-mechanism)

--- a/specs/experimental/admin-and-auth.md
+++ b/specs/experimental/admin-and-auth.md
@@ -138,13 +138,6 @@ Note: in the diagram above, the [`ProtocolVersions`
    Protocol", because the decision to follow the version signals in the contract is optional. It is
    included here for completeness, but is not considered as either Safety or Liveness affecting.
 
-## Guardian Safe
-
-The Security Council (at
-[eth:0xc2819DC788505Aac350142A7A707BF9D03E3Bd03](https://etherscan.io/address/0xc2819DC788505Aac350142A7A707BF9D03E3Bd03))
-uses a specially extended Safe multisig contract to provide additional security guarantees on top of
-those provided by the Safe contract.
-
 ## Deputy guardian module
 
 The Security Council acts as the Guardian, which is authorized to activate the [Superchain

--- a/specs/experimental/admin-and-auth.md
+++ b/specs/experimental/admin-and-auth.md
@@ -39,50 +39,43 @@ functionality. This document describes the system of Safe's and their purposes.
 This list outlines the various Safes, including mainnet addresses, thresholds, ownership, and any
 extensions.
 
-1. **[The ProxyAdminOwner
-   Safe](https://etherscan.io/address/0x5a0Aae59D09fccBdDb6C6CcEB07B7279367C3d2A):** The name of
-    this Safe is slightly misleading. While it does control the `ProxyAdmin` contract, can therefore
-   upgrade contracts in the system, more generally it is in charge of _safety_, meaning it should
-   control any action which has an impact on the determination of a valid L2 state, or the custody
-   of bridged assets. This includes but is not limited to upgrading L1 contracts, and modifying the
-   implementation of the dispute game.
-
    This safe has a threshold of 2, and is owned by two other Safes:
       1. The Security Council Safe.
       2. The Foundation Upgrade Safe.
+1. **The ProxyAdminOwner Safe:** The name of this Safe is slightly misleading. While it does control
+   the `ProxyAdmin` contract, and can therefore upgrade contracts in the system, more generally it
+   is in charge of _safety_, meaning it should control any action which has an impact on the
+   determination of a valid L2 state, or the custody of bridged assets. This includes but is not
+   limited to upgrading L1 contracts, and modifying the implementation of the dispute game.
 
-1. **[The Guardian Safe](https://etherscan.io/address/0x09f7150D8c019BeF34450d6920f6B3608ceFdAf2):**
-   This Safe is in charge of _liveness_, meaning it should control any action which may cause a
-   delay in the finalization of L2 states, or in the settlement on L1 resulting from those states on
-   L1. This includes but is not limited to pausing all code paths related to withdrawals. It is also
-   extended with the `DeputyGuardianModule` which is detailed below.
+   Accordingly, this Safe is authorized to call the following safety-critical functions:
+      - All `ProxyAdmin` `onlyOwner` functions.
+      - All `DisputeGameFactory` `onlyOwner` functions.
 
    This Safe has a threshold of 1 and is owned by the Security Council Safe.
 
-1. **[The Security Council
-   Safe](https://etherscan.io/address/0xc2819DC788505Aac350142A7A707BF9D03E3Bd03):** This Safe is
-   one of the two owners of the ProxyAdminOwner Safe. It is extended with the Liveness Checking
-   system which is detailed below.
+1. **The Guardian Safe:** This Safe is in charge of _liveness_, meaning it should control any action
+   which may cause a delay in the finalization of L2 states, or in the settlement on L1 resulting
+   from those states on L1. This includes but is not limited to pausing all code paths related to
+   withdrawals. It is also extended with the `DeputyGuardianModule` which is detailed below.
 
-   This Safe currently has a threshold of 10 and 13 owners. Anytime owners are added or removed, the
-   threshold should also be modified to ensure it is the lowest value which is greater than 75% of
-   the number of owners. This is intended to meet Stage 1 requirements.
+   Accordingly, this Safe is authorized to call the following liveness-critical functions:
+      - All `SuperchainConfig` `onlyOwner` functions.
+      - All `OptimismPortal2` `onlyOwner` functions.
 
-1. **[The Foundation Upgrade
-   Safe](https://etherscan.io/address/0x847B5c174615B1B7fDF770882256e2D3E95b9D92):** This Safe is
-   one of the two owners of the ProxyAdminOwner Safe. It is also able to update the recommended and
-   required versions on the `ProtocolVersions` contract, given that observing the state of this
-   contract is optional, this is not considered to be affect safety and can therefore be managed the
-   Foundation Safe.
+   This Safe has a threshold of 1 and is owned by the Security Council Safe.
 
-   This Safe has a threshold of 5 and has 7 owners.
+1. **The Security Council Safe:** This Safe is one of the two owners of the ProxyAdminOwner Safe. It
+   is extended with the Liveness Checking system which is detailed below.
 
-1. **[The Foundation Operations
-   Safe](https://etherscan.io/address/0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A):** This Safe acts
-   as the Deputy Guardian, meaning that (via the Guardian Safes's `DeputyGuardianModule`) can call
-   any functions in the system which impact liveness.
+1. **The Foundation Upgrade Safe:** This Safe is one of the two owners of the ProxyAdminOwner Safe.
+   It is also able to update the recommended and required versions on the `ProtocolVersions`
+   contract, given that observing the state of this contract is optional, this is not considered to
+   be affect safety and can therefore be managed the Foundation Safe.
 
-   This Safe has a threshold of 5 and has the same 7 owners as the Foundation Upgrade Safe.
+1. **The Foundation Operations Safe:** This Safe acts as the Deputy Guardian, meaning that (via the
+   Guardian Safes's `DeputyGuardianModule`) can call any functions in the system which impact
+   liveness.
 
 ## Ownership model diagram
 

--- a/specs/experimental/admin-and-auth.md
+++ b/specs/experimental/admin-and-auth.md
@@ -37,9 +37,10 @@ functionality. This document describes the system of Safe's and their purposes.
 
 ## List of Safes
 
-This list outlines the various Safes, including thresholds, ownership and extensions.
+This list outlines the various Safes, including mainnet addresses, thresholds, ownership, and any
+extensions.
 
-1. **The ProxyAdminOwner Safe:** The name of this Safe is slightly misleading. While it does control
+1. **[The ProxyAdminOwner Safe](https://etherscan.io/address/0x5a0Aae59D09fccBdDb6C6CcEB07B7279367C3d2A):** The name of this Safe is slightly misleading. While it does control
    the `ProxyAdmin` contract, can therefore upgrade contracts in the system, more generally it is
     in charge of _safety_, meaning it should control any
    action which has an impact on the determination of a valid L2 state, or the custody of bridged
@@ -50,7 +51,7 @@ This list outlines the various Safes, including thresholds, ownership and extens
       1. The Security Council Safe.
       2. The Foundation Upgrade Safe.
 
-1. **The Guardian Safe:** This Safe is in charge of _liveness_, meaning it should control any action
+1. **[The Guardian Safe](https://etherscan.io/address/0x09f7150D8c019BeF34450d6920f6B3608ceFdAf2):** This Safe is in charge of _liveness_, meaning it should control any action
    which may cause a delay in the finalization of L2 states, or in the settlement on L1 resulting
    from those states on L1. This includes but is not limited to pausing all code paths related to
    withdrawals. It is also extended with the `DeputyGuardianModule` which is detailed below.
@@ -58,21 +59,21 @@ This list outlines the various Safes, including thresholds, ownership and extens
    This Safe has a threshold of 1 and is owned by the Security Council Safe.
 
 
-1. **The Security Council Safe:** This Safe is one of the two owners of the ProxyAdminOwner Safe. It
+1. **[The Security Council Safe](https://etherscan.io/address/0xc2819DC788505Aac350142A7A707BF9D03E3Bd03):** This Safe is one of the two owners of the ProxyAdminOwner Safe. It
    is extended with the Liveness Checking system which is detailed below.
 
    This Safe currently has a threshold of 10 and 13 owners. Anytime owners are added or removed, the
    threshold should also be modified to ensure it is the lowest value which is greater than 75% of
    the number of owners. This is intended to meet Stage 1 requirements.
 
-1. **The Foundation Upgrade Safe:** This Safe is one of the two owners of the ProxyAdminOwner Safe.
+1. **[The Foundation Upgrade Safe](https://etherscan.io/address/0x847B5c174615B1B7fDF770882256e2D3E95b9D92):** This Safe is one of the two owners of the ProxyAdminOwner Safe.
    It is also able to update the recommended and required versions on the `ProtocolVersions` contract,
    given that observing the state of this contract is optional, this is not considered to be
    affect safety and can therefore be managed the Foundation Safe.
 
    This Safe has a threshold of 5 and has 7 owners.
 
-1. **The Foundation Operations Safe:** This Safe acts as the Deputy Guardian, meaning that (via the
+1. **[The Foundation Operations Safe](https://etherscan.io/address/0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A):** This Safe acts as the Deputy Guardian, meaning that (via the
    Guardian Safes's `DeputyGuardianModule`) can call any functions in the system which impact
    liveness.
 

--- a/specs/experimental/admin-and-auth.md
+++ b/specs/experimental/admin-and-auth.md
@@ -39,42 +39,48 @@ functionality. This document describes the system of Safe's and their purposes.
 This list outlines the various Safes, including mainnet addresses, thresholds, ownership, and any
 extensions.
 
-1. **[The ProxyAdminOwner Safe](https://etherscan.io/address/0x5a0Aae59D09fccBdDb6C6CcEB07B7279367C3d2A):** The name of this Safe is slightly misleading. While it does control
-   the `ProxyAdmin` contract, can therefore upgrade contracts in the system, more generally it is
-    in charge of _safety_, meaning it should control any
-   action which has an impact on the determination of a valid L2 state, or the custody of bridged
-   assets. This includes but is not limited to upgrading L1 contracts, and modifying the
+1. **[The ProxyAdminOwner
+   Safe](https://etherscan.io/address/0x5a0Aae59D09fccBdDb6C6CcEB07B7279367C3d2A):** The name of
+    this Safe is slightly misleading. While it does control the `ProxyAdmin` contract, can therefore
+   upgrade contracts in the system, more generally it is in charge of _safety_, meaning it should
+   control any action which has an impact on the determination of a valid L2 state, or the custody
+   of bridged assets. This includes but is not limited to upgrading L1 contracts, and modifying the
    implementation of the dispute game.
 
    This safe has a threshold of 2, and is owned by two other Safes:
       1. The Security Council Safe.
       2. The Foundation Upgrade Safe.
 
-1. **[The Guardian Safe](https://etherscan.io/address/0x09f7150D8c019BeF34450d6920f6B3608ceFdAf2):** This Safe is in charge of _liveness_, meaning it should control any action
-   which may cause a delay in the finalization of L2 states, or in the settlement on L1 resulting
-   from those states on L1. This includes but is not limited to pausing all code paths related to
-   withdrawals. It is also extended with the `DeputyGuardianModule` which is detailed below.
+1. **[The Guardian Safe](https://etherscan.io/address/0x09f7150D8c019BeF34450d6920f6B3608ceFdAf2):**
+   This Safe is in charge of _liveness_, meaning it should control any action which may cause a
+   delay in the finalization of L2 states, or in the settlement on L1 resulting from those states on
+   L1. This includes but is not limited to pausing all code paths related to withdrawals. It is also
+   extended with the `DeputyGuardianModule` which is detailed below.
 
    This Safe has a threshold of 1 and is owned by the Security Council Safe.
 
-
-1. **[The Security Council Safe](https://etherscan.io/address/0xc2819DC788505Aac350142A7A707BF9D03E3Bd03):** This Safe is one of the two owners of the ProxyAdminOwner Safe. It
-   is extended with the Liveness Checking system which is detailed below.
+1. **[The Security Council
+   Safe](https://etherscan.io/address/0xc2819DC788505Aac350142A7A707BF9D03E3Bd03):** This Safe is
+   one of the two owners of the ProxyAdminOwner Safe. It is extended with the Liveness Checking
+   system which is detailed below.
 
    This Safe currently has a threshold of 10 and 13 owners. Anytime owners are added or removed, the
    threshold should also be modified to ensure it is the lowest value which is greater than 75% of
    the number of owners. This is intended to meet Stage 1 requirements.
 
-1. **[The Foundation Upgrade Safe](https://etherscan.io/address/0x847B5c174615B1B7fDF770882256e2D3E95b9D92):** This Safe is one of the two owners of the ProxyAdminOwner Safe.
-   It is also able to update the recommended and required versions on the `ProtocolVersions` contract,
-   given that observing the state of this contract is optional, this is not considered to be
-   affect safety and can therefore be managed the Foundation Safe.
+1. **[The Foundation Upgrade
+   Safe](https://etherscan.io/address/0x847B5c174615B1B7fDF770882256e2D3E95b9D92):** This Safe is
+   one of the two owners of the ProxyAdminOwner Safe. It is also able to update the recommended and
+   required versions on the `ProtocolVersions` contract, given that observing the state of this
+   contract is optional, this is not considered to be affect safety and can therefore be managed the
+   Foundation Safe.
 
    This Safe has a threshold of 5 and has 7 owners.
 
-1. **[The Foundation Operations Safe](https://etherscan.io/address/0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A):** This Safe acts as the Deputy Guardian, meaning that (via the
-   Guardian Safes's `DeputyGuardianModule`) can call any functions in the system which impact
-   liveness.
+1. **[The Foundation Operations
+   Safe](https://etherscan.io/address/0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A):** This Safe acts
+   as the Deputy Guardian, meaning that (via the Guardian Safes's `DeputyGuardianModule`) can call
+   any functions in the system which impact liveness.
 
    This Safe has a threshold of 5 and has the same 7 owners as the Foundation Upgrade Safe.
 
@@ -141,12 +147,12 @@ Note: in the diagram above, the [`ProtocolVersions`
 
 The Security Council acts as the Guardian, which is authorized to activate the [Superchain
 Pause](../protocol/superchain-configuration.md#pausability) functionality and for
-[blacklisting](../fault-proof/stage-one/bond-incentives.md#authenticated-roles) dispute
-game contracts.
+[blacklisting](../fault-proof/stage-one/bond-incentives.md#authenticated-roles) dispute game
+contracts.
 
 However the Security Council cannot be expected to react quickly in an emergency situation.
-Therefore the Deputy Guardian module enables the Security Council to share this
-authorization with another account.
+Therefore the Deputy Guardian module enables the Security Council to share this authorization with
+another account.
 
 The module has the following minimal interface:
 
@@ -184,8 +190,9 @@ interface DeputyGuardianModule {
 }
 ```
 
-For simplicity, the `DeputyGuardianModule` module does not have functions for updating the `safe` and
-`deputyGuardian` addresses. If necessary these can be modified by swapping out with a new module.
+For simplicity, the `DeputyGuardianModule` module does not have functions for updating the `safe`
+and `deputyGuardian` addresses. If necessary these can be modified by swapping out with a new
+module.
 
 ### Deputy Guardian Module Security Properties
 
@@ -238,26 +245,28 @@ Owners are recorded in this mapping in one of 4 ways:
    are ignored.
 1. An owner may call the contract's `showLiveness()` method directly in order to prove liveness.
 
-Note that the first two methods do not require the owner to actually sign anything. However these mechanisms
-are necessary to prevent new owners from being removed before they have had a chance to show liveness.
+Note that the first two methods do not require the owner to actually sign anything. However these
+mechanisms are necessary to prevent new owners from being removed before they have had a chance to
+show liveness.
 
 ### The liveness module
 
 A `LivenessModule` is also created which does the following:
 
-1. Has a function `removeOwners()` that anyone may call to specify one or more owners to be removed from the
-   Safe.
-1. The Module would then check the `LivenessGuard.lastLive()` to determine if the signer is
-   eligible for removal.
+1. Has a function `removeOwners()` that anyone may call to specify one or more owners to be removed
+   from the Safe.
+1. The Module would then check the `LivenessGuard.lastLive()` to determine if the signer is eligible
+   for removal.
 1. If so, it will call the Safe's `removeSigner()` to remove the non-live signer, and if necessary
    reduce the threshold.
 1. When a member is removed, the signing parameters are modified such that `M/N` is the lowest ratio
-   which remains greater than or equal to 75%. Using integer math, this can be expressed as `M = (N * 75 + 99) / 100`.
+   which remains greater than or equal to 75%. Using integer math, this can be expressed as
+   `M = (N * 75 + 99) / 100`.
 
 ### Owner removal call flow
 
-The following diagram illustrates the flow for removing a single owner. The `verifyFinalState`
-box indicates calls to the Safe which ensure the final state is valid.
+The following diagram illustrates the flow for removing a single owner. The `verifyFinalState` box
+indicates calls to the Safe which ensure the final state is valid.
 
 ```mermaid
 sequenceDiagram
@@ -280,8 +289,8 @@ sequenceDiagram
 ### Shutdown
 
 In the unlikely event that the signer set (`N`) is reduced below the allowed minimum number of
-owners, then (and only then) is a shutdown mechanism activated which removes the existing
-signers, and hands control of the multisig over to a predetermined entity.
+owners, then (and only then) is a shutdown mechanism activated which removes the existing signers,
+and hands control of the multisig over to a predetermined entity.
 
 ### Liveness Security Properties
 
@@ -316,8 +325,8 @@ live'.
 
 ### Interdependency between the guard and module
 
-The guard has no dependency on the module, and can be used independently to track liveness of
-Safe owners.
+The guard has no dependency on the module, and can be used independently to track liveness of Safe
+owners.
 
 This means that the module can be removed or replaced without any affect on the guard.
 
@@ -339,7 +348,8 @@ therefore be done prior to adding a new owner.
 The module and guard are intended to be deployed and installed on the safe in the following
 sequence:
 
-1. Deploy the guard contract. The guard's constructor will read the Safe's owners and set a timestamp.
+1. Deploy the guard contract. The guard's constructor will read the Safe's owners and set a
+   timestamp.
 1. Deploy the module.
 1. Set the guard on the safe.
 1. Enable the module on the safe.

--- a/specs/experimental/admin-and-auth.md
+++ b/specs/experimental/admin-and-auth.md
@@ -132,8 +132,10 @@ flowchart LR
    class SuperchainSystem,GuardianSystem,UpgradeSystem outer
 ```
 
-The remainder of this document outlines each safe, including its key configuration parameters, and
-where applicable details the specific extensions (Safe Modules and Guards) employed on them.
+Note: in the diagram above, the [`ProtocolVersions`
+   contract](../protocol/superchain-upgrades.md#protocolversions-l1-contract) is listed as "Out of
+   Protocol", because the decision to follow the version signals in the contract is optional. It is
+   included here for completeness, but is not considered as either Safety or Liveness affecting.
 
 ## Guardian Safe
 

--- a/specs/experimental/admin-and-auth.md
+++ b/specs/experimental/admin-and-auth.md
@@ -39,9 +39,6 @@ functionality. This document describes the system of Safe's and their purposes.
 This list outlines the various Safes, including mainnet addresses, thresholds, ownership, and any
 extensions.
 
-   This safe has a threshold of 2, and is owned by two other Safes:
-      1. The Security Council Safe.
-      2. The Foundation Upgrade Safe.
 1. **The ProxyAdminOwner Safe:** The name of this Safe is slightly misleading. While it does control
    the `ProxyAdmin` contract, and can therefore upgrade contracts in the system, more generally it
    is in charge of _safety_, meaning it should control any action which has an impact on the
@@ -52,7 +49,9 @@ extensions.
       - All `ProxyAdmin` `onlyOwner` functions.
       - All `DisputeGameFactory` `onlyOwner` functions.
 
-   This Safe has a threshold of 1 and is owned by the Security Council Safe.
+   This safe has a threshold of 2, and is owned by two other Safes:
+      1. The Security Council Safe.
+      2. The Foundation Upgrade Safe.
 
 1. **The Guardian Safe:** This Safe is in charge of _liveness_, meaning it should control any action
    which may cause a delay in the finalization of L2 states, or in the settlement on L1 resulting
@@ -81,8 +80,6 @@ extensions.
 
 The following diagram outlines the control relationships between the contracts in the system.
 
-
-
 ```mermaid
 flowchart LR
    subgraph SuperchainSystem[Superchain System]
@@ -99,7 +96,6 @@ flowchart LR
          PV[ProtocolVersions]
       end
    end
-
 
    subgraph UpgradeSystem[Upgrade System]
       FndUp[Foundation Upgrade Safe]

--- a/specs/experimental/security-council-safe.md
+++ b/specs/experimental/security-council-safe.md
@@ -197,13 +197,15 @@ The following security properties must be upheld:
 #### In the module
 
 1. During a shutdown the module correctly removes all signers, and converts the safe to a 1 of 1.
+1. After a shutdown, the module's removeOwner function is no longer callable.
 1. The module only removes an owner if they have not demonstrated liveness during the interval, or
    if enough other owners have been removed to activate the shutdown mechanism.
 1. The module correctly sets the Safe's threshold upon removing a signer.
 
-Note: neither the module nor guard attempt to prevent a quorum of owners from removing either the liveness
-module or guard. There are legitimate reasons they might wish to do so. Moreover, if such a quorum
-of owners exists, there is no benefit to removing them, as they are defacto 'sufficiently live'.
+Note: neither the module nor guard attempt to prevent a quorum of owners from removing either the
+liveness module or guard. There are legitimate reasons they might wish to do so. Moreover, if such a
+quorum of owners exists, there is no benefit to removing them, as they are defacto 'sufficiently
+live'.
 
 ### Interdependency between the guard and module
 

--- a/specs/experimental/security-council-safe.md
+++ b/specs/experimental/security-council-safe.md
@@ -25,9 +25,11 @@
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-Highly sensitive actions are managed by a system of multisignature Safe contracts, as well as custom
-extensions to those Safe contracts which provide additional functionality. This document describes
-the system of Safe's and their purposes.
+## Overview
+
+Administrative actions in the Superchain are managed by a system of multisignature Safe contracts,
+ as well as custom extensions to those Safe contracts which provide additional functionality. This
+document describes the system of Safe's and their purposes.
 
 1. **The ProxyAdminOwner Safe:** The name of this Safe is slightly misleading. While it does control
    the `ProxyAdmin` contract, can therefore upgrade contracts in the system, more generally it is
@@ -43,26 +45,27 @@ the system of Safe's and their purposes.
 1. **The Guardian Safe:** This Safe is in charge of _liveness_, meaning it should control any action
    which may cause a delay in the finalization of L2 states, or in the settlement on L1 resulting
    from those states on L1. This includes but is not limited to pausing all code paths related to
-   withdrawals.
-
-   This safe is extended with the `DeputyGuardianModule` which is detailed below.
+   withdrawals. It is also extended with the `DeputyGuardianModule` which is detailed below.
 
    This Safe has a threshold of 1 and is owned by the Security Council Safe.
+
 
 1. **The Security Council Safe:** This Safe is one of the two owners of the ProxyAdminOwner Safe. It
    is extended with the Liveness Checking system which is detailed below.
 
-   This Safe has a threshold of 10, and currently has 13 owners.
+   This Safe currently has a threshold of 10 and 13 owners. Anytime owners are added or removed, the
+   threshold should also be modified to ensure it is the lowest value which is greater than 75% of
+   the number of owners. This is intended to meet Stage 1 requirements.
 
 1. **The Foundation Upgrade Safe:** This Safe is one of the two owners of the ProxyAdminOwner Safe.
    It is also able to update the recommended and required versions on the `ProtocolVersions` contract,
    given that observing the state of this contract is optional, this is not considered to be
    affect safety and can therefore be managed the Foundation Safe.
 
-   This Safe has a threshold of 5 and currently has 7 owners.
+   This Safe has a threshold of 5 and has 7 owners.
 
-1. **The Foundation Operations Safe:** This Safe acts as the Deputy Guardian, meaning that it should
-   be able, via the `DeputyGuardianModule` to call any functions in the system which impact
+1. **The Foundation Operations Safe:** This Safe acts as the Deputy Guardian, meaning that (via the
+   Guardian Safes's `DeputyGuardianModule`) can call any functions in the system which impact
    liveness.
 
    This Safe has a threshold of 5 and has the same 7 owners as the Foundation Upgrade Safe.

--- a/specs/experimental/security-council-safe.md
+++ b/specs/experimental/security-council-safe.md
@@ -74,29 +74,40 @@ document describes the system of Safe's and their purposes.
 
 ```mermaid
 flowchart LR
-    subgraph System
-        Safety[Upgrades\nDispute Game\nFinality]
-        Liveness[Pausability \n+ Other \nLiveness controls]
-        PV[ProtocolVersions]
-    end
+   subgraph SuperchainSystem[Superchain System]
+      subgraph Liveness
+         Pausability
+         OtherLiveness[Other Liveness controls]
+      end
+      subgraph Safety
+         ContractUpgrades
+         DisputeGame
+         OtherSafety[Other Safety]
+      end
+      subgraph NonProtocol[Out of Protocol]
+         PV[ProtocolVersions]
+      end
+   end
 
-    subgraph Upgrade System
-	    FndUp[Foundation Upgrade Safe]
 
-	    POA[ProxyAdminOwner Safe]
-	    subgraph Security Council Safe
-        Council[Security Council Safe\n+ LivenessGuard]
-        LM[Liveness Module]
-	    end
-	  end
+   subgraph UpgradeSystem[Upgrade System]
+      FndUp[Foundation Upgrade Safe]
+      POA[ProxyAdminOwner Safe]
+      subgraph Security Council Safe
+         Council[Security Council Safe\n+ LivenessGuard]
+         LM[Liveness Module]
+      end
+   end
 
-    subgraph Guardian System
-        FndOps[Foundation Ops Safe]
-        GS[Guardian Safe]
-        DGM[Deputy Guardian Module]
-    end
+   subgraph GuardianSystem[Guardian System]
+      FndOps[Foundation Ops Safe]
+      subgraph GuardianSafe[Guardian Safe]
+         GS[Guardian Safe]
+         DGM[Deputy Guardian Module]
+      end
+   end
 
-    POA -->|controls| Safety[Contract Upgrades\nDispute Game\nSafety and Finality Controls]
+    POA -->|controls| Safety
     FndUp --> POA
     Council --> POA
     Council --> GS
@@ -105,6 +116,12 @@ flowchart LR
     LM -->|execTransactionFromModule| Council
     DGM -->|execTransactionFromModule| GS
     GS -->|controls| Liveness
+
+   %% Declare a class to make the outer boxes somewhat transparent to provide some contrast
+   classDef outer fill:#ffffff44
+   class SuperchainSystem outer
+   class GuardianSystem outer
+   class UpgradeSystem outer
 ```
 
 The remainder of this document outlines each safe, including its key configuration parameters, and

--- a/specs/experimental/security-council-safe.md
+++ b/specs/experimental/security-council-safe.md
@@ -129,7 +129,7 @@ Owners are recorded in this mapping in one of 4 ways:
 1. When a transaction is executed, the signatures on that transaction are passed to the guard and
    used to identify the signers. If more than the required number of signatures is provided, they
    are ignored.
-1. An owner may call the contract's `showLiveness()()` method directly in order to prove liveness.
+1. An owner may call the contract's `showLiveness()` method directly in order to prove liveness.
 
 Note that the first two methods do not require the owner to actually sign anything. However these mechanisms
 are necessary to prevent new owners from being removed before they have had a chance to show liveness.


### PR DESCRIPTION
Renames and updates  the former Security Council Safe spec to a more comprehensive Superchain Administration and Authorization Model. 

This includes detailed descriptions of the various safes, their purposes, their thresholds, and ownership models.

Further PRs will be stacked on this one to keep the diff as readable as possible.

