### PR TITLE
interop: add `L2ToL2CrossDomainMessenger` predeploy invariants

### DIFF
--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -275,11 +275,9 @@ as well as domain binding, ie the executing transaction can only be valid on a s
 
 ### `relayMessage` Invariants
 
-- It MUST NOT be possible to call the function more than once per execution
 - The `Identifier.origin` MUST be `address(L2ToL2CrossDomainMessenger)`
 - The `_destination` chain id MUST be equal to the local chain id
 - Messages MUST NOT be relayed more than once
-- The `msg.sender` MUST be equal to the `entrypoint` address, if set
 
 ### `sendMessage` Invariants
 

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -16,6 +16,7 @@
   - [`Identifier` Getters](#identifier-getters)
 - [L2ToL2CrossDomainMessenger](#l2tol2crossdomainmessenger)
   - [`relayMessage` Invariants](#relaymessage-invariants)
+  - [`sendMessage` Invariants](#sendmessage-invariants)
   - [Message Versioning](#message-versioning)
   - [No Native Support for Cross Chain Ether Sends](#no-native-support-for-cross-chain-ether-sends)
   - [Interfaces](#interfaces)

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -275,8 +275,16 @@ as well as domain binding, ie the executing transaction can only be valid on a s
 
 ### `relayMessage` Invariants
 
+- It MUST NOT be possible to call the function more than once per execution
 - The `Identifier.origin` MUST be `address(L2ToL2CrossDomainMessenger)`
 - The `_destination` chain id MUST be equal to the local chain id
+- Messages MUST NOT be relayed more than once
+- The `msg.sender` MUST be equal to the `entrypoint` address, if set
+
+### `sendMessage` Invariants
+
+- Sent Messages MUST be uniquely identifiable
+- It must emit the `SentMessage` event
 
 ### Message Versioning
 


### PR DESCRIPTION
### Description
Add missing invariants to `L2ToL2CrossDomainMessenger` description. 