### PR TITLE
fix table format in configurability.md

### DIFF
--- a/specs/protocol/holocene/configurability.md
+++ b/specs/protocol/holocene/configurability.md
@@ -58,7 +58,7 @@ The following `ConfigUpdate` enum is defined where the `CONFIG_VERSION` is `uint
 | `FEE_SCALARS` | `uint8(1)` | `(uint256(0x01) << 248) \| (uint256(_blobbasefeeScalar) << 32) \| _basefeeScalar` | Modifies the fee scalars |
 | `GAS_LIMIT` | `uint8(2)` | `abi.encode(uint64 _gasLimit)` | Modifies the L2 gas limit |
 | `UNSAFE_BLOCK_SIGNER` | `uint8(3)` | `abi.encode(address)` | Modifies the account that is authorized to progress the unsafe chain |
-| `EIP_1559_PARAMS` | `uint8(4)` | `uint256(uint64(_denominator)) << 32 | uint64(_elasticity)` | Modifies the EIP-1559 denominator and elasticity |
+| `EIP_1559_PARAMS` | `uint8(4)` | `uint256(uint64(_denominator)) << 32 \| uint64(_elasticity)` | Modifies the EIP-1559 denominator and elasticity |
 
 ### Initialization
 


### PR DESCRIPTION

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Escape a '|' character to keep it from being interpreted as a column break.
