### PR TITLE
fix: prefer block hash instead of number for hint

### DIFF
--- a/specs/fault-proof/index.md
+++ b/specs/fault-proof/index.md
@@ -35,7 +35,7 @@
     - [`l2-state-node <nodehash>`](#l2-state-node-nodehash)
     - [`l2-output <outputroot>`](#l2-output-outputroot)
     - [`l2-execution-witness <blocknumber>`](#l2-execution-witness-blocknumber)
-    - [`l2-account-proof <blocknumber_and_address>`](#l2-account-proof-blocknumber_and_address)
+    - [`l2-account-proof <blockhash_and_address>`](#l2-account-proof-blockhash_and_address)
   - [Precompile Accelerators](#precompile-accelerators)
 - [Fault Proof VM](#fault-proof-vm)
 - [Fault Proof Interactive Dispute Game](#fault-proof-interactive-dispute-game)
@@ -444,10 +444,10 @@ The L2 Output is the preimage of a
 
 Requests the host to prepare all preimages used in the execution of the block at `<blocknumber>` height.
 
-#### `l2-account-proof <blocknumber_and_address>`
+#### `l2-account-proof <blockhash_and_address>`
 
-Requests the host send account proof for a certain block number and address. `<blocknumber_and_address>` is hex
-encoded: 8-byte BE block number + 20-byte address.
+Requests the host send account proof for a certain block number and address. `<blockhash_and_address>` is hex
+encoded: 32-byte block hash + 20-byte address.
 
 `l2-execution-witness` and `l2-account-proof` hints are preferred over the more granular `l2-code` and `l2-state-node`,
 and they should be sent before the more granular hints to ensure proper handling.


### PR DESCRIPTION
**Description**

Use block hash instead of block number for account proof.

Fixes this comment: https://github.com/ethereum-optimism/specs/pull/438/files#r1814122088 #439 