### PR TITLE
feat: update `OptimismMintableERC20Factory` to use CREATE3

### DIFF
--- a/specs/protocol/predeploys.md
+++ b/specs/protocol/predeploys.md
@@ -298,7 +298,9 @@ and implement the interface required by the `StandardBridge` to just work with d
 Each `OptimismMintableERC20` contract that is created by the `OptimismMintableERC20Factory` allows for the `L2StandardBridge` to mint
 and burn tokens, depending on if the user is depositing from L1 to L2 or withdrawing from L2 to L1.
 
-The factory will deploy using `CREATE3`, where the salt will depend on the user inputs: `remoteToken`, `name`, `symbol`, and `decimals`. The use of `CREATE3` over `CREATE2` removes any dependence on the compiler.
+The factory will deploy using `CREATE3`, where the salt will depend on the user inputs:
+`remoteToken`, `name`, `symbol`, and `decimals`.
+The use of `CREATE3` over `CREATE2` removes any dependence on the compiler.
 
 ```solidity
 bytes memory _creationCode = abi.encodePacked(
@@ -310,8 +312,8 @@ bytes32 salt = keccak256(abi.encode(_remoteToken, _name, _symbol, _decimals));
 _optimismMintableERC20 = CREATE3.deploy(salt, _creationCode);
 ```
 
-The `OptimismMintableERC20Factory` will include a `deployments` mapping to store the `remoteToken` address for each deployed `OptimsimMintableERC20`. 
-
+The `OptimismMintableERC20Factory` will include a `deployments` mapping
+to store the `remoteToken` address for each deployed `OptimsimMintableERC20`. 
 
 ## OptimismMintableERC721Factory
 

--- a/specs/protocol/predeploys.md
+++ b/specs/protocol/predeploys.md
@@ -295,8 +295,10 @@ The `OptimismMintableERC20Factory` is responsible for creating ERC20 contracts o
 used for depositing native L1 tokens into (`OptimismMintableERC20`). These ERC20 contracts can be created permisionlessly
 and implement the interface required by the `StandardBridge` to just work with deposits and withdrawals.
 
-Each `OptimismMintableERC20` contract that is created by the `OptimismMintableERC20Factory` allows for the `L2StandardBridge` to mint
-and burn tokens, depending on if the user is depositing from L1 to L2 or withdrawing from L2 to L1.
+Each `OptimismMintableERC20` contract that is created by the `OptimismMintableERC20Factory`
+allows for the `L2StandardBridge` to mint
+and burn tokens, depending on if the user is
+depositing from L1 to L2 or withdrawing from L2 to L1.
 
 The factory will deploy using `CREATE3`, where the salt will depend on the user inputs:
 `remoteToken`, `name`, `symbol`, and `decimals`.
@@ -313,7 +315,7 @@ _optimismMintableERC20 = CREATE3.deploy(salt, _creationCode);
 ```
 
 The `OptimismMintableERC20Factory` will include a `deployments` mapping
-to store the `remoteToken` address for each deployed `OptimsimMintableERC20`. 
+to store the `remoteToken` address for each deployed `OptimsimMintableERC20`.
 
 ## OptimismMintableERC721Factory
 


### PR DESCRIPTION
**Description**

Updated the `OptimismMintableERC20Factory` specs in `predeploys.md` to use `CREATE3` and store deployments.

This update will allow to implement the liquidity migration process as described in the [Liquidity Migration specs](https://github.com/ethereum-optimism/specs/pull/294).

The implementation link was temporarily removed from the document.