### PR TITLE
interop: change SuperchainERC20 function naming to be Superchain neutral

### DIFF
--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -855,9 +855,10 @@ It SHOULD burn `_amount` tokens with address `_tokenAddress` and initialize a me
 in the target address `_to` at `_chainId` and emit the `SentERC20` event including the `msg.sender` as parameter.
 
 To burn the token, the `sendERC20` function
-calls `__superchainBurn` in the token contract,
-which is included as part of the the `SuperchainERC20`
-[standard](./token-bridging.md#__superchainburn).
+calls `__crosschainBurn` in the token contract,
+which is included as part of the the `ICrosschainERC20`
+[interface](./token-bridging.md#__crosschainburn)
+implemented by the `SuperchainERC20` standard.
 
 ```solidity
 sendERC20(address _tokenAddress, address _to, uint256 _amount, uint256 _chainId)
@@ -873,9 +874,10 @@ and emit an event including the `_tokenAddress`, the `_from` and chain id from t
 `source` chain, where `_from` is the `msg.sender` of `sendERC20`.
 
 To mint the token, the `relayERC20` function
-calls `__superchainMint` in the token contract,
-which is included as part of the the `SuperchainERC20`
-[standard](./token-bridging.md#__superchainmint).
+calls `__crosschainMint` in the token contract,
+which is included as part of the the `ICrosschainERC20`
+[interface](./token-bridging.md#__crosschainmint)
+implemented by the `SuperchainERC20` standard.
 
 ```solidity
 relayERC20(address _tokenAddress, address _from, address _to, uint256 _amount)
@@ -915,13 +917,13 @@ sequenceDiagram
   participant SuperERC20_B as SuperchainERC20 (Chain B)
 
   from->>L2SBA: sendERC20To(tokenAddr, to, amount, chainID)
-  L2SBA->>SuperERC20_A: __superchainBurn(from, amount)
+  L2SBA->>SuperERC20_A: __crosschainBurn(from, amount)
   SuperERC20_A-->SuperERC20_A: emit SuperchainBurn(from, amount)
   L2SBA->>Messenger_A: sendMessage(chainId, message)
   L2SBA-->L2SBA: emit SentERC20(tokenAddr, from, to, amount, destination)
   Inbox->>Messenger_B: relayMessage()
   Messenger_B->>L2SBB: relayERC20(tokenAddr, from, to, amount)
-  L2SBB->>SuperERC20_B: __superchainMint(to, amount)
+  L2SBB->>SuperERC20_B: __crosschainMint(to, amount)
   SuperERC20_B-->SuperERC20_B: emit SuperchainMinted(to, amount)
   L2SBB-->L2SBB: emit RelayedERC20(tokenAddr, from, to, amount, source)
 ```

--- a/specs/interop/token-bridging.md
+++ b/specs/interop/token-bridging.md
@@ -65,7 +65,7 @@ token standard, that includes two external functions and two events:
 
 #### `__crosschainMint`
 
-Mints `_amount` of token to address `_account`. It should only be callable by the `SuperchainERC20Bridge`
+Mints `_amount` of token to address `_account`.
 
 ```solidity
 __crosschainMint(address _account, uint256 _amount)
@@ -73,7 +73,7 @@ __crosschainMint(address _account, uint256 _amount)
 
 #### `__crosschainBurn`
 
-Burns `_amount` of token from address `_account`. It should only be callable by the `SuperchainERC20Bridge`
+Burns `_amount` of token from address `_account`.
 
 ```solidity
 __crosschainBurn(address _account, uint256 _amount)

--- a/specs/interop/token-bridging.md
+++ b/specs/interop/token-bridging.md
@@ -32,9 +32,11 @@ The `SuperchainERC20Bridge` is a predeploy that builds on the messaging protocol
 
 ### Properties
 
-The standard will build on top of ERC20, implement the [`ICrosschainERC20`](#icrosschainerc20) interface and include the following properties:
+The standard will build on top of ERC20, implement the [`ICrosschainERC20`](#icrosschainerc20)
+interface and include the following properties:
 
-1. Give `mint` and `burn` rights to the `SuperchainERC20Bridge`.
+1. Only allow `SuperchainERC20Bridge` to call
+[`__crosschainMint`](#__crosschainmint) and [`__crosschainBurn`](#__crosschainburn).
 2. Be deployed at the same address on every chain in the Superchain.
 
 The first property will allow the `SuperchainERC20Bridge` to have a liquidity guarantee,
@@ -58,7 +60,8 @@ using a custom bridge or implementing `sendERC20` and `relayERC20` on their own 
 
 ### `ICrosschainERC20`
 
-Implementations of the `SuperchainERC20` standard will need to implement the `ICrosschainERC20` token standard, that includes two external functions and two events:
+Implementations of the `SuperchainERC20` standard will need to implement the `ICrosschainERC20`
+token standard, that includes two external functions and two events:
 
 #### `__crosschainMint`
 

--- a/specs/interop/token-bridging.md
+++ b/specs/interop/token-bridging.md
@@ -7,7 +7,7 @@
 - [Overview](#overview)
 - [`SuperchainERC20` standard](#superchainerc20-standard)
   - [Properties](#properties)
-  - [Interface](#interface)
+  - [`ICrosschainERC20`](#icrosschainerc20)
     - [`__crosschainMint`](#__crosschainmint)
     - [`__crosschainBurn`](#__crosschainburn)
     - [`CrosschainMinted`](#crosschainminted)


### PR DESCRIPTION
**Description**
Modified the `__superchainMint` and `__superchainBurn` functions to be cross-chain neutral and extensible to other L2s. 
These PR changes the names to `__crosschainMint` and `__crosschainBurn`. The same for the `CrosschainMinted` and `CrosschainBurnt` events. Moreover, this interface gets renamed to `ICrosschainERC20` and `SuperchainERC20` will extend from it to make the functions only callable by the `SuperchainERC20Bridge`.