### PR TITLE
chore: add return value to sendMessage in L2ToL2CrossDomainMessenger specs

### DIFF
--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -326,13 +326,15 @@ chain is included instead.
 The following function is used for sending messages between domains:
 
 ```solidity
-function sendMessage(uint256 _destination, address _target, bytes calldata _message) external;
+function sendMessage(uint256 _destination, address _target, bytes calldata _message) external returns (bytes32);
 ```
 
+It returns the hash of the message being sent,
+used to track whether the message has successfully been relayed.
 It emits a `SentMessage` event with the necessary metadata to execute when relayed on the destination chain.
 
 ```solidity
-event SentMessage(uint256 indexed destination, address indexed target, uint256 indexed messageNonce, address sender, bytes message);``
+event SentMessage(uint256 indexed destination, address indexed target, uint256 indexed messageNonce, address sender, bytes message);
 ```
 
 An explicit `_destination` chain and `nonce` are used to ensure that the message can only be played on a single remote


### PR DESCRIPTION
**Description**
Added the return value of the `sendMessage` function in the `L2ToL2CrossDomainMessenger` specs (interop/Predeploys.md). 

This was implemented in the [L2ToL2CrossDomainMessenger.sol](https://github.com/ethereum-optimism/optimism/blob/9d9dc32977d5cda01628530b6f54047e4d4e0f9b/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol#L124) but was not referenced in the specs.
