### PR TITLE
governance: update migration logic in `GovernanceDelegation`

### DIFF
--- a/specs/experimental/gov-delegation.md
+++ b/specs/experimental/gov-delegation.md
@@ -310,8 +310,8 @@ enum AllowanceType {
 All write functions in the `GovernanceDelegation` MUST check if the users interacting with it have been migrated by
 checking the `migrated` mapping from its [storage](#storage). If a user has not been migrated, the `GovernanceDelegation`
 MUST copy the delegation and checkpoint data from the token contract to its own state. After copying the data, the
-`GovernanceDelegation` MUST update the `migrated` mapping to reflect that the address has been migrated, and remove the
-state from the `GovernanceToken` contract via a function that can only be called by the `GovernanceDelegation` contract.
+`GovernanceDelegation` MUST update the `migrated` mapping to reflect that the address has been migrated, and clear the
+delegation in the `GovernanceToken` contract.
 
 ## Backwards Compatibility
 

--- a/specs/experimental/gov-delegation.md
+++ b/specs/experimental/gov-delegation.md
@@ -307,11 +307,19 @@ enum AllowanceType {
 
 ## Migration
 
-All write functions in the `GovernanceDelegation` MUST check if the users interacting with it have been migrated by
-checking the `migrated` mapping from its [storage](#storage). If a user has not been migrated, the `GovernanceDelegation`
-MUST copy the delegation and checkpoint data from the token contract to its own state. After copying the data, the
-`GovernanceDelegation` MUST update the `migrated` mapping to reflect that the address has been migrated, and clear the
-delegation in the `GovernanceToken` contract.
+All write functions in the `GovernanceDelegation` MUST check if the users interacting with it (such as creating or updating
+a delegation) have been migrated by checking the `migrated` mapping from its [storage](#storage). If a user has not been
+migrated, the `GovernanceDelegation` MUST copy the delegation and checkpoint data from the token contract to its own state.
+After copying the data, the `GovernanceDelegation` MUST update the `migrated` mapping to reflect that the address has been
+migrated, and clear the delegation in the `GovernanceToken` contract.
+
+The `GovernanceDelegation` MUST enforce the following invariants for the migration logic:
+
+1. A user MUST NOT have an active delegation in both `GovernanceToken` and `GovernanceDelegation` at the same time.
+A delegation to address(0) is not considered an active delegation.
+2. The sum of the voting power of all advance delegations of a user MUST NOT exceed the total voting power of the user.
+3. The sum of the voting power a user receives from delegations in the `GovernanceDelegation` and the `GovernanceToken`
+MUST NOT be double counted.
 
 ## Backwards Compatibility
 

--- a/specs/experimental/gov-delegation.md
+++ b/specs/experimental/gov-delegation.md
@@ -317,8 +317,8 @@ state from the `GovernanceToken` contract via a function that can only be called
 
 The `GovernanceDelegation` contract ensures backwards compatibility by allowing the migration of delegation state from the
 `GovernanceToken`, and implementing the same type of getter functions. External contracts that need to consume voting power
-data, like the `Governor`, will have to query both the legacy state in the `GovernanceToken` if a user has not been migrated,
-and the up-to-date state in the `GovernanceDelegation` if the user has been migrated.
+data, like the `Governor`, will have to query the legacy state in the `GovernanceToken` if a user has not been migrated,
+or the up-to-date state in the `GovernanceDelegation` if the user has been migrated.
 
 ## User Flow
 

--- a/specs/experimental/gov-delegation.md
+++ b/specs/experimental/gov-delegation.md
@@ -21,7 +21,6 @@
     - [`getVotes`](#getvotes)
     - [`getPastVotes`](#getpastvotes)
     - [`getPastTotalSupply`](#getpasttotalsupply)
-    - [`migrated`](#migrated)
     - [`delegations`](#delegations)
   - [Events](#events)
     - [`DelegationCreated`](#delegationcreated)
@@ -213,14 +212,6 @@ Retrieves the total supply of the `GovernanceToken` at a given block.
 function getPastTotalSupply(uint256 _blockNumber) external view returns (uint256)
 ```
 
-#### `migrated`
-
-Returns the migration status of an account — `True` if the account has been migrated, `False` otherwise.
-
-```solidity
-function migrated(address _account) public view returns (bool)
-```
-
 #### `delegations`
 
 Retrieves the delegations of a given user address sorted in descending order by voting power.
@@ -254,9 +245,6 @@ The `GovernanceDelegation` contract MUST be able to store delegations and checkp
 defined as in the `GovernanceToken` and use the same types:
 
 ```solidity
-// Addresses that had their delegation state migrated from the `GovernanceToken` to the `GovernanceDelegation`.
-mapping(address => bool) public migrated;
-
 // Voting power delegations of an account.
 mapping(address => Delegation[]) public delegations;
 
@@ -307,11 +295,10 @@ enum AllowanceType {
 
 ## Migration
 
-All write functions in the `GovernanceDelegation` MUST check if the users interacting with it (such as creating or updating
-a delegation) have been migrated by checking the `migrated` mapping from its [storage](#storage). If a user has not been
-migrated, the `GovernanceDelegation` MUST copy the delegation and checkpoint data from the token contract to its own state.
-After copying the data, the `GovernanceDelegation` MUST update the `migrated` mapping to reflect that the address has been
-migrated, and clear the delegation in the `GovernanceToken` contract.
+Functions that create or update delegations MUST check that the delegator and new delegatees have been migrated from
+the `GovernanceToken`. If a user has not been migrated, the `GovernanceDelegation` MUST copy the delegation and
+checkpoint data from the token contract to its own state. After copying the data, the `GovernanceDelegation` MUST clear
+its state in the `GovernanceToken` contract.
 
 The `GovernanceDelegation` MUST enforce the following invariants for the migration logic:
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description & Context**

For interop, the governor will have to be updated use the L1 block number instead of the OP L2 block number as networks in their superchain will have their own cadence of blocks.

Proposed by @smartcontracts, the interop update introduces breaking changes so it's better to have the delegation state separated: the legacy state in the `GovernanceToken` (with L2 block number), and the new state in the `GovernanceDelegation` contract. This means that the `GovernanceToken` doens't call the `GovernanceDelegation` in its getter functions, and vice versa.