### PR TITLE
refactor: add return data change on relay message

### DIFF
--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -380,7 +380,7 @@ A message is relayed by providing the [identifier](./messaging.md#message-identi
 event and its corresponding [message payload](./messaging.md#message-payload).
 
 ```solidity
-function relayMessage(ICrossL2Inbox.Identifier calldata _id, bytes calldata _sentMessage) external payable {
+function relayMessage(ICrossL2Inbox.Identifier calldata _id, bytes calldata _sentMessage) external payable returns (bytes memory returnData_) {
     require(_id.origin == Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER);
     CrossL2Inbox(Predeploys.CROSS_L2_INBOX).validateMessage(_id, keccak256(_sentMessage));
 
@@ -394,7 +394,8 @@ function relayMessage(ICrossL2Inbox.Identifier calldata _id, bytes calldata _sen
     // log data
     (address _sender, bytes memory _message) = abi.decode(_sentMessage[128:], (address,bytes));
 
-    bool success = SafeCall.call(_target, msg.value, _message);
+    bool success;
+    (success, returnData_) = _target.call(_target, msg.value, _message);
     require(success);
     successfulMessages[messageHash] = true;
     emit RelayedMessage(_source, _nonce, messageHash);

--- a/specs/protocol/messengers.md
+++ b/specs/protocol/messengers.md
@@ -55,7 +55,7 @@ interface CrossDomainMessenger {
         uint256 _value,
         uint256 _minGasLimit,
         bytes memory _message
-    ) external payable;
+    ) external payable returns (bytes memory returnData_);
     function sendMessage(address _target, bytes memory _message, uint32 _minGasLimit) external payable;
     function successfulMessages(bytes32) external view returns (bool);
     function xDomainMessageSender() external view returns (address);


### PR DESCRIPTION
**Description**

Return the returned data from the call to the target on `L2ToL2CrossDomainMessenger#relayMessage()`.

**Additional context**

* https://github.com/ethereum-optimism/optimism/pull/13358#issuecomment-2539985771