### PR TITLE
specs: Specify derivation of future tx types

### DIFF
--- a/specs/protocol/derivation.md
+++ b/specs/protocol/derivation.md
@@ -1300,12 +1300,12 @@ transaction's receipt as invalid.
 - If it's a known transaction type, that is, legacy (first byte of the encoding is in the range `[0xc0, 0xfe]`) or its
 first byte is in the range `[0, 4]` or `0x7e` (_deposited_), then it's not a _future transaction_ and we know how to
 decode the receipt and this process is irrelevant.
-- If a transaction's first byte is in the range `[5, 0x7d]`, it is expected to be a _future_ EIP-2718 transaction, so we can
-proceed to the receipt. Note that we excluded `0x7e` because that's the deposit transaction type, which is known.
-- The _future_ receipt encoding's first byte must be the same byte as the transaction encoding's first byte, or it is discarded
-as invalid, because we require it to be an EIP-2718-encoded receipt to continue.
-- The receipt payload is decoded as if it is encoded as `rlp([status, cumulative_transaction_gas_used, logs_bloom, logs])`,
-which is the encoding of the known non-legacy transaction types.
+- If a transaction's first byte is in the range `[5, 0x7d]`, it is expected to be a _future_ EIP-2718 transaction, so we
+can proceed to the receipt. Note that we excluded `0x7e` because that's the deposit transaction type, which is known.
+- The _future_ receipt encoding's first byte must be the same byte as the transaction encoding's first byte, or it is
+discarded as invalid, because we require it to be an EIP-2718-encoded receipt to continue.
+- The receipt payload is decoded as if it is encoded as `rlp([status, cumulative_transaction_gas_used, logs_bloom,
+logs])`, which is the encoding of the known non-legacy transaction types.
   - If this decoding fails, the transaction's receipt is discarded as invalid.
   - If this decoding succeeds, the `logs` have been obtained and can be processed as those of known transaction types.
 

--- a/specs/protocol/derivation.md
+++ b/specs/protocol/derivation.md
@@ -1298,12 +1298,12 @@ not _future_ transactions). We can then proceed as follows to get the logs of su
 transaction's receipt as invalid.
 
 - If it's a known transaction type, that is, legacy (first byte of the encoding is in the range `[0xc0, 0xfe]`) or its
-first byte is in the range `[0, 4]`, then it's not a _future transaction_ and we know how to decode the receipt and this
-process is irrelevant.
-- If a transaction's first byte is in the range `[5, 0x7f]`, it is expected to be a _future_ EIP-2718 transaction, so we can
-proceed to the receipt.
-- The receipt encoding's first byte must be the same byte as the transaction encoding's first byte, or it is discarded
-as invalid.
+first byte is in the range `[0, 4]` or `0x7e` (_deposited_), then it's not a _future transaction_ and we know how to
+decode the receipt and this process is irrelevant.
+- If a transaction's first byte is in the range `[5, 0x7d]`, it is expected to be a _future_ EIP-2718 transaction, so we can
+proceed to the receipt. Note that we excluded `0x7e` because that's the deposit transaction type, which is known.
+- The _future_ receipt encoding's first byte must be the same byte as the transaction encoding's first byte, or it is discarded
+as invalid, because we require it to be an EIP-2718-encoded receipt to continue.
 - The receipt payload is decoded as if it is encoded as `rlp([status, cumulative_transaction_gas_used, logs_bloom, logs])`,
 which is the encoding of the known non-legacy transaction types.
   - If this decoding fails, the transaction's receipt is discarded as invalid.

--- a/specs/protocol/derivation.md
+++ b/specs/protocol/derivation.md
@@ -499,6 +499,9 @@ transaction is one with the following properties:
 
 - The [`to`] field is equal to the configured batcher inbox address.
 
+- The transaction type is one of `0`, `1`, `2`, `3`, or `0x7e` (L2 [Deposited transaction type][g-deposit-tx-type], to
+  support force-inclusion of batcher transactions on nested OP Stack chains).
+
 - The sender, as recovered from the transaction signature (`v`, `r`, and `s`), is the batcher
   address loaded from the system config matching the L1 block of the data.
 
@@ -1013,6 +1016,12 @@ Refer to the [**deposit contract specification**][deposit-contract-spec] for det
 entries.
 
 [deposit-contract-spec]: deposits.md#deposit-contract
