### PR TITLE
SuperchainERC20 redesign

### DIFF
--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -60,7 +60,7 @@
     - [`Converted`](#converted)
   - [Invariants](#invariants)
   - [Conversion Flow](#conversion-flow)
-- [InteropStandardBridge](#interopstandardbridge)
+- [SuperchainERC20Bridge](#superchainerc20bridge)
   - [Overview](#overview-2)
   - [Functions](#functions-2)
     - [`sendERC20`](#senderc20)
@@ -796,7 +796,7 @@ sequenceDiagram
   L2StandardBridge-->L2StandardBridge: emit Converted(from, to, Alice, amount)
 ```
 
-## InteropStandardBridge
+## SuperchainERC20Bridge
 
 | Constant | Value                                        |
 | -------- | -------------------------------------------- |
@@ -804,7 +804,7 @@ sequenceDiagram
 
 ### Overview
 
-The `InteropStandardBridge` is an abstraction on top of the `L2toL2CrossDomainMessenger`
+The `SuperchainERC20Bridge` is an abstraction on top of the `L2toL2CrossDomainMessenger`
 that facilitates token bridging using interop.
 It has mint and burn rights over `SuperchainERC20` tokens
 as described in the [token bridging spec](./token-bridging.md).
@@ -861,12 +861,12 @@ The following diagram depicts a cross-chain transfer.
 ```mermaid
 sequenceDiagram
   participant from
-  participant L2SBA as InteropStandardBridge (Chain A)
+  participant L2SBA as SuperchainERC20Bridge (Chain A)
   participant SuperERC20_A as SuperchainERC20 (Chain A)
   participant Messenger_A as L2ToL2CrossDomainMessenger (Chain A)
   participant Inbox as CrossL2Inbox
   participant Messenger_B as L2ToL2CrossDomainMessenger (Chain B)
-  participant L2SBB as InteropStandardBridge (Chain B)
+  participant L2SBB as SuperchainERC20Bridge (Chain B)
   participant SuperERC20_B as SuperchainERC20 (Chain B)
 
   from->>L2SBA: sendERC20To(tokenAddr, to, amount, chainID)
@@ -881,7 +881,7 @@ sequenceDiagram
 
 ### Invariants
 
-The bridging of `SuperchainERC20` using the `InteropStandardBridge` will require the following invariants:
+The bridging of `SuperchainERC20` using the `SuperchainERC20Bridge` will require the following invariants:
 
 - Conservation of bridged `amount`: The minted `amount` in `relayERC20()` should match the `amount`
   that was burnt in `sendERC20()`, as long as target chain has the initiating chain in the dependency set.

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -60,6 +60,16 @@
     - [`Converted`](#converted)
   - [Invariants](#invariants)
   - [Conversion Flow](#conversion-flow)
+- [InteropStandardBridge](#interopstandardbridge)
+  - [Overview](#overview-2)
+  - [Functions](#functions-2)
+    - [`sendERC20`](#senderc20)
+    - [`relayERC20`](#relayerc20)
+  - [Events](#events-2)
+    - [`SentERC20`](#senterc20)
+    - [`RelayedERC20`](#relayederc20)
+  - [Diagram](#diagram)
+  - [Invariants](#invariants-1)
 - [Security Considerations](#security-considerations)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -816,8 +826,8 @@ sendERC20(address _tokenAddress, address _to, uint256 _amount, uint256 _chainId)
 #### `relayERC20`
 
 Process incoming messages IF AND ONLY IF initiated
-by the same contract (token) address on a different chain
-and come from the `L2ToL2CrossChainMessenger` in the local chain.
+by the same contract (bridge) address on a different chain
+and relayed from the `L2ToL2CrossChainMessenger` in the local chain.
 It SHOULD mint `_amount` of tokens with address `_tokenAddress` to address `_to`, as defined in `sendERC20`
 and emit an event including the `_tokenAddress`, the `_from` and chain id from the
 `source` chain, where `_from` is the `msg.sender` of `sendERC20`.

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -764,7 +764,7 @@ The `convert` function conserves the following invariants:
     remote token addresses.
 - Freedom of conversion for valid and paired tokens:
   anyone can convert between allowed legacy representations and
-  valid `OptimismSuperchainERC20s` corresponding to the same remote token.
+  valid `OptimismSuperchainERC20` corresponding to the same remote token.
 
 ### Conversion Flow
 
@@ -785,6 +785,124 @@ sequenceDiagram
   L2StandardBridge->>SuperERC20: IERC20(to).mint(Alice, amount)
   L2StandardBridge-->L2StandardBridge: emit Converted(from, to, Alice, amount)
 ```
+
+## InteropStandardBridge
+
+| Constant | Value                                        |
+| -------- | -------------------------------------------- |
+| Address  | `0x4200000000000000000000000000000000000028` |
+
+### Overview
+
+The `InteropStandardBridge` is an abstraction on top of the `L2toL2CrossDomainMessenger`
+that facilitates token bridging using interop.
+It has mint and burn rights over `SuperchainERC20` tokens
+as described in the [token bridging spec](./token-bridging.md).
+
+### Functions
+
+#### `sendERC20`
+
+Initializes a transfer of `_amount` amount of tokens with address `_tokenAddress` to target address `_to` in chain `_chainId`.
+
+It SHOULD burn `_amount` tokens with address `_tokenAddress` and initialize a message to the
+`L2ToL2CrossChainMessenger` to mint the `_amount` of the same token
+in the target address `_to` at `_chainId` and emit the `SentERC20` event including the `msg.sender` as parameter.
+
+```solidity
+sendERC20(address _tokenAddress, address _to, uint256 _amount, uint256 _chainId)
+```
+
+#### `relayERC20`
+
+Process incoming messages IF AND ONLY IF initiated
+by the same contract (token) address on a different chain
+and come from the `L2ToL2CrossChainMessenger` in the local chain.
+It SHOULD mint `_amount` of tokens with address `_tokenAddress` to address `_to`, as defined in `sendERC20`
+and emit an event including the `_tokenAddress`, the `_from` and chain id from the
+`source` chain, where `_from` is the `msg.sender` of `sendERC20`.
+
+```solidity
+relayERC20(address _tokenAddress, address _from, address _to, uint256 _amount)
+```
+
+### Events
+
+#### `SentERC20`
+
+MUST trigger when a cross-chain transfer is initiated using `sendERC20`.
+
+```solidity
+event SentERC20(address indexed tokenAddress, address indexed from, address indexed to, uint256 amount, uint256 destination)
+```
+
+#### `RelayedERC20`
+
+MUST trigger when a cross-chain transfer is finalized using `relayERC20`.
+
+```solidity
+event RelayedERC20(address indexed tokenAddress, address indexed from, address indexed to, uint256 amount, uint256 source);
+```
+
+### Diagram
+
+The following diagram depicts a cross-chain transfer.
+
+```mermaid
+sequenceDiagram
+  participant from
+  participant L2SBA as L2StandardBridge (Chain A)
+  participant SuperERC20_A as SuperchainERC20 (Chain A)
+  participant Messenger_A as L2ToL2CrossDomainMessenger (Chain A)
+  participant Inbox as CrossL2Inbox
+  participant Messenger_B as L2ToL2CrossDomainMessenger (Chain B)
+  participant L2SBB as L2StandardBridge (Chain B)
+  participant SuperERC20_B as SuperchainERC20 (Chain B)
+
+  from->>L2SBA: sendERC20To(tokenAddr, to, amount, chainID)
+  L2SBA->>SuperERC20_A: burn(from, amount)
+  L2SBA->>Messenger_A: sendMessage(chainId, message)
+  L2SBA-->L2SBA: emit SentERC20(tokenAddr, from, to, amount, destination)
+  Inbox->>Messenger_B: relayMessage()
+  Messenger_B->>L2SBB: relayERC20(tokenAddr, from, to, amount)
+  L2SBB->>SuperERC20_B: mint(to, amount)
+  L2SBB-->L2SBB: emit RelayedERC20(tokenAddr, from, to, amount, source)
+```
+
+### Invariants
+
+The bridging of `SuperchainERC20` using the `InteropStandardBridge` will require the following invariants:
+
+- Conservation of bridged `amount`: The minted `amount` in `relayERC20()` should match the `amount`
+  that was burnt in `sendERC20()`, as long as target chain has the initiating chain in the dependency set.
+  - Corollary 1: Finalized cross-chain transactions will conserve the sum of `totalSupply`
+    and each user's balance for each chain in the Superchain.
+  - Corollary 2: Each initiated but not finalized message (included in initiating chain but not yet in target chain)
+    will decrease the `totalSupply` and the initiating user balance precisely by the burnt `amount`.
+  - Corollary 3: `SuperchainERC20s` should not charge a token fee or increase the balance when moving cross-chain.
+  - Note: if the target chain is not in the initiating chain dependency set,
+    funds will be locked, similar to sending funds to the wrong address.
+    If the target chain includes it later, these could be unlocked.
+- Freedom of movement: Users should be able to send and receive tokens in any target
+  chain with the initiating chain in its dependency set
+  using `sendERC20()` and `relayERC20()`, respectively.
+- Unique Messenger: The `sendERC20()` function must exclusively use the `L2toL2CrossDomainMessenger` for messaging.
+  Similarly, the `relayERC20()` function should only process messages originating from the `L2toL2CrossDomainMessenger`.
+- Unique Address: The `sendERC20()` function must exclusively send a message
+  to the same address on the target chain.
+  Similarly, the `relayERC20()` function should only process messages originating from the same address.
+  - Note: The `Create2Deployer` preinstall and the custom Factory will ensure same address deployment.
+- Locally initiated: The bridging action should be initialized
+  from the chain where funds are located only.
+  - This is because the same address might correspond to different users cross-chain.
+    For example, two SAFEs with the same address in two chains might have different owners.
+    With the prospects of a smart wallet future, it is impossible to assume
+    there will be a way to distinguish EOAs from smart wallets.
+  - A way to allow for remotely initiated bridging is to include remote approval,
+    i.e. approve a certain address in a certain chainId to spend local funds.
+- Bridge Events:
+  - `sendERC20()` should emit a `SentERC20` event. `
+  - `relayERC20()` should emit a `RelayedERC20` event.
 
 ## Security Considerations
 

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -421,8 +421,9 @@ function relayExpire(bytes32 _expiredHash, uint256 _messageSource) external {
 
 ### OptimismSuperchainERC20
 
-The `OptimismSuperchainERC20Factory` creates ERC20 contracts that implement to the `SuperchainERC20` [standard](token-bridging.md)
-and grant mint-burn rights to the `L2StandardBridge` (`OptimismSuperchainERC20`).
+The `OptimismSuperchainERC20Factory` creates ERC20 contracts that implements the `SuperchainERC20` [standard](token-bridging.md),
+grants mint-burn rights to the `L2StandardBridge` (`OptimismSuperchainERC20`)
+and include a `remoteToken` variable.
 These ERC20s are called `OptimismSuperchainERC20` and can be converted back and forth with `OptimismMintableERC20` tokens.
 The goal of the `OptimismSuperchainERC20` is to extend functionalities
 of the `OptimismMintableERC20` so that they are interop compatible.

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -861,12 +861,12 @@ The following diagram depicts a cross-chain transfer.
 ```mermaid
 sequenceDiagram
   participant from
-  participant L2SBA as L2StandardBridge (Chain A)
+  participant L2SBA as InteropStandardBridge (Chain A)
   participant SuperERC20_A as SuperchainERC20 (Chain A)
   participant Messenger_A as L2ToL2CrossDomainMessenger (Chain A)
   participant Inbox as CrossL2Inbox
   participant Messenger_B as L2ToL2CrossDomainMessenger (Chain B)
-  participant L2SBB as L2StandardBridge (Chain B)
+  participant L2SBB as InteropStandardBridge (Chain B)
   participant SuperERC20_B as SuperchainERC20 (Chain B)
 
   from->>L2SBA: sendERC20To(tokenAddr, to, amount, chainID)

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -901,7 +901,8 @@ The bridging of `SuperchainERC20` using the `InteropStandardBridge` will require
 - Unique Address: The `sendERC20()` function must exclusively send a message
   to the same address on the target chain.
   Similarly, the `relayERC20()` function should only process messages originating from the same address.
-  - Note: The `Create2Deployer` preinstall and the custom Factory will ensure same address deployment.
+  - Note: The [`Create2Deployer` preinstall](../protocol/preinstalls.md#create2deployer)
+  and the custom Factory will ensure same address deployment.
 - Locally initiated: The bridging action should be initialized
   from the chain where funds are located only.
   - This is because the same address might correspond to different users cross-chain.

--- a/specs/interop/token-bridging.md
+++ b/specs/interop/token-bridging.md
@@ -96,8 +96,6 @@ sequenceDiagram
 ## Implementation
 
 An example implementation for the `sendERC20` and `relayERC20` functions is provided.
-This construction builds on top of the
-for both replay protection and domain binding.
 
 ```solidity
 function sendERC20(SuperchainERC20 _token, address _to, uint256 _amount, uint256 _chainId) public {

--- a/specs/interop/token-bridging.md
+++ b/specs/interop/token-bridging.md
@@ -45,12 +45,15 @@ There is also the [`OptimismSuperchainERC20Factory`](predeploys.md#optimismminta
 predeploy that facilitates this process for L1 native tokens.
 
 Notice that ERC20s that do not implement the standard can still be fungible
-using interop message passing but would need to use a custom bridge.
+using interop message passing
+using a custom bridge or implementing `sendERC20` and `relayERC20` on their own contracts.
 
 ## `InteropStandardBridge`
 
 The `InteropStandardBridge` is a predeploy that works as an abstraction
-on top of the [L2ToL2CrossDomainMessenger][l2-to-l2] for token bridging. The `L2ToL2CrossDomainMessenger` is used for replay protection,
+on top of the [L2ToL2CrossDomainMessenger][l2-to-l2]
+for token bridging.
+The `L2ToL2CrossDomainMessenger` is used for replay protection,
 domain binding and access to additional message information.
 The `InteropStandardBridge` includes two functions for bridging:
 
@@ -72,12 +75,12 @@ The following diagram depicts a cross-chain transfer.
 ```mermaid
 sequenceDiagram
   participant from
-  participant L2SBA as L2StandardBridge (Chain A)
+  participant L2SBA as InteropStandardBridge (Chain A)
   participant SuperERC20_A as SuperchainERC20 (Chain A)
   participant Messenger_A as L2ToL2CrossDomainMessenger (Chain A)
   participant Inbox as CrossL2Inbox
   participant Messenger_B as L2ToL2CrossDomainMessenger (Chain B)
-  participant L2SBB as L2StandardBridge (Chain B)
+  participant L2SBB as InteropStandardBridge (Chain B)
   participant SuperERC20_B as SuperchainERC20 (Chain B)
 
   from->>L2SBA: sendERC20To(tokenAddr, to, amount, chainID)
@@ -93,7 +96,7 @@ sequenceDiagram
 ## Implementation
 
 An example implementation for the `sendERC20` and `relayERC20` functions is provided.
-This construction builds on top of the 
+This construction builds on top of the
 for both replay protection and domain binding.
 
 ```solidity

--- a/specs/interop/token-bridging.md
+++ b/specs/interop/token-bridging.md
@@ -41,7 +41,7 @@ Same address abstracts away cross-chain validation.
 One way to guarantee the same address across the Superchain, and also bind it to the same `init_code`
 and constructor arguments is to use the
 [`Create2Deployer` preinstall](../protocol/preinstalls.md#create2deployer).
-There is also a [`OptimismSuperchainERC20Factory`](predeploys.md#optimismmintableerc20factory)
+There is also the [`OptimismSuperchainERC20Factory`](predeploys.md#optimismmintableerc20factory)
 predeploy that facilitates this process for L1 native tokens.
 
 Notice that ERC20s that do not implement the standard can still be fungible
@@ -50,8 +50,9 @@ using interop message passing but would need to use a custom bridge.
 ## `InteropStandardBridge`
 
 The `InteropStandardBridge` is a predeploy that works as an abstraction
-on top of the `L2toL2CrossDomainMessenger` for token bridging.
-It includes two functions:
+on top of the [L2ToL2CrossDomainMessenger][l2-to-l2] for token bridging. The `L2ToL2CrossDomainMessenger` is used for replay protection,
+domain binding and access to additional message information.
+The `InteropStandardBridge` includes two functions for bridging:
 
 - `sendERC20`: initializes a cross-chain transfer of a `SuperchainERC20`
 by burning the tokens locally and sending a message to the `InteropStandardBridge`
@@ -61,6 +62,8 @@ and mints the corresponding amount of the `SuperchainERC20`
 
 The full specifications and invariants are detailed
 in the [predeploys spec](./predeploys.md#interopstandardbridge).
+
+[l2-to-l2]: ./predeploys.md#l2tol2crossdomainmessenger
 
 ## Diagram
 
@@ -89,12 +92,9 @@ sequenceDiagram
 
 ## Implementation
 
-An example implementation that depends on deterministic deployments across chains
-for security is provided.
-This construction builds on top of the [L2ToL2CrossDomainMessenger][l2-to-l2]
+An example implementation for the `sendERC20` and `relayERC20` functions is provided.
+This construction builds on top of the 
 for both replay protection and domain binding.
-
-[l2-to-l2]: ./predeploys.md#l2tol2crossdomainmessenger
 
 ```solidity
 function sendERC20(SuperchainERC20 _token, address _to, uint256 _amount, uint256 _chainId) public {

--- a/specs/interop/token-bridging.md
+++ b/specs/interop/token-bridging.md
@@ -6,7 +6,7 @@
 
 - [Overview](#overview)
 - [`SuperchainERC20` standard](#superchainerc20-standard)
-- [`InteropStandardBridge`](#interopstandardbridge)
+- [`SuperchainERC20Bridge`](#superchainerc20bridge)
 - [Diagram](#diagram)
 - [Implementation](#implementation)
 - [Future Considerations](#future-considerations)
@@ -19,22 +19,22 @@
 
 Without a standardized security model, bridged assets may not be fungible with each other.
 The `SuperchainERC20` standard is a set of properties allowing ERC20 to be fungible across the
-Superchain using the official `InteropStandardBridge`.
-The `InteropStandardBridge` is a predeploy that builds on the messaging protocol as the most trust-minimized bridging solution.
+Superchain using the official `SuperchainERC20Bridge`.
+The `SuperchainERC20Bridge` is a predeploy that builds on the messaging protocol as the most trust-minimized bridging solution.
 
 ## `SuperchainERC20` standard
 
 The standard will build on top of ERC20 and include the following properties:
 
-1. Give `mint` and `burn` rights to the `InteropStandardBridge`.
+1. Give `mint` and `burn` rights to the `SuperchainERC20Bridge`.
 2. Be deployed at the same address on every chain in the Superchain.
 
-The first property will allow the `InteropStandardBridge` to have a liquidity guarantee,
+The first property will allow the `SuperchainERC20Bridge` to have a liquidity guarantee,
 which would not be possible in a model based on lock/unlock.
 Liquidity availability is fundamental to achieving fungibility.
 
 The second property removes the need for cross-chain access control lists.
-Otherwise, the `InteropStandardBridge` would need a way to verify if the tokens they mint on
+Otherwise, the `SuperchainERC20Bridge` would need a way to verify if the tokens they mint on
 destination correspond to the tokens that were burned on source.
 Same address abstracts away cross-chain validation.
 
@@ -48,23 +48,23 @@ Notice that ERC20s that do not implement the standard can still be fungible
 using interop message passing
 using a custom bridge or implementing `sendERC20` and `relayERC20` on their own contracts.
 
-## `InteropStandardBridge`
+## `SuperchainERC20Bridge`
 
-The `InteropStandardBridge` is a predeploy that works as an abstraction
+The `SuperchainERC20Bridge` is a predeploy that works as an abstraction
 on top of the [L2ToL2CrossDomainMessenger][l2-to-l2]
 for token bridging.
 The `L2ToL2CrossDomainMessenger` is used for replay protection,
 domain binding and access to additional message information.
-The `InteropStandardBridge` includes two functions for bridging:
+The `SuperchainERC20Bridge` includes two functions for bridging:
 
 - `sendERC20`: initializes a cross-chain transfer of a `SuperchainERC20`
-by burning the tokens locally and sending a message to the `InteropStandardBridge`
+by burning the tokens locally and sending a message to the `SuperchainERC20Bridge`
 on the target chain using the `L2toL2CrossDomainMessenger`.
 - `relayERC20`: process incoming messages from the `L2toL2CrossDomainMessenger`
 and mints the corresponding amount of the `SuperchainERC20`
 
 The full specifications and invariants are detailed
-in the [predeploys spec](./predeploys.md#interopstandardbridge).
+in the [predeploys spec](./predeploys.md#superchainerc20bridge).
 
 [l2-to-l2]: ./predeploys.md#l2tol2crossdomainmessenger
 
@@ -75,12 +75,12 @@ The following diagram depicts a cross-chain transfer.
 ```mermaid
 sequenceDiagram
   participant from
-  participant L2SBA as InteropStandardBridge (Chain A)
+  participant L2SBA as SuperchainERC20Bridge (Chain A)
   participant SuperERC20_A as SuperchainERC20 (Chain A)
   participant Messenger_A as L2ToL2CrossDomainMessenger (Chain A)
   participant Inbox as CrossL2Inbox
   participant Messenger_B as L2ToL2CrossDomainMessenger (Chain B)
-  participant L2SBB as InteropStandardBridge (Chain B)
+  participant L2SBB as SuperchainERC20Bridge (Chain B)
   participant SuperERC20_B as SuperchainERC20 (Chain B)
 
   from->>L2SBA: sendERC20To(tokenAddr, to, amount, chainID)


### PR DESCRIPTION
**Description**

This PR introduces changes to `token-bridging.md` and `predeploys.md`. 
The main idea is migrating the `sendERC20` and `relayERC20` functions from the `SuperchainERC20` standard to a new `InteropStandardBridge`. The reasons behind this change are in [this PR to the Design Doc repo](https://github.com/ethereum-optimism/design-docs/pull/83).
