### PR TITLE
fault-proof: add links to design notes in spec

### DIFF
--- a/specs/interop/fault-proof.md
+++ b/specs/interop/fault-proof.md
@@ -4,13 +4,14 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**
 
+- [Cascading dependencies](#cascading-dependencies)
 - [Security Considerations](#security-considerations)
-  - [Cascading dependencies](#cascading-dependencies)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 The fault proof design is not complete, but the following docs show high level overviews of the direction:
-- [Notes 1](https://oplabs.notion.site/External-Interop-Fault-Dispute-Game-Notes-1537bf9fad054bcfb2245dea88d48d16) 
+
+- [Notes 1](https://oplabs.notion.site/External-Interop-Fault-Dispute-Game-Notes-1537bf9fad054bcfb2245dea88d48d16)
 - [Notes 2](https://oplabs.notion.site/External-Interop-Fault-Proofs-spec-WORK-IN-PROGRESS-29cfaae285994870b3fa51254d0391f2)
 
 ## Cascading dependencies

--- a/specs/interop/fault-proof.md
+++ b/specs/interop/fault-proof.md
@@ -9,7 +9,14 @@
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-TODO
+The fault proof design is not complete, but the following docs show high level overviews of the direction:
+- [Notes 1](https://oplabs.notion.site/External-Interop-Fault-Dispute-Game-Notes-1537bf9fad054bcfb2245dea88d48d16) 
+- [Notes 2](https://oplabs.notion.site/External-Interop-Fault-Proofs-spec-WORK-IN-PROGRESS-29cfaae285994870b3fa51254d0391f2)
+
+## Cascading dependencies
+
+Deposits are a special case, synchronous with derivation, at enforced cross-L2 delay.
+Thus deposits cannot reference each others events intra-block.
 
 No changes to the dispute game bisection are required. The only changes required are to the fault proof program itself.
 The insight is that the fault proof program can be a superset of the state transition function.
@@ -17,8 +24,3 @@ The insight is that the fault proof program can be a superset of the state trans
 ## Security Considerations
 
 TODO
-
-### Cascading dependencies
-
-Deposits are a special case, synchronous with derivation, at enforced cross-L2 delay.
-Thus deposits cannot reference each others events intra-block.


### PR DESCRIPTION
**Description**

Adds a link to the notion docs

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