+
+Logs for all transaction types are parsed for deposits, also from possibly unknown transactions types like those that
+are considered invalid batcher transaction types, see [L1 Retrieval][#l1-retrieval]. However, they are parsed as if they
+were receipts for one of the known transactions types `0`, `1`, `2`, `3`, `4` and `0x7e`. If they fail this best-effort
+decoding process, they are dropped and considered invalid.
+The intention of this best-effort decoding is to future-proof the protocol for new L1 transaction types.
 
 ### Network upgrade automation transactions
 

--- a/specs/protocol/derivation.md
+++ b/specs/protocol/derivation.md
@@ -50,6 +50,7 @@
         - [GasPriceOracle Enable Ecotone](#gaspriceoracle-enable-ecotone)
         - [Beacon block roots contract deployment (EIP-4788)](#beacon-block-roots-contract-deployment-eip-4788)
   - [Building Individual Payload Attributes](#building-individual-payload-attributes)
+  - [On Future-Proof Transaction Log Derivation](#on-future-proof-transaction-log-derivation)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/specs/protocol/derivation.md
+++ b/specs/protocol/derivation.md
@@ -1293,16 +1293,15 @@ As described in [L1 Retrieval][#l1-retrieval], batcher transactions' types are r
 However, we want to allow deposit transactions and `SystemConfig` update events to get derived even from receipts of
 future transaction types, as long as the receipts can be decoded following a best-effort process:
 
-As long as a future transaction type follows the [EIP-2718][https://eips.ethereum.org/EIPS/eip-2718] specification,
-the type can be decoded as the first byte of an encoded transaction or receipt (excluding legacy transactions, which are
-not _future_ transactions). We can then proceed as follows to get the logs of such a future transaction, or discard the
-transaction's receipt as invalid.
+As long as a future transaction type follows the [EIP-2718][https://eips.ethereum.org/EIPS/eip-2718] specification, the
+type can be decoded from the first byte of the transaction's (or its receipt's) binary encoding. We can then proceed as
+follows to get the logs of such a future transaction, or discard the transaction's receipt as invalid.
 
 - If it's a known transaction type, that is, legacy (first byte of the encoding is in the range `[0xc0, 0xfe]`) or its
 first byte is in the range `[0, 4]` or `0x7e` (_deposited_), then it's not a _future transaction_ and we know how to
 decode the receipt and this process is irrelevant.
-- If a transaction's first byte is in the range `[5, 0x7d]`, it is expected to be a _future_ EIP-2718 transaction, so we
-can proceed to the receipt. Note that we excluded `0x7e` because that's the deposit transaction type, which is known.
+- If a transaction's first byte is in the range `[0x05, 0x7d]`, it is expected to be a _future_ EIP-2718 transaction, so
+we can proceed to the receipt. Note that we excluded `0x7e` because that's the deposit transaction type, which is known.
 - The _future_ receipt encoding's first byte must be the same byte as the transaction encoding's first byte, or it is
 discarded as invalid, because we require it to be an EIP-2718-encoded receipt to continue.
 - The receipt payload is decoded as if it is encoded as `rlp([status, cumulative_transaction_gas_used, logs_bloom,

--- a/specs/protocol/system-config.md
+++ b/specs/protocol/system-config.md
@@ -163,3 +163,9 @@ The contained log events are filtered and processed as follows:
 Note that individual derivation stages may be processing different L1 blocks,
 and should thus maintain individual system configuration copies,
 and apply the event-based changes as the stage traverses to the next L1 block.
+
+Logs for all transaction types are parsed for `SystemConfig` events, also from possibly unknown transactions types like
+those that are considered invalid batcher transaction types, see [L1 Retrieval][derivation.md#l1-retrieval]. However,
+they are parsed as if they were receipts for one of the known transactions types `0`, `1`, `2`, `3`, `4` and `0x7e`. If
+they fail this best-effort decoding process, they are dropped and considered invalid.
+The intention of this best-effort decoding is to future-proof the protocol for new L1 transaction types.

--- a/specs/protocol/system-config.md
+++ b/specs/protocol/system-config.md
@@ -144,6 +144,9 @@ A rollup node initializes its derivation process by finding a starting point bas
 After preparing the initial system configuration for the given L1 starting input,
 the system configuration is updated by processing all receipts from each new L1 block.
 
+Logs are derived from transactions following the future-proof best-effort process described in
+[On Future-Proof Transaction Log Derivation][derivation.md#on-future-proof-transaction-log-derivation]
+
 The contained log events are filtered and processed as follows:
 
 - the log event contract address must match the rollup `SystemConfig` deployment
@@ -163,9 +166,3 @@ The contained log events are filtered and processed as follows:
 Note that individual derivation stages may be processing different L1 blocks,
 and should thus maintain individual system configuration copies,
 and apply the event-based changes as the stage traverses to the next L1 block.
-
-Logs for all transaction types are parsed for `SystemConfig` events, also from possibly unknown transactions types like
-those that are considered invalid batcher transaction types, see [L1 Retrieval][derivation.md#l1-retrieval]. However,
-they are parsed as if they were receipts for one of the known transactions types `0`, `1`, `2`, `3`, `4` and `0x7e`. If
-they fail this best-effort decoding process, they are dropped and considered invalid.
-The intention of this best-effort decoding is to future-proof the protocol for new L1 transaction types.


### PR DESCRIPTION
**Description**

Clarifies how to deal with 7702 and future transactions.

- batcher tx must be of type `0-3`, or `0x7e`, but _not_ `4`, that is, 7702 txs.
- we allow 7702 txs, and possibly other future txs with similarly encoded logs, for user deposits on L1 and SystemConfig configuration tx

**Metadata**

Part of https://github.com/ethereum-optimism/optimism/issues/13627
