### PR TITLE
Remove warning from Fjord and Granite pages

### DIFF
--- a/specs/protocol/fjord/overview.md
+++ b/specs/protocol/fjord/overview.md
@@ -9,8 +9,6 @@
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-This document is not finalized and should be considered experimental.
-
 ## Execution Layer
 
 - [RIP-7212: Precompile for secp256r1 Curve Support](../precompiles.md#P256VERIFY)

--- a/specs/protocol/granite/overview.md
+++ b/specs/protocol/granite/overview.md
@@ -9,8 +9,6 @@
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-This document is not finalized and should be considered experimental.
-
 ## Execution Layer
 
 - [Limit `bn256Pairing` precompile input size](./exec-engine.md#bn256pairing-precompile-input-restriction)


### PR DESCRIPTION
Remove "This document is not finalized and should be considered experimental" from the Fjord and Granite pages.