### PR TITLE
Improve definition of channel encoding

### DIFF
--- a/specs/protocol/derivation.md
+++ b/specs/protocol/derivation.md
@@ -376,7 +376,8 @@ rlp_batches = rlp_encode(encoded_batches)
 
 where:
 
-- `batches` is the input, a sequence of batches each with a byte-encoder function `.encode()` as per the next section ("Batch Encoding")
+- `batches` is the input, a sequence of batches each with a byte-encoder
+function `.encode()` as per the next section ("Batch Encoding")
 - `encoded_batches` is a byte array: the concatenation of the encoded batches
 - `rlp_batches` is the rlp encoding of the concatenated encoded batches
 

--- a/specs/protocol/derivation.md
+++ b/specs/protocol/derivation.md
@@ -376,12 +376,12 @@ rlp_batches = rlp_encode(encoded_batches)
 
 where:
 
-- `batches` is the input, a sequence of batches with a byte-encoder function `.encode()` as per the next section ("Batch Encoding")
+- `batches` is the input, a sequence of batches each with a byte-encoder function `.encode()` as per the next section ("Batch Encoding")
 - `encoded_batches` is a byte array: the concatenation of the encoded batches
 - `rlp_batches` is the rlp encoding of the concatenated encoded batches
 
 ```text
-channel_encoding = zlib_compress(serialized_channel)
+channel_encoding = zlib_compress(rlp_batches)
 ```
 
 where zlib_compress is the ZLIB algorithm (as specified in [RFC-1950][rfc1950]) with no dictionary.

--- a/specs/protocol/derivation.md
+++ b/specs/protocol/derivation.md
@@ -370,14 +370,14 @@ A channel is encoded by applying a streaming compression algorithm to a list of 
 ```text
 encoded_batches = []
 for batch in batches:
-    encoded_batches.append(batch.encode())
+    encoded_batches ++ batch.encode()
 rlp_batches = rlp_encode(encoded_batches)
 ```
 
 where:
 
 - `batches` is the input, a sequence of batches with a byte-encoder function `.encode()` as per the next section ("Batch Encoding")
-- `encoded_batches` is the concatenation of the RLP-encoded batches
+- `encoded_batches` is a byte array: the concatenation of the encoded batches
 - `rlp_batches` is the rlp encoding of the concatenated encoded batches
 
 ```text

--- a/specs/protocol/derivation.md
+++ b/specs/protocol/derivation.md
@@ -368,18 +368,20 @@ where:
 A channel is encoded by applying a streaming compression algorithm to a list of batches:
 
 ```text
-rlp_batches = []
+encoded_batches = []
 for batch in batches:
-    rlp_batches.append(batch)
+    encoded_batches.append(batch.encode())
+rlp_batches = rlp_encode(encoded_batches)
 ```
 
 where:
 
-- `batches` is the input, a sequence of batches byte-encoded as per the next section ("Batch Encoding")
-- `rlp_batches` is the concatenation of the RLP-encoded batches
+- `batches` is the input, a sequence of batches with a byte-encoder function `.encode()` as per the next section ("Batch Encoding")
+- `encoded_batches` is the concatenation of the RLP-encoded batches
+- `rlp_batches` is the rlp encoding of the concatenated encoded batches
 
 ```text
-channel_encoding = zlib_compress(rlp_batches)
+channel_encoding = zlib_compress(serialized_channel)
 ```
 
 where zlib_compress is the ZLIB algorithm (as specified in [RFC-1950][rfc1950]) with no dictionary.


### PR DESCRIPTION
I think this section was written before span batches were invented, and it doesn't use "rlp encode" accurately any more. 

Drive-by observation: I think the final `rlp_encode` (the only one, if using span batches) is superfluous and could in principle be removed from the protocol -- it adds a few bytes which don't contain any useful information, since the input is just a byte string.

https://github.com/ethereum-optimism/optimism/blob/02d5832349a1f469adb00191459333e2032b09b4/op-node/rollup/derive/batch.go#L82

