### PR TITLE
holocene: add rule to limit channel size at channel stage

### DIFF
--- a/specs/protocol/holocene/derivation.md
+++ b/specs/protocol/holocene/derivation.md
@@ -110,6 +110,9 @@ frame loading becomes simpler in the channel bank:
 correct frame for this channel, the frame and channel are dropped, including all future frames for
 the channel that might still be in the frame queue. Note that the equivalent rule was already
 present pre-Holocene.
+- After adding a frame to the staging channel, the channel is dropped if its raw compressed size as
+defined in the Bedrock specification is larger than `MAX_RLP_BYTES_PER_CHANNEL`. This rule replaces
+the total limit of all channels' combined sizes by `MAX_CHANNEL_BANK_SIZE` before Holocene.
 
 ## Span Batches
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Adds rule to limit channel size at channel stage by `MaxRLPBytesPerChannel`. This replaces the limit of all channels' sizes by `MaxChannelBankSize`.

**Additional context**

This rule makes sense since the channel stage now only holds a single (still compressed) channel, so it can be limited in size by the later limit on an uncompressed channel. Compression is none worst-case (ignoring overheads), so practically this doesn't add any stronger limits on a channel, but early-limits the size by which the channel bank could grow, back to 100 MB from 1 GB, since the channel bank size was increased to 1GB with Fjord.
