### PR TITLE
fix: Remove Predeploys in Holocene

### DIFF
--- a/specs/SUMMARY.md
+++ b/specs/SUMMARY.md
@@ -53,7 +53,6 @@
     - [Holocene](./protocol/holocene/overview.md)
       - [Derivation](./protocol/holocene/derivation.md)
       - [Execution Engine](./protocol/holocene/exec-engine.md)
-      - [Predeploys](./protocol/holocene/predeploys.md)
       - [System Config](./protocol/holocene/system-config.md)
 - [Governance]()
   - [Governance Token](./governance/gov-token.md)


### PR DESCRIPTION
### Description

Quick fix to remove the [empty Predeploy page](https://specs.optimism.io/protocol/holocene/predeploys.html) in Holocene.