### PR TITLE
chore: rename `ICrosschainERC20` interface for `IERC7802`

### DIFF
--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -888,8 +888,8 @@ in the target address `_to` at `_chainId` and emit the `SentERC20` event includi
 
 To burn the token, the `sendERC20` function
 calls `crosschainBurn` in the token contract,
-which is included as part of the the `ICrosschainERC20`
-[interface](./token-bridging.md#crosschainburn)
+which is included as part of the the
+[`IERC7802` interface](https://github.com/ethereum/ERCs/pull/692)
 implemented by the `SuperchainERC20` standard.
 
 Returns the `msgHash_` crafted by the `L2ToL2CrossChainMessenger`.
@@ -909,8 +909,8 @@ and emit an event including the `_tokenAddress`, the `_from` and chain id from t
 
 To mint the token, the `relayERC20` function
 calls `crosschainMint` in the token contract,
-which is included as part of the the `ICrosschainERC20`
-[interface](./token-bridging.md#crosschainmint)
+which is included as part of the the
+[`IERC7802` interface](https://github.com/ethereum/ERCs/pull/692)
 implemented by the `SuperchainERC20` standard.
 
 ```solidity

--- a/specs/interop/token-bridging.md
+++ b/specs/interop/token-bridging.md
@@ -7,7 +7,7 @@
 - [Overview](#overview)
 - [`SuperchainERC20` standard](#superchainerc20-standard)
   - [Properties](#properties)
-  - [`ICrosschainERC20`](#icrosschainerc20)
+  - [`IERC7802`](#ierc7802)
     - [`crosschainMint`](#crosschainmint)
     - [`crosschainBurn`](#crosschainburn)
     - [`CrosschainMint`](#crosschainmint)
@@ -32,7 +32,8 @@ The `SuperchainERC20Bridge` is a predeploy that builds on the messaging protocol
 
 ### Properties
 
-The standard will build on top of ERC20, implement the [`ICrosschainERC20`](#icrosschainerc20)
+The standard will build on top of ERC20, implement the
+[`IERC7802`](https://github.com/ethereum/ERCs/pull/692)
 interface and include the following properties:
 
 1. Only allow `SuperchainERC20Bridge` to call
@@ -58,10 +59,11 @@ Notice that ERC20s that do not implement the standard can still be fungible
 using interop message passing
 using a custom bridge or implementing `sendERC20` and `relayERC20` on their own contracts.
 
-### `ICrosschainERC20`
+### `IERC7802`
 
-Implementations of the `SuperchainERC20` standard will need to implement the `ICrosschainERC20`
-token standard, that includes two external functions and two events:
+Implementations of the `SuperchainERC20` standard will
+be required to implement the `IERC7802` interface,
+that includes two external functions and two events:
 
 #### `crosschainMint`
 


### PR DESCRIPTION

**Description**
This PR renames the `ICrosschainERC20` interface for `IERC7802`. This is in line with the recent publication of [ERC-7802](https://github.com/ethereum/ERCs/pull/692).
