### PR TITLE
linting: fix filename linting

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -39,12 +39,13 @@ lint-links:
 
 lint-filenames:
     #!/usr/bin/env bash
-    for file in $(find . -type f); do
+    for file in $(find ./specs -type f); do
       if [[ "$file" == *_* ]]; then
         echo "File with underscore found: $file"
         exit 1
       fi
     done
+    echo "Filename linting complete"
 
 build:
     mdbook build


### PR DESCRIPTION
**Description**

It was previously getting stuck up on a file
in `node_modules`. Now it specifically only
looks at the `specs` directory, which is the
markdown that we care about.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

