### PR TITLE
feat: add sender to ERC7802 events

### DIFF
--- a/specs/interop/token-bridging.md
+++ b/specs/interop/token-bridging.md
@@ -2,7 +2,6 @@
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
 **Table of Contents**
 
 - [Overview](#overview)


### PR DESCRIPTION
**Description**

Based on the discussions around ERC7802, we are including `msg.sender` in the `CrosschainMint` and `CrosschainBurn` events.

**Additional context**

ERC7802 discussion: https://github.com/ethereum/ERCs/pull/692#discussion_r1829865880
