### PR TITLE
holocene: fix activation specs

### DIFF
--- a/specs/protocol/holocene/derivation.md
+++ b/specs/protocol/holocene/derivation.md
@@ -187,8 +187,8 @@ Holocene activation timestamp. Note that this is in contrast to how span batches
 [Delta](../delta/overview.md), namely via the span batch L1 origin timestamp.
 
 When the L1 traversal stage of the derivation pipeline moves its origin to the L1 block whose
-timestamp matches the Holocene activation timestamp, the derivation pipeline's state is mostly reset
-by **discarding**
+timestamp is the first to be greater or equal to the Holocene activation timestamp, the derivation
+pipeline's state is mostly reset by **discarding**
 
 - all frames in the frame queue,
 - channels in the channel bank, and


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

L1 may miss a block, in which case we'd never see the L1 block with timestamp exactly equal to the Holocene activation timestamp. Clarify that the first block with timestamp >= Holocene is the trigger for the pipeline reset.
