### PR TITLE
chore: Migrate github pages deployment workflow to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,7 @@ jobs:
     executor: default
     steps:
       - checkout
+      - install-dependencies
       - run:
           name: markdown lint
           command: just lint-specs-md-check
@@ -51,6 +52,7 @@ jobs:
     executor: default
     steps:
       - checkout
+      - install-dependencies
       - run:
           name: Lint check
           command: just lint-links

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,25 +5,23 @@ orbs:
   utils: ethereum-optimism/circleci-utils@0.0.12
 
 executors:
-  base:
+  default:
     machine:
-      image: ubuntu-2404:current
-  builder:
-    docker:
-      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder-rust:22ebfb824d959a27a372cca10fe39aeb0b610343
+      image: ubuntu-2204:2024.08.1
 
 commands:
   install-dependencies:
-    description: Install dependencies
     steps:
-      # We enable corepack, a nodejs package manager manager
-      # that is reponsible for automatically determining the correct version of pnpm to use
       - run:
-          name: Enable corepack
-          command: corepack enable
+          name: Install mise
+          command: curl https://mise.run | MISE_INSTALL_PATH=/home/circleci/bin/mise sh
       - run:
-          name: Install dependencies
-          command: just deps
+          name: Activate mise
+          command: echo 'eval "$(mise activate bash)"' >> $BASH_ENV
+      - run:
+          name: Install mise dependencies
+          command: mise install
+
   notify-failures-on-develop:
     description: "Notify Slack"
     parameters:
@@ -39,7 +37,7 @@ commands:
 
 jobs:
   lint-specs:
-    executor: builder
+    executor: default
     steps:
       - checkout
       - run:
@@ -50,7 +48,7 @@ jobs:
           command: just lint-specs-toc-check
 
   lint-links:
-    executor: builder
+    executor: default
     steps:
       - checkout
       - run:
@@ -60,7 +58,7 @@ jobs:
           channel: C055R639XT9 #notify-link-check
 
   build-book:
-    executor: builder
+    executor: default
     steps:
       - checkout
       - install-dependencies
@@ -76,7 +74,7 @@ jobs:
             - html
 
   publish-book:
-    executor: base
+    executor: default
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,7 @@ workflows:
     jobs:
       - lint-specs
       - build-book
+  
   scheduled-links-check:
     when:
       equal: [build_daily, <<pipeline.schedule.name>>]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,9 +10,18 @@ executors:
       image: ubuntu-2204:2022.07.1
   builder:
     docker:
-      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder-rust:v0.35.0
+      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder-rust:22ebfb824d959a27a372cca10fe39aeb0b610343
 
 commands:
+  install-dependencies:
+    description: Install dependencies
+    steps:
+      - run:
+          name: Enable corepack
+          command: corepack enable
+      - run:
+          name: Install dependencies
+          command: just deps
   notify-failures-on-develop:
     description: "Notify Slack"
     parameters:
@@ -31,9 +40,7 @@ jobs:
     executor: builder
     steps:
       - checkout
-      - run:
-          name: Install deps
-          command: just deps
+      - install-dependencies
       - run:
           name: markdown lint
           command: just lint-specs-md-check
@@ -58,9 +65,7 @@ jobs:
     executor: builder
     steps:
       - checkout
-      - run:
-          name: Install dependencies
-          command: just deps
+      - install-dependencies
       - run:
           name: Build
           command: just build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,8 @@ workflows:
   publish:
     jobs:
       - publish-pages:
+          context: 
+            - circleci-repo-specs
           filters: 
             branches:
               only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,6 @@ jobs:
       - utils/get-github-access-token
       - utils/github-pages-deploy:
           src-pages-dir: /tmp/book/html
-          pages-branch: gh-pages-test
 
 workflows:
   specs-check:
@@ -109,6 +108,6 @@ workflows:
             - build-book
           context: 
             - circleci-repo-specs
-          # filters: 
-          #   branches:
-          #     only: main
+          filters: 
+            branches:
+              only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   slack: circleci/slack@4.10.1
-  utils: ethereum-optimism/circleci-utils@0.0.11
+  utils: ethereum-optimism/circleci-utils@0.0.12
 
 executors:
   base:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,12 +102,12 @@ workflows:
 
   publish:
     jobs:
-      - build-book
+      - build-book:
+          filters: 
+            branches:
+              only: main
       - publish-book:
           requires:
             - build-book
           context: 
             - circleci-repo-specs
