### PR TITLE
docs(alt-da): add full input commitment examples

### DIFF
--- a/specs/experimental/alt-da.md
+++ b/specs/experimental/alt-da.md
@@ -6,6 +6,7 @@
 
 - [Overview](#overview)
 - [Input Commitment Submission](#input-commitment-submission)
+  - [Example Commitments](#example-commitments)
 - [DA Server](#da-server)
 - [Data Availability Challenge Contract](#data-availability-challenge-contract)
   - [Parameters](#parameters)

--- a/specs/experimental/alt-da.md
+++ b/specs/experimental/alt-da.md
@@ -78,6 +78,17 @@ store the request payload so as to signal to the batcher to retry.
 Input commitments submitted onchain without proper storage on the DA provider service are subject to
 challenges if the input cannot be retrieved during the challenge window, as detailed in the following section.
 
+### Example Commitments
+
+| `version_byte` | `commitment_type` | `da_layer_byte` | `payload`           |
+| -------------- | ----------------- | --------------- | ------------------- |
+| 0              |                   |                 | frames              |
+| 1              | 0                 |                 | keccak_commitment   |
+| 1              | 1                 | 0               | eigenda_commitment  |
+| 1              | 1                 | 0x0a            | avail_commitment    |
+| 1              | 1                 | 0x0c            | celestia_commitment |
+| 1              | 1                 | ...             | altda_commitment    |
+
 [batcher]: ../protocol/derivation.md#batch-submission
 [batchertx]: ../protocol/derivation.md#batcher-transaction-format
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

I'm a very visual person and keep coming back to the spec and having to reparse it, figure it out, read a few paragraphs, etc. So instead I go to our own README with a [similar diagram](https://github.com/Layr-Labs/eigenda-proxy?tab=readme-ov-file#commitment-schemas). Adding it here for completeness of the spec.

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
