### PR TITLE
fix: links and table of contents linter

### DIFF
--- a/specs/experimental/op-contracts-manager.md
+++ b/specs/experimental/op-contracts-manager.md
@@ -1,6 +1,5 @@
 # OP Contracts Manager
 
-[`op-contracts/v1.4.0`]: https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv1.6.0
 [Optimism Monorepo releases]: https://github.com/ethereum-optimism/optimism/releases
 [contract releases]: https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/VERSIONING.md
 [standard configuration]: ../protocol/configurability.md

--- a/specs/protocol/configurability.md
+++ b/specs/protocol/configurability.md
@@ -408,8 +408,8 @@ existing [permissioned dispute games](../fault-proof/stage-one/bridge-integratio
 [^of-gnosis-safe-l1]<br/>
 **Notes:** Optimism Foundation (OF) multisig
 leveraging [battle-tested software](https://github.com/safe-global/safe-smart-account). This role is only active when
-the `OptimismPortal` respected game type is [
-`PERMISSIONED_CANNON`](https://github.com/ethereum-optimism/optimism/blob/op-contracts/v1.5.0/packages/contracts-bedrock/src/dispute/lib/Types.sol#L31).<br/>
+the `OptimismPortal` respected game type is [`PERMISSIONED_CANNON`]
+(<https://github.com/ethereum-optimism/optimism/blob/op-contracts/v1.5.0/packages/contracts-bedrock/src/dispute/lib/Types.sol#L31>).<br/>
 
 ### [Guardian address](https://github.com/ethereum-optimism/optimism/blob/c927ed9e8af501fd330349607a2b09a876a9a1fb/packages/contracts-bedrock/src/L1/SuperchainConfig.sol#L50)
 
@@ -429,8 +429,8 @@ with [permissioned dispute games](../fault-proof/stage-one/bridge-integration.md
 L1.<br/>
 **Administrator:** [L1 Proxy Admin](#admin-roles)<br/>
 **Requirement:** No requirement<br/>
-**Notes:** This role is only active when the `OptimismPortal` respected game type is [
-`PERMISSIONED_CANNON`](https://github.com/ethereum-optimism/optimism/blob/op-contracts/v1.5.0/packages/contracts-bedrock/src/dispute/lib/Types.sol#L31).
+**Notes:** This role is only active when the `OptimismPortal` respected game type is [`PERMISSIONED_CANNON`]
+(<https://github.com/ethereum-optimism/optimism/blob/op-contracts/v1.5.0/packages/contracts-bedrock/src/dispute/lib/Types.sol#L31>).
 The `L1ProxyAdmin` sets the implementation of the `PERMISSIONED_CANNON` game type. Thus, it determines the proposer
 configuration of the permissioned dispute game.<br/>
 


### PR DESCRIPTION
I ran into these small lint issues while running `just lint-specs-md-fix` and `just lint-specs-toc-check`, as mentioned in the README.  