-          filters: 
-            branches:
-              only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
       - notify-failures-on-develop:
           channel: C055R639XT9 #notify-link-check
 
-  publish-pages:
+  build-pages:
     executor: builder
     steps:
       - checkout
@@ -72,9 +72,22 @@ jobs:
       - run:
           name: Add CNAME file
           command: echo "specs.optimism.io" > ./book/html/CNAME
+      - persist_to_workspace:
+          root: ./book
+          paths:
+            - html
+
+  publish-pages:
+    executor: base
+    steps:
+      - attach_workspace:
+          at: /tmp/book
+      - run:
+          name: List
+          command: ls -al /tmp/book
       - utils/get-github-access-token
       - utils/github-pages-deploy:
-          src-pages-dir: ./book/html
+          src-pages-dir: /tmp/book/html
           pages-branch: gh-pages-test
 
 workflows:
@@ -93,7 +106,10 @@ workflows:
 
   publish:
     jobs:
+      - build-pages
       - publish-pages:
+          requires:
+            - build-pages
           context: 
             - circleci-repo-specs
           # filters: 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 executors:
   base:
     machine:
-      image: ubuntu-2204:2022.07.1
+      image: ubuntu-2404:current
   builder:
     docker:
       - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder-rust:22ebfb824d959a27a372cca10fe39aeb0b610343
@@ -16,6 +16,8 @@ commands:
   install-dependencies:
     description: Install dependencies
     steps:
+      # We enable corepack, a nodejs package manager manager
+      # that is reponsible for automatically determining the correct version of pnpm to use
       - run:
           name: Enable corepack
           command: corepack enable
@@ -37,19 +39,15 @@ commands:
 
 jobs:
   lint-specs:
-    executor: builder
+    executor: base
     steps:
       - checkout
-      - install-dependencies
       - run:
           name: markdown lint
           command: just lint-specs-md-check
       - run:
           name: markdown toc
           command: just lint-specs-toc-check
-      - run:
-          name: build book
-          command: just build
 
   lint-links:
     executor: base
@@ -61,7 +59,7 @@ jobs:
       - notify-failures-on-develop:
           channel: C055R639XT9 #notify-link-check
 
-  build-pages:
+  build-book:
     executor: builder
     steps:
       - checkout
@@ -77,18 +75,15 @@ jobs:
           paths:
             - html
 
-  publish-pages:
+  publish-book:
     executor: base
     steps:
+      - checkout
       - attach_workspace:
           at: /tmp/book
-      - run:
-          name: List
-          command: ls -al /tmp/book
       - utils/get-github-access-token
       - utils/github-pages-deploy:
           src-pages-dir: /tmp/book/html
-          pages-branch: gh-pages-test
 
 workflows:
   specs-check:
@@ -97,6 +92,7 @@ workflows:
         equal: [scheduled_pipeline, << pipeline.trigger_source >>]
     jobs:
       - lint-specs
+      - build-book
   scheduled-links-check:
     when:
       equal: [build_daily, <<pipeline.schedule.name>>]
@@ -106,10 +102,10 @@ workflows:
 
   publish:
     jobs:
-      - build-pages
-      - publish-pages:
+      - build-book
+      - publish-book:
           requires:
-            - build-pages
+            - build-book
           context: 
             - circleci-repo-specs
           # filters: 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,7 @@ jobs:
       - utils/get-github-access-token
       - utils/github-pages-deploy:
           src-pages-dir: /tmp/book/html
+          pages-branch: gh-pages-test
 
 workflows:
   specs-check:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,17 @@
 version: 2.1
+
 orbs:
   slack: circleci/slack@4.10.1
-parameters:
-  ci_builder_image:
-    type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.35.0
-  base_image:
-    type: string
-    default: ubuntu-2204:2022.07.1
+  utils: ethereum-optimism/circleci-utils@0.0.11
+
+executors:
+  base:
+    machine:
+      image: ubuntu-2204:2022.07.1
+  builder:
+    docker:
+      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder-rust:v0.35.0
+
 commands:
   notify-failures-on-develop:
     description: "Notify Slack"
@@ -21,15 +25,12 @@ commands:
           event: fail
           template: basic_fail_1
           branch_pattern: develop
+
 jobs:
   lint-specs:
-    docker:
-      - image: <<pipeline.parameters.ci_builder_image>>
+    executor: builder
     steps:
       - checkout
-      - run:
-          name: Install pnpm
-          command: npm install -g pnpm@9.1.0
       - run:
           name: Install deps
           command: just deps
