### PR TITLE
interop: add link to `SuperchainWETH`

### DIFF
--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -195,6 +195,7 @@ function messageNonce() public view returns (uint256) {
 
 To enable interoperability between chains that use a custom gas token, there is no native support for
 sending `ether` between chains. `ether` must first be wrapped into WETH before sending between chains.
+See [SuperchainWETH](./superchain-weth.md) for more information.
 
 ### Interfaces
 


### PR DESCRIPTION
**Description**

Adds a link in the appropriate place to `SuperchainWETH` so that
the information is more discoverable.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

