### PR TITLE
interop: added superc20 interface for bridge interaction

### DIFF
--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -855,9 +855,9 @@ It SHOULD burn `_amount` tokens with address `_tokenAddress` and initialize a me
 in the target address `_to` at `_chainId` and emit the `SentERC20` event including the `msg.sender` as parameter.
 
 To burn the token, the `sendERC20` function
-calls `burnFromBridge` in the token contract,
+calls `__superchainBurn` in the token contract,
 which is included as part of the the `SuperchainERC20`
-[standard](./token-bridging.md#burnfrombridge).
+[standard](./token-bridging.md#__superchainburn).
 
 ```solidity
 sendERC20(address _tokenAddress, address _to, uint256 _amount, uint256 _chainId)
@@ -873,9 +873,9 @@ and emit an event including the `_tokenAddress`, the `_from` and chain id from t
 `source` chain, where `_from` is the `msg.sender` of `sendERC20`.
 
 To mint the token, the `relayERC20` function
-calls `mintFromBridge` in the token contract,
+calls `__superchainMint` in the token contract,
 which is included as part of the the `SuperchainERC20`
-[standard](./token-bridging.md#mintfrombridge).
+[standard](./token-bridging.md#__superchainmint).
 
 ```solidity
 relayERC20(address _tokenAddress, address _from, address _to, uint256 _amount)
@@ -915,12 +915,12 @@ sequenceDiagram
   participant SuperERC20_B as SuperchainERC20 (Chain B)
 
   from->>L2SBA: sendERC20To(tokenAddr, to, amount, chainID)
-  L2SBA->>SuperERC20_A: burnFromBridge(from, amount)
+  L2SBA->>SuperERC20_A: __superchainBurn(from, amount)
   L2SBA->>Messenger_A: sendMessage(chainId, message)
   L2SBA-->L2SBA: emit SentERC20(tokenAddr, from, to, amount, destination)
   Inbox->>Messenger_B: relayMessage()
   Messenger_B->>L2SBB: relayERC20(tokenAddr, from, to, amount)
-  L2SBB->>SuperERC20_B: mintFromBridge(to, amount)
+  L2SBB->>SuperERC20_B: __superchainMint(to, amount)
   L2SBB-->L2SBB: emit RelayedERC20(tokenAddr, from, to, amount, source)
 ```
 

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -854,6 +854,11 @@ It SHOULD burn `_amount` tokens with address `_tokenAddress` and initialize a me
 `L2ToL2CrossChainMessenger` to mint the `_amount` of the same token
 in the target address `_to` at `_chainId` and emit the `SentERC20` event including the `msg.sender` as parameter.
 
+To burn the token, the `sendERC20` function
+calls `burnFromBridge` in the token contract,
+which is included as part of the the `SuperchainERC20`
+[standard](./token-bridging.md#burnfrombridge).
+
 ```solidity
 sendERC20(address _tokenAddress, address _to, uint256 _amount, uint256 _chainId)
 ```
@@ -866,6 +871,11 @@ and relayed from the `L2ToL2CrossChainMessenger` in the local chain.
 It SHOULD mint `_amount` of tokens with address `_tokenAddress` to address `_to`, as defined in `sendERC20`
 and emit an event including the `_tokenAddress`, the `_from` and chain id from the
 `source` chain, where `_from` is the `msg.sender` of `sendERC20`.
+
+To mint the token, the `relayERC20` function
+calls `mintFromBridge` in the token contract,
+which is included as part of the the `SuperchainERC20`
+[standard](./token-bridging.md#mintfrombridge).
 
 ```solidity
 relayERC20(address _tokenAddress, address _from, address _to, uint256 _amount)
@@ -905,12 +915,12 @@ sequenceDiagram
   participant SuperERC20_B as SuperchainERC20 (Chain B)
 
   from->>L2SBA: sendERC20To(tokenAddr, to, amount, chainID)
-  L2SBA->>SuperERC20_A: burn(from, amount)
+  L2SBA->>SuperERC20_A: burnFromBridge(from, amount)
   L2SBA->>Messenger_A: sendMessage(chainId, message)
   L2SBA-->L2SBA: emit SentERC20(tokenAddr, from, to, amount, destination)
   Inbox->>Messenger_B: relayMessage()
   Messenger_B->>L2SBB: relayERC20(tokenAddr, from, to, amount)
-  L2SBB->>SuperERC20_B: mint(to, amount)
+  L2SBB->>SuperERC20_B: mintFromBridge(to, amount)
   L2SBB-->L2SBB: emit RelayedERC20(tokenAddr, from, to, amount, source)
 ```
 

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -916,11 +916,13 @@ sequenceDiagram
 
   from->>L2SBA: sendERC20To(tokenAddr, to, amount, chainID)
   L2SBA->>SuperERC20_A: __superchainBurn(from, amount)
+  SuperERC20_A-->SuperERC20_A: emit SuperchainBurn(from, amount)
   L2SBA->>Messenger_A: sendMessage(chainId, message)
   L2SBA-->L2SBA: emit SentERC20(tokenAddr, from, to, amount, destination)
   Inbox->>Messenger_B: relayMessage()
   Messenger_B->>L2SBB: relayERC20(tokenAddr, from, to, amount)
   L2SBB->>SuperERC20_B: __superchainMint(to, amount)
+  SuperERC20_B-->SuperERC20_B: emit SuperchainMint(to, amount)
   L2SBB-->L2SBB: emit RelayedERC20(tokenAddr, from, to, amount, source)
 ```
 

--- a/specs/interop/token-bridging.md
+++ b/specs/interop/token-bridging.md
@@ -10,6 +10,8 @@
   - [Interface](#interface)
     - [`__superchainMint`](#__superchainmint)
     - [`__superchainBurn`](#__superchainburn)
+    - [`SuperchainMint`](#superchainmint)
+    - [`SuperchainBurn`](#superchainburn)
 - [`SuperchainERC20Bridge`](#superchainerc20bridge)
 - [Diagram](#diagram)
 - [Implementation](#implementation)
@@ -74,6 +76,22 @@ Burns `_amount` of token from address `_account`. It should only be callable by 
 __superchainBurn(address _account, uint256 _amount)
 ```
 
+#### `SuperchainMint`
+
+MUST trigger when `__superchainMint` is called
+
+```solidity
+event SuperchainMint(address indexed _to, uint256 _amount)
+```
+
+#### `SuperchainBurn`
+
+MUST trigger when `__superchainBurn` is called
+
+```solidity
+event SuperchainBurn(address indexed _from, uint256 _amount)
+```
+
 ## `SuperchainERC20Bridge`
 
 The `SuperchainERC20Bridge` is a predeploy that works as an abstraction
@@ -111,11 +129,13 @@ sequenceDiagram
 
   from->>L2SBA: sendERC20To(tokenAddr, to, amount, chainID)
   L2SBA->>SuperERC20_A: __superchainBurn(from, amount)
+  SuperERC20_A-->SuperERC20_A: emit SuperchainBurn(from, amount)
   L2SBA->>Messenger_A: sendMessage(chainId, message)
   L2SBA-->L2SBA: emit SentERC20(tokenAddr, from, to, amount, destination)
   Inbox->>Messenger_B: relayMessage()
   Messenger_B->>L2SBB: relayERC20(tokenAddr, from, to, amount)
   L2SBB->>SuperERC20_B: __superchainMint(to, amount)
+  SuperERC20_B-->SuperERC20_B: emit SuperchainMint(to, amount)
   L2SBB-->L2SBB: emit RelayedERC20(tokenAddr, from, to, amount, source)
 ```
 
@@ -203,12 +223,14 @@ sequenceDiagram
   from->>Intermediate_A: sendWithData(data)
   Intermediate_A->>L2SBA: sendERC20To(tokenAddr, to, amount, chainID)
   L2SBA->>SuperERC20_A: __superchainBurn(from, amount)
+  SuperERC20_A-->SuperERC20_A: emit SuperchainBurn(from, amount)
   L2SBA->>Messenger_A: sendMessage(chainId, message)
   L2SBA-->L2SBA: emit SentERC20(tokenAddr, from, to, amount, destination)
   Intermediate_A->>Messenger_A: sendMessage(chainId, to, data)
   Inbox->>Messenger_B: relayMessage()
   Messenger_B->>L2SBB: relayERC20(tokenAddr, from, to, amount)
   L2SBB->>SuperERC20_B: __superchainMint(to, amount)
+  SuperERC20_B-->SuperERC20_B: emit SuperchainMint(to, amount)
   Inbox->>Messenger_B: relayMessage(): call
   L2SBB-->L2SBB: emit RelayedERC20(tokenAddr, from, to, amount, source)
   Messenger_B->>to: call(data)


### PR DESCRIPTION

**Description**
Added an interface to the `SuperchainERC20` standard. The new interface includes two functions: `mintFromBridge` and `burnFromBridge` which can only be called by the `SuperchainERC20Bridge` and work as an entrypoint for the bridge.

Closes #397 .