@@ -42,9 +43,9 @@ jobs:
       - run:
           name: build book
           command: just build
+
   lint-links:
-    machine:
-      image: <<pipeline.parameters.base_image>>
+    executor: base
     steps:
       - checkout
       - run:
@@ -52,6 +53,24 @@ jobs:
           command: just lint-links
       - notify-failures-on-develop:
           channel: C055R639XT9 #notify-link-check
+
+  publish-pages:
+    executor: builder
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: just deps
+      - run:
+          name: Build
+          command: just build
+      - run:
+          name: Add CNAME file
+          command: echo "specs.optimism.io" > ./book/html/CNAME
+      - utils/get-github-access-token
+      - utils/github-pages-deploy:
+          src-pages-dir: ./book/html
+
 workflows:
   specs-check:
     when:
@@ -65,3 +84,10 @@ workflows:
     jobs:
       - lint-links:
           context: slack
+
+  publish:
+    jobs:
+      - publish-pages:
+          filters: 
+            branches:
+              only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ commands:
 
 jobs:
   lint-specs:
-    executor: base
+    executor: builder
     steps:
       - checkout
       - run:
@@ -50,7 +50,7 @@ jobs:
           command: just lint-specs-toc-check
 
   lint-links:
-    executor: base
+    executor: builder
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,7 @@ jobs:
       - utils/get-github-access-token
       - utils/github-pages-deploy:
           src-pages-dir: ./book/html
+          pages-branch: gh-pages-test
 
 workflows:
   specs-check:
@@ -95,6 +96,6 @@ workflows:
       - publish-pages:
           context: 
             - circleci-repo-specs
-          filters: 
-            branches:
-              only: main
+          # filters: 
+          #   branches:
+          #     only: main

--- a/README.md
+++ b/README.md
@@ -19,6 +19,26 @@ We welcome your contributions. Read through [CONTRIBUTING.md](./CONTRIBUTING.md)
 
 ### Dependencies
 
+#### Using `mise`
+
+We use [`mise`](https://mise.jdx.dev/) as a dependency manager for these tools.
+Once properly installed, `mise` will provide the correct versions for each tool. `mise` does not
+replace any other installations of these binaries and will only serve these binaries when you are
+working inside of the `optimism` directory.
+
+##### Install `mise`
+
+Install `mise` by following the instructions provided on the
+[Getting Started page](https://mise.jdx.dev/getting-started.html#_1-install-mise-cli).
+
+##### Install dependencies
+
+```sh
+mise install
+```
+
+#### Manual installation
+
 **Rust Toolchain**
 
 ```sh

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,23 @@
+[tools]
+
+# Core dependencies
+rust = "1.83.0"
+just = "1.37.0"
+node = "20.9.0"
+
+# Cargo dependencies
+"cargo:mdbook" = "0.4.43"
+"cargo:mdbook-katex" = "0.9.2"
+"cargo:mdbook-linkcheck" = "0.7.7"
+"cargo:mdbook-mermaid" = "0.14.1"
+
+[hooks]
+postinstall = [
+    # Enabling corepack will install the `pnpm` package manager specified in package.json
+    'npx corepack enable',
+    'pnpm i --frozen-lockfile'
+]
+
+[settings]
+# Needs to be enabled for hooks to work
+experimental = true

--- a/package.json
+++ b/package.json
@@ -10,5 +10,6 @@
     "doctoc": "^2.2.1",
     "markdownlint-cli2": "0.4.0",
     "cspell": "^8.1.3"
-  }
+  },
+  "packageManager": "pnpm@9.15.4"
 }


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Migrates the GH Pages deployment workflow to CircleCI.

I also added `mise` as a dependency manager. `mise` is being used in the [optimism monorepo](https://github.com/ethereum-optimism/optimism/blob/develop/mise.toml) and provides a great way of managing tooling required for development.

It is an add-on, it does not break or affect any existing development flows, just provides a convenient way of setting up your development environment (as well as the CI environment).

- Adds the new `publish` workflow
  - The workflow is split into `build-book` and `publish-book` jobs to further restrict the access to the `circleci-repo-specs` security context
    - `build-book` does not need any secrets and will build the artifacts only
    - `publish-book` receives the artifacts and publishes them to GH Pages
 - Reused the `build-book` job for `specs-check` workflow instead of running `just build` as a step
 - Added a missing `packageManager` field to `package.json`

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

The workflow has been tested on a separate test branch, see [here](https://app.circleci.com/pipelines/github/ethereum-optimism/specs/2467)

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
