### PR TITLE
feat: Proofs: DelayedWETH Incident response improvements

### DIFF
--- a/specs/fault-proof/stage-one/bond-incentives.md
+++ b/specs/fault-proof/stage-one/bond-incentives.md
@@ -149,7 +149,10 @@ seconds and reverts if not. It also confirms that the amount being withdrawn is 
 request. Before completing the withdrawal, it reduces the amount contained within the withdrawal request. The original
 `withdraw(wad)` function becomes an alias for `withdraw(msg.sender, wad)`.
 `withdraw(guy,wad)` will not be callable when `SuperchainConfig.paused()` is `true`.
-- `DelayedWETH` has a `hold()` function that allows the `owner()` address to give itself an allowance from any address.
+- `DelayedWETH` has a `hold(guy,wad)` function that allows the `owner()` address to, for any holder, give itself an
+allowance and immediately `transferFrom` that allowance amount to itself.
+- `DelayedWETH` has a `hold(guy)` function that allows the `owner()` address to, for any holder, give itself a full
+allowance of the holder's balance and immediately `transferFrom` that amount to itself.
 - `DelayedWETH` has a `recover()` function that allows the `owner()` address to recover any amount of ETH from the
 contract.
 


### PR DESCRIPTION
Re: https://github.com/ethereum-optimism/optimism/issues/12172 > https://github.com/ethereum-optimism/optimism/issues/12174

This spec PR modifies the existing DelayedWETH spec to support the design changes outlined in [Design Docs: DelayedWETH expansion](https://github.com/ethereum-optimism/design-docs/blob/main/protocol/proofs/delayed-weth-expansion.md)

Let me know what you think of my decision to modify the DelayedWETH spec in place, rather than break it out into its own md file.

Also, if you have a suggestion on how to represent upgradeability concerns (i.e. I took care on storage slots here; should it be documented here or in FMA?) please let me know.