### PR TITLE
fix: adding return hash and fixing event tenses

### DIFF
--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -863,7 +863,7 @@ implemented by the `SuperchainERC20` standard.
 Returns the `msgHash_` crafted by the `L2ToL2CrossChainMessenger`.
 
 ```solidity
-sendERC20(address _tokenAddress, address _to, uint256 _amount, uint256 _chainId) returns (bytes32 _msgHash)
+sendERC20(address _tokenAddress, address _to, uint256 _amount, uint256 _chainId) returns (bytes32 msgHash_)
 ```
 
 #### `relayERC20`

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -860,8 +860,10 @@ which is included as part of the the `ICrosschainERC20`
 [interface](./token-bridging.md#__crosschainburn)
 implemented by the `SuperchainERC20` standard.
 
+Returns the `msgHash_` crafted by the `L2ToL2CrossChainMessenger`.
+
 ```solidity
-sendERC20(address _tokenAddress, address _to, uint256 _amount, uint256 _chainId)
+sendERC20(address _tokenAddress, address _to, uint256 _amount, uint256 _chainId) returns (bytes32 _msgHash)
 ```
 
 #### `relayERC20`
@@ -916,11 +918,13 @@ sequenceDiagram
   participant L2SBB as SuperchainERC20Bridge (Chain B)
   participant SuperERC20_B as SuperchainERC20 (Chain B)
 
-  from->>L2SBA: sendERC20To(tokenAddr, to, amount, chainID)
+  from->>L2SBA: sendERC20(tokenAddr, to, amount, chainID)
   L2SBA->>SuperERC20_A: __crosschainBurn(from, amount)
   SuperERC20_A-->SuperERC20_A: emit SuperchainBurn(from, amount)
   L2SBA->>Messenger_A: sendMessage(chainId, message)
+  Messenger_A->>L2SBA: return msgHash_ 
   L2SBA-->L2SBA: emit SentERC20(tokenAddr, from, to, amount, destination)
+  L2SBA->>from: return msgHash_ 
   Inbox->>Messenger_B: relayMessage()
   Messenger_B->>L2SBB: relayERC20(tokenAddr, from, to, amount)
   L2SBB->>SuperERC20_B: __crosschainMint(to, amount)


### PR DESCRIPTION
**Description**

- Updates the token bridging section of `predeploys.md` to include the `msgHash_` returned by the `L2ToL2CrossDomainMessenger#sendMessage` function.
- Updates the mermaid to reflect this change. Similarly, it fixes `sendERC20To` to `sendERC20` function name in the mermaid.
- Introduces the same updates in `token-bridging.md` and fixes event tense.
