### PR TITLE
Add execution witness and account proof hint types

### DIFF
--- a/specs/fault-proof/index.md
+++ b/specs/fault-proof/index.md
@@ -34,6 +34,8 @@
     - [`l2-code <codehash>`](#l2-code-codehash)
     - [`l2-state-node <nodehash>`](#l2-state-node-nodehash)
     - [`l2-output <outputroot>`](#l2-output-outputroot)
+    - [`l2-execution-witness <blocknumber>`](#l2-execution-witness-blocknumber)
+    - [`l2-account-proof <blocknumber_and_address>`](#l2-account-proof-blocknumber_and_address)
   - [Precompile Accelerators](#precompile-accelerators)
 - [Fault Proof VM](#fault-proof-vm)
 - [Fault Proof Interactive Dispute Game](#fault-proof-interactive-dispute-game)

--- a/specs/fault-proof/index.md
+++ b/specs/fault-proof/index.md
@@ -438,6 +438,18 @@ Requests the host to prepare the L2 Output at the l2 output root `<outputroot>`.
 The L2 Output is the preimage of a
 [computed output root](../protocol/proposals.md#l2-output-commitment-construction).
 
+#### `l2-execution-witness <blocknumber>`
+
+Requests the host to prepare all preimages used in the execution of the block at `<blocknumber>` height.
+
+#### `l2-account-proof <blocknumber_and_address>`
+
+Requests the host send account proof for a certain block number and address. `<blocknumber_and_address>` is hex
+encoded: 8-byte BE block number + 20-byte address.
+
+`l2-execution-witness` and `l2-account-proof` hints are preferred over the more granular `l2-code` and `l2-state-node`,
+and they should be sent before the more granular hints to ensure proper handling.
+
 ### Precompile Accelerators
 
 Precompiles that are too expensive to be executed in a fault-proof VM can be executed


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

Adds `l2-execution-witness` and `l2-account-proof` which are op-program hints that will replace the more granular `l2-code` and `l2-state-node` hints.

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

optimism PR: https://github.com/ethereum-optimism/optimism/pull/12559