### PR TITLE
Recommended fixes for specs/interop/messaging.md and specs/interop/predeploys.md

### DIFF
--- a/specs/interop/derivation.md
+++ b/specs/interop/derivation.md
@@ -117,7 +117,7 @@ When the [cross chain dependency resolution](./messaging.md#resolving-cross-chai
 that a block contains an [invalid message](./messaging.md#invalid-messages), the block is replaced
 by a block with the same inputs, except for the transactions included. The transactions from the
 original block are trimmed to include only deposit transactions plus an
-[optimistic block info deposit transaction](#optimistic-block-deposited-transaction) which is appended
+[optimistic block info deposit transaction](#optimistic-block-deposited-transaction), which is appended
 to the trimmed transaction list.
 
 ### Optimistic Block Deposited Transaction

--- a/specs/interop/derivation.md
+++ b/specs/interop/derivation.md
@@ -122,7 +122,8 @@ to the trimmed transaction list.
 
 ### Optimistic Block Deposited Transaction
 
-An [L1 attributes deposited transaction](../protocol/deposits.md#l1-attributes-deposited-transaction) is a deposit transaction sent to the zero address.
+An [L1 attributes deposited transaction](../protocol/deposits.md#l1-attributes-deposited-transaction)
+is a deposit transaction sent to the zero address.
 
 This transaction MUST have the following values:
 

--- a/specs/interop/derivation.md
+++ b/specs/interop/derivation.md
@@ -122,9 +122,6 @@ to the trimmed transaction list.
 
 ### Optimistic Block Deposited Transaction
 
-[l1-attr-deposit]: ../protocol/deposits.md#l1-attributes-deposited-transaction
-[l2-output-root-proposals]: ../protocol/proposals.md#l2-output-commitment-construction
-
 An [L1 attributes deposited transaction](../protocol/deposits.md#l1-attributes-deposited-transaction) is a deposit transaction sent to the zero address.
 
 This transaction MUST have the following values:

--- a/specs/interop/derivation.md
+++ b/specs/interop/derivation.md
@@ -125,7 +125,7 @@ to the trimmed transaction list.
 [l1-attr-deposit]: ../protocol/deposits.md#l1-attributes-deposited-transaction
 [l2-output-root-proposals]: ../protocol/proposals.md#l2-output-commitment-construction
 
-An [L1 attributes deposited transaction](l1-attr-deposit) is a deposit transaction sent to the zero address.
+An [L1 attributes deposited transaction](../protocol/deposits.md#l1-attributes-deposited-transaction) is a deposit transaction sent to the zero address.
 
 This transaction MUST have the following values:
 

--- a/specs/interop/derivation.md
+++ b/specs/interop/derivation.md
@@ -122,15 +122,15 @@ to the trimmed transaction list.
 
 ### Optimistic Block Deposited Transaction
 
-[l1-attr-deposit]: #l1-attributes-deposited-transaction
+[l1-attr-deposit]: ../protocol/deposits.md#l1-attributes-deposited-transaction
 [l2-output-root-proposals]: ../protocol/proposals.md#l2-output-commitment-construction
 
-An [L1 attributes deposited transaction][g-l1-attr-deposit] is a deposit transaction sent to the zero address.
+An [L1 attributes deposited transaction](l1-attr-deposit) is a deposit transaction sent to the zero address.
 
 This transaction MUST have the following values:
 
 1. `from` is `0xdeaddeaddeaddeaddeaddeaddeaddeaddead0002` (the address of the
-   [L1 Attributes depositor account][depositor-account])
+   [L1 Attributes depositor account](../protocol/deposits.md#l1-attributes-depositor-account))
 2. `to` is `0x0000000000000000000000000000000000000000` (the zero address as no EVM code execution is expected).
 3. `mint` is `0`
 4. `value` is `0`

--- a/specs/interop/fault-proof.md
+++ b/specs/interop/fault-proof.md
@@ -17,7 +17,7 @@ The fault proof design is not complete, but the following docs show high level o
 ## Cascading dependencies
 
 Deposits are a special case, synchronous with derivation, at enforced cross-L2 delay.
-Thus deposits cannot reference each others events intra-block.
+Thus deposits cannot reference each other's events intra-block.
 
 No changes to the dispute game bisection are required. The only changes required are to the fault proof program itself.
 The insight is that the fault proof program can be a superset of the state transition function.

--- a/specs/interop/messaging.md
+++ b/specs/interop/messaging.md
@@ -129,7 +129,7 @@ do not count as executing messages.
 
 ### Timestamp Invariant
 
-The timestamp invariant ensures that initiating messages is at least the same timestamp as the Interop upgrade timestamp
+The timestamp invariant ensures that initiating messages have at least the same timestamp as the Interop upgrade timestamp
 and cannot come from a future block than the block of its executing message. Note that since
 all transactions in a block have the same timestamp, it is possible for an executing transaction to be
 ordered before the initiating message in the same block.

--- a/specs/interop/messaging.md
+++ b/specs/interop/messaging.md
@@ -209,7 +209,6 @@ may have dependencies on one another.
 
 To determine cross-chain safety, the graph is inspected for valid graph components that have no invalid dependencies,
 while applying the respective safety-view on the blocks in the graph.
-
 I.e., the graph must not have any inward edges towards invalid blocks within the safety-view.
 
 A safety-view is the subset of canonical blocks of all chains with the specified safety label or a higher safety label.

--- a/specs/interop/messaging.md
+++ b/specs/interop/messaging.md
@@ -210,7 +210,7 @@ may have dependencies on one another.
 To determine cross-chain safety, the graph is inspected for valid graph components that have no invalid dependencies,
 while applying the respective safety-view on the blocks in the graph.
 
-I.e. the graph must not have any inward edges towards invalid blocks within the safety-view.
+I.e., the graph must not have any inward edges towards invalid blocks within the safety-view.
 
 A safety-view is the subset of canonical blocks of all chains with the specified safety label or a higher safety label.
 Dependencies on blocks outside of the safety-view are invalid,

--- a/specs/interop/messaging.md
+++ b/specs/interop/messaging.md
@@ -88,8 +88,8 @@ exact state of the block templates between multiple chains together.
 
 [log]: https://github.com/ethereum/go-ethereum/blob/5c67066a050e3924e1c663317fd8051bc8d34f43/core/types/log.go#L29
 
-Each [Log][log] (also known as `event` in solidity) forms an initiating message.
-The raw log data from the [Message Payload](#message-payload).
+Each [Log][log] (also known as `event` in solidity) forms an initiating message,
+with the raw log data coming from the [Message Payload](#message-payload).
 
 Messages are *broadcast*: the protocol does not enshrine address-targeting within messages.
 

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -665,6 +665,7 @@ The `convert` function conserves the following invariants:
 ---
 config:
   theme: dark
+  fontSize: 28
 ---
 sequenceDiagram
   participant Alice
@@ -760,6 +761,11 @@ event RelayedERC20(address indexed tokenAddress, address indexed from, address i
 The following diagram depicts a cross-chain transfer.
 
 ```mermaid
+---
+config:
+  theme: dark
+  fontSize: 48
+---
 sequenceDiagram
   participant from
   participant L2SBA as SuperchainTokenBridge (Chain A)

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -348,7 +348,7 @@ getters.
 
 The `OptimismSuperchainERC20Factory` creates ERC20 contracts that implements the `SuperchainERC20` [standard](token-bridging.md),
 grants mint-burn rights to the `L2StandardBridge` (`OptimismSuperchainERC20`)
-and include a `remoteToken` variable.
+and includes a `remoteToken` variable.
 These ERC20s are called `OptimismSuperchainERC20` and can be converted back and forth with `OptimismMintableERC20` tokens.
 The goal of the `OptimismSuperchainERC20` is to extend functionalities
 of the `OptimismMintableERC20` so that they are interop compatible.

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -248,7 +248,7 @@ function sendMessage(uint256 _destination, address _target, bytes calldata _mess
 ```
 
 It returns the hash of the message being sent,
-which isused to track whether the message has successfully been relayed.
+which is used to track whether the message has successfully been relayed.
 It also emits a `SentMessage` event with the necessary metadata to execute when relayed on the destination chain.
 
 ```solidity

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -203,7 +203,7 @@ properties about the `_msg`.
 The `L2ToL2CrossDomainMessenger` is a higher level abstraction on top of the `CrossL2Inbox` that
 provides general message passing, utilized for secure transfers ERC20 tokens between L2 chains.
 Messages sent through the `L2ToL2CrossDomainMessenger` on the source chain receive both replay protection
-as well as domain binding, ie the executing transaction can only be valid on a single chain.
+as well as domain binding, i.e. the executing transaction can only be valid on a single chain.
 
 ### `relayMessage` Invariants
 

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -307,8 +307,8 @@ chain. The hash of the message is used for replay protection.
 It is important to ensure that the source chain is in the dependency set of the destination chain, otherwise
 it is possible to send a message that is not playable.
 
-A message is relayed by providing the [identifier](./messaging.md#message-identifier) to a `SentMessage`
-event and its corresponding [message payload](./messaging.md#message-payload).
+A message is relayed by providing the [identifier](./messaging.md#message-identifier) of a `SentMessage`
+event along with its corresponding [message payload](./messaging.md#message-payload).
 
 ```solidity
 function relayMessage(ICrossL2Inbox.Identifier calldata _id, bytes calldata _sentMessage) external payable returns (bytes memory returnData_) {

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -235,7 +235,7 @@ See [SuperchainWETH](./superchain-weth.md) for more information.
 
 ### Interfaces
 
-The `L2ToL2CrossDomainMessenger` uses a similar interface to the `L2CrossDomainMessenger` but
+The `L2ToL2CrossDomainMessenger` uses a similar interface to the `L2CrossDomainMessenger`, but
 the `_minGasLimit` is removed to prevent complexity around EVM gas introspection and the `_destination`
 chain is included instead.
 

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -823,7 +823,7 @@ The bridging of `SuperchainERC20` using the `SuperchainTokenBridge` will require
   - A way to allow for remotely initiated bridging is to include remote approval,
     i.e. approve a certain address in a certain chainId to spend local funds.
 - Bridge Events:
-  - `sendERC20()` should emit a `SentERC20` event. `
+  - `sendERC20()` should emit a `SentERC20` event.
   - `relayERC20()` should emit a `RelayedERC20` event.
 
 ## Security Considerations

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -580,7 +580,7 @@ This function exists for backwards compatibility with the legacy version.
 #### `OptimismMintableERC20Created`
 
 It MUST trigger when `createOptimismMintableERC20WithDecimals`,
-`createOptimismMintableERC20` or `createStandardL2Token` are called.
+`createOptimismMintableERC20` or `createStandardL2Token` is called.
 
 ```solidity
 event OptimismMintableERC20Created(address indexed localToken, address indexed remoteToken, address deployer);
@@ -589,7 +589,7 @@ event OptimismMintableERC20Created(address indexed localToken, address indexed r
 #### `StandardL2TokenCreated`
 
 It MUST trigger when `createOptimismMintableERC20WithDecimals`,
-`createOptimismMintableERC20` or `createStandardL2Token` are called.
+`createOptimismMintableERC20` or `createStandardL2Token` is called.
 This event exists for backward compatibility with legacy version.
 
 ```solidity

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -248,8 +248,8 @@ function sendMessage(uint256 _destination, address _target, bytes calldata _mess
 ```
 
 It returns the hash of the message being sent,
-used to track whether the message has successfully been relayed.
-It emits a `SentMessage` event with the necessary metadata to execute when relayed on the destination chain.
+which isused to track whether the message has successfully been relayed.
+It also emits a `SentMessage` event with the necessary metadata to execute when relayed on the destination chain.
 
 ```solidity
 event SentMessage(uint256 indexed destination, address indexed target, uint256 indexed messageNonce, address sender, bytes message);

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -301,7 +301,7 @@ flowchart LR
 ```
 
 When relaying a message through the `L2ToL2CrossDomainMessenger`, it is important to require that
-the `_destination` equal to `block.chainid` to ensure that the message is only valid on a single
+the `_destination` be equal to `block.chainid` to ensure that the message is only valid on a single
 chain. The hash of the message is used for replay protection.
 
 It is important to ensure that the source chain is in the dependency set of the destination chain, otherwise

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -662,6 +662,10 @@ The `convert` function conserves the following invariants:
 ### Conversion Flow
 
 ```mermaid
+---
+config:
+  theme: dark
+---
 sequenceDiagram
   participant Alice
   participant L2StandardBridge

--- a/specs/interop/superchain-weth.md
+++ b/specs/interop/superchain-weth.md
@@ -123,12 +123,14 @@ but does not preclude a protocol-layer solution as long as we minimize implement
 
 #### Global Invariants
 
-- Initial balance must be set to `type(uint248).max` (wei). 
+- Initial balance must be set to `type(uint248).max` (wei).
 The purpose for using `type(uint248).max` is to guarantee that
-the balance will be sufficient to credit all use within the `SuperchainWETH` contract, but will never overflow on calls
-to `burn` because there is not enough ETH in the total ETH supply to cause such an overflow. The invariant that avoids overflow is
-maintained by  `SuperchainWETH`, but could theoretically be broken by some future contract that is allowed to integrate
-with `ETHLiquidity`. Maintainers should be careful to ensure that such future contracts do not break this invariant.
+the balance will be sufficient to credit all use within the `SuperchainWETH` contract, 
+but will never overflow on calls to `burn` because there is not enough ETH 
+in the total ETH supply to cause such an overflow. 
+The invariant that avoids overflow is maintained by  `SuperchainWETH`, but could theoretically 
+be broken by some future contract that is allowed to integrate with `ETHLiquidity`. Maintainers should be careful to 
+ensure that such future contracts do not break this invariant.
 
 #### `burn`
 

--- a/specs/interop/superchain-weth.md
+++ b/specs/interop/superchain-weth.md
@@ -123,7 +123,8 @@ but does not preclude a protocol-layer solution as long as we minimize implement
 
 #### Global Invariants
 
-- Initial balance must be set to `type(uint248).max` (wei). The purpose for using `type(uint248).max` is to guarantee that
+- Initial balance must be set to `type(uint248).max` (wei). 
+The purpose for using `type(uint248).max` is to guarantee that
 the balance will be sufficient to credit all use within the `SuperchainWETH` contract, but will never overflow on calls
 to `burn` because there is not enough ETH in the total ETH supply to cause such an overflow. The invariant that avoids overflow is
 maintained by  `SuperchainWETH`, but could theoretically be broken by some future contract that is allowed to integrate

--- a/specs/interop/superchain-weth.md
+++ b/specs/interop/superchain-weth.md
@@ -125,11 +125,11 @@ but does not preclude a protocol-layer solution as long as we minimize implement
 
 - Initial balance must be set to `type(uint248).max` (wei).
 The purpose for using `type(uint248).max` is to guarantee that
-the balance will be sufficient to credit all use within the `SuperchainWETH` contract, 
-but will never overflow on calls to `burn` because there is not enough ETH 
-in the total ETH supply to cause such an overflow. 
-The invariant that avoids overflow is maintained by  `SuperchainWETH`, but could theoretically 
-be broken by some future contract that is allowed to integrate with `ETHLiquidity`. Maintainers should be careful to 
+the balance will be sufficient to credit all use within the `SuperchainWETH` contract,
+but will never overflow on calls to `burn` because there is not enough ETH
+in the total ETH supply to cause such an overflow.
+The invariant that avoids overflow is maintained by  `SuperchainWETH`, but could theoretically
+be broken by some future contract that is allowed to integrate with `ETHLiquidity`. Maintainers should be careful to
 ensure that such future contracts do not break this invariant.
 
 #### `burn`

--- a/specs/interop/superchain-weth.md
+++ b/specs/interop/superchain-weth.md
@@ -123,10 +123,10 @@ but does not preclude a protocol-layer solution as long as we minimize implement
 
 #### Global Invariants
 
-- Initial balance must be set to `type(uint248).max` (wei). Purpose for using `type(uint248).max` is to guarantees that
-the balance will be sufficient to credit all use within the `SuperchainWETH` contract but will never overflow on calls
-to `burn` because there is not ETH in the total ETH supply to cause such an overflow. Invariant that avoids overflow is
-maintained by  `SuperchainWETH` but could theoretically be broken by some future contract that is allowed to integrate
+- Initial balance must be set to `type(uint248).max` (wei). The purpose for using `type(uint248).max` is to guarantee that
+the balance will be sufficient to credit all use within the `SuperchainWETH` contract, but will never overflow on calls
+to `burn` because there is not enough ETH in the total ETH supply to cause such an overflow. The invariant that avoids overflow is
+maintained by  `SuperchainWETH`, but could theoretically be broken by some future contract that is allowed to integrate
 with `ETHLiquidity`. Maintainers should be careful to ensure that such future contracts do not break this invariant.
 
 #### `burn`

--- a/specs/interop/token-bridging.md
+++ b/specs/interop/token-bridging.md
@@ -267,8 +267,8 @@ sequenceDiagram
   Messenger_B->>to: call(data)
 ```
 
-Adding the call to the standard would remove the dependence on the sequencer for 
-proper transaction ordering at the sequencer level. 
-However, it would also introduce additional risks for cross-chain fund transfers. 
-Specifically, an incorrectly formatted call could burn funds on the initiating chain, 
-but revert on the destination chain, and could never be successfully replayed."
+Adding the call to the standard would remove the dependence on the sequencer for
+proper transaction ordering at the sequencer level.
+However, it would also introduce additional risks for cross-chain fund transfers.
+Specifically, an incorrectly formatted call could burn funds on the initiating chain,
+but revert on the destination chain, and could never be successfully replayed.

--- a/specs/interop/token-bridging.md
+++ b/specs/interop/token-bridging.md
@@ -116,9 +116,9 @@ The `SuperchainERC20Bridge` includes two functions for bridging:
 - `sendERC20`: initializes a cross-chain transfer of a `SuperchainERC20`
   by burning the tokens locally and sending a message to the `SuperchainERC20Bridge`
   on the target chain using the `L2toL2CrossDomainMessenger`.
-  Additionaly, it returns the `msgHash_` crafted by the `L2toL2CrossDomainMessenger`.
-- `relayERC20`: process incoming messages from the `L2toL2CrossDomainMessenger`
-  and mints the corresponding amount of the `SuperchainERC20`
+  Additionally, it returns the `msgHash_` crafted by the `L2toL2CrossDomainMessenger`.
+- `relayERC20`: processes incoming messages from the `L2toL2CrossDomainMessenger`
+  and mints the corresponding amount of the `SuperchainERC20`.
 
 The full specifications and invariants are detailed
 in the [predeploys spec](./predeploys.md#superchainerc20bridge).

--- a/specs/interop/token-bridging.md
+++ b/specs/interop/token-bridging.md
@@ -199,6 +199,11 @@ For the moment, the standard will not include any specific functionality
 to facilitate such an action and rely on the usage of `Permit2` like this:
 
 ```mermaid
+---
+config:
+  theme: dark
+  fontSize: 48 
+---
 sequenceDiagram
   participant from
   participant Intermediate_A as Initiator
@@ -230,6 +235,11 @@ i.e. bridge funds and then do X.
 This vertical has much potential but can also be achieved outside the standard in the following way:
 
 ```mermaid
+---
+config:
+  theme: dark
+  fontSize: 48 
+---
 sequenceDiagram
   participant from
   participant Intermediate_A as intermediate A

--- a/specs/interop/token-bridging.md
+++ b/specs/interop/token-bridging.md
@@ -130,6 +130,11 @@ in the [predeploys spec](./predeploys.md#superchainerc20bridge).
 The following diagram depicts a cross-chain transfer.
 
 ```mermaid
+---
+config:
+  theme: dark
+  fontSize: 48 
+---
 sequenceDiagram
   participant from
   participant L2SBA as SuperchainERC20Bridge (Chain A)

--- a/specs/interop/token-bridging.md
+++ b/specs/interop/token-bridging.md
@@ -54,8 +54,8 @@ Otherwise, the `SuperchainERC20Bridge` would need a way to verify if the tokens 
 destination correspond to the tokens that were burned on source.
 Same address abstracts away cross-chain validation.
 
-One way to guarantee the same address across the Superchain, and also bind it to the same `init_code`
-and constructor arguments is to use the
+One way to guarantee the same address across the Superchain (and also bind it to the same `init_code`
+and constructor arguments) is to use the
 [`Create2Deployer` preinstall](../protocol/preinstalls.md#create2deployer).
 There is also the [`OptimismSuperchainERC20Factory`](predeploys.md#optimismmintableerc20factory)
 predeploy that facilitates this process for L1 native tokens.

--- a/specs/interop/token-bridging.md
+++ b/specs/interop/token-bridging.md
@@ -34,7 +34,7 @@ The `SuperchainERC20Bridge` is a predeploy that builds on the messaging protocol
 
 The standard will build on top of ERC20, implement the
 [`IERC7802`](https://github.com/ethereum/ERCs/pull/692)
-interface and include the following properties:
+interface, and include the following properties:
 
 1. Implement the [ERC20](https://eips.ethereum.org/EIPS/eip-20) interface
 2. Implement the [`ERC7802`](https://github.com/ethereum/ERCs/pull/692) interface

--- a/specs/interop/token-bridging.md
+++ b/specs/interop/token-bridging.md
@@ -232,7 +232,7 @@ additional call to the `_to` address.
 This feature could be used for cross-chain concatenated actions,
 i.e. bridge funds and then do X.
 
-This vertical has much potential but can also be achieved outside the standard in the following way:
+This approach has great potential but can also be achieved outside the standard in the following way:
 
 ```mermaid
 ---
@@ -267,7 +267,8 @@ sequenceDiagram
   Messenger_B->>to: call(data)
 ```
 
-Adding the call to the standard would remove the dependence on the sequencer regarding the proper tx ordering
-at the sequencer level, but would also introduce more risk for cross-chain fund transferring,
-as an incorrectly formatted call would burn funds in the initiating chain but would revert
-in destination and could never be successfully replayed.
+Adding the call to the standard would remove the dependence on the sequencer for 
+proper transaction ordering at the sequencer level. 
+However, it would also introduce additional risks for cross-chain fund transfers. 
+Specifically, an incorrectly formatted call could burn funds on the initiating chain, 
+but revert on the destination chain, and could never be successfully replayed."

--- a/specs/interop/token-bridging.md
+++ b/specs/interop/token-bridging.md
@@ -46,7 +46,7 @@ The third property will allow the `SuperchainERC20Bridge` to have a liquidity gu
 which would not be possible in a model based on lock/unlock.
 Liquidity availability is fundamental to achieving fungibility.
 
-SuperchainERC20Bridge does not have to be the exclusive caller of `crosschainMint` and `crosschainBurn`,
+SuperchainERC20Bridge does not have to be the exclusive caller of `crosschainMint` and `crosschainBurn`;
 other addresses may also be permitted to call these functions.
 
 The fourth property removes the need for cross-chain access control lists.

--- a/specs/interop/token-bridging.md
+++ b/specs/interop/token-bridging.md
@@ -50,7 +50,7 @@ SuperchainERC20Bridge does not have to be the exclusive caller of `crosschainMin
 other addresses may also be permitted to call these functions.
 
 The fourth property removes the need for cross-chain access control lists.
-Otherwise, the `SuperchainERC20Bridge` would need a way to verify if the tokens they mint on
+Otherwise, the `SuperchainERC20Bridge` would need a way to verify if the tokens it mints on
 destination correspond to the tokens that were burned on source.
 Same address abstracts away cross-chain validation.
 

--- a/specs/interop/tx-pool.md
+++ b/specs/interop/tx-pool.md
@@ -20,13 +20,13 @@ and inserted into the node's transaction pool before being broadcasted via p2p n
 
 Since there is little cost to sending invalid transactions over the p2p network maliciously,
 Ethereum opts to ensure that the transactions can be validated as cheaply as possible. This validation
-consists of a nonce and balance (fee payment) check which can be done with solely state lookups and
+consists of a nonce and a balance (fee payment) check, which can be done with solely state lookups and
 the chain tips block header. Features that make this validation more costly have been rejected from L1
 Ethereum due to the desire to ensure [commodity hardware](https://hackmd.io/@kevaundray/S1hUQuV4Jx) can
 easily participate in consensus.
 
-Layer twos can make more aggressive tradeoffs and raise the minimum hardware requirements of the network.
-With interop, it requires full EVM execution of the transaction to fully validate it.
+Layer twos can make more aggressive trade-offs and raise the minimum hardware requirements of the network. 
+However, with interop, full EVM execution of the transaction is required to fully validate it.
 
 ## Transaction validation
 

--- a/specs/interop/tx-pool.md
+++ b/specs/interop/tx-pool.md
@@ -25,7 +25,7 @@ the chain tips block header. Features that make this validation more costly have
 Ethereum due to the desire to ensure [commodity hardware](https://hackmd.io/@kevaundray/S1hUQuV4Jx) can
 easily participate in consensus.
 
-Layer twos can make more aggressive trade-offs and raise the minimum hardware requirements of the network. 
+Layer twos can make more aggressive trade-offs and raise the minimum hardware requirements of the network.
 However, with interop, full EVM execution of the transaction is required to fully validate it.
 
 ## Transaction validation

--- a/specs/interop/tx-pool.md
+++ b/specs/interop/tx-pool.md
@@ -20,7 +20,7 @@ and inserted into the node's transaction pool before being broadcasted via p2p n
 
 Since there is little cost to sending invalid transactions over the p2p network maliciously,
 Ethereum opts to ensure that the transactions can be validated as cheaply as possible. This validation
-consists of a nonce and a balance (fee payment) check, which can be done with solely state lookups and
+consists of a nonce and balance (fee payment) check, which can be done with solely state lookups and
 the chain tips block header. Features that make this validation more costly have been rejected from L1
 Ethereum due to the desire to ensure [commodity hardware](https://hackmd.io/@kevaundray/S1hUQuV4Jx) can
 easily participate in consensus.

--- a/specs/interop/tx-pool.md
+++ b/specs/interop/tx-pool.md
@@ -36,7 +36,7 @@ SHOULD be enforced before entry into the transaction pool.
 After each new block, each transaction in the transaction pool is checked for validity again.
 A transaction with a definitively invalid message-dependency SHOULD be "demoted" from the transaction pool.
 
-It is possible that a transaction that was valid becomes invalid or vice versa. The sequencer MAY choose
+It is possible that a transaction deemed valid becomes invalid or vice versa. The sequencer MAY choose
 to demote messages which are invalid but can still technically become valid.
 
 Transactions with invalid message-dependencies MUST NOT be included in block-building,

--- a/specs/interop/tx-pool.md
+++ b/specs/interop/tx-pool.md
@@ -64,5 +64,5 @@ the new deposit-context closing transaction (under 36,000 gas), and margin for e
 Since the validation of the executing message relies on a remote RPC request, this introduces a denial of
 service attack vector. The cost of network access is magnitudes larger than in memory validity checks.
 The mempool SHOULD perform low-cost checks before any sort of network access is performed.
-The results of the check SHOULD be cached such that another request does not need to be performed
-when building the block although consistency is not guaranteed.
+The results of the check SHOULD be cached, such that another request does not need to be performed
+when building the block, although consistency is not guaranteed.

--- a/specs/interop/verifier.md
+++ b/specs/interop/verifier.md
@@ -99,10 +99,10 @@ if the data is reorganized, then validators will be slashed.
 
 ### Honest Verifier
 
-The honest verifier follows a naive verification algorithm. That is similar
+The honest verifier follows a naive verification algorithm that is similar
 to the block building code that the [sequencer](./sequencer.md#direct-dependency-confirmation)
 follows. The main difference is that the validity of included executing
-messages is verified instead of verifying possible executing messages before
+messages is verified, instead of verifying possible executing messages before
 inclusion.
 
 ## Security Considerations

--- a/specs/interop/verifier.md
+++ b/specs/interop/verifier.md
@@ -70,9 +70,10 @@ particular software when building the block.
 - MUST have valid cross chain messages
 
 `cross-unsafe` represents the `unsafe` blocks that have had their cross chain messages fully verified.
-The network can be represented as a graph, where each block across all chains is represented as a node. A directed edge between two blocks indicates the source block of the initiating message and the block that includes the executing message."
+The network can be represented as a graph, where each block across all chains is represented as a node. 
+A directed edge between two blocks indicates the source block of the initiating message and the block that includes the executing message."
 
-An input can be promoted from `unsafe` to `cross-unsafe` when the full dependency graph is resolved
+An input can be promoted from `unsafe` to `cross-unsafe` when the full dependency graph is resolved,
 such that all cross chain messages are verified to be valid and at least one message in the dependency
 graph is still `unsafe`.
 

--- a/specs/interop/verifier.md
+++ b/specs/interop/verifier.md
@@ -70,7 +70,7 @@ particular software when building the block.
 - MUST have valid cross chain messages
 
 `cross-unsafe` represents the `unsafe` blocks that have had their cross chain messages fully verified.
-The network can be represented as a graph, where each block across all chains is represented as a node. 
+The network can be represented as a graph, where each block across all chains is represented as a node.
 A directed edge between two blocks indicates the source block of the initiating message and the block that includes the executing message."
 
 An input can be promoted from `unsafe` to `cross-unsafe` when the full dependency graph is resolved,

--- a/specs/interop/verifier.md
+++ b/specs/interop/verifier.md
@@ -69,10 +69,8 @@ particular software when building the block.
 
 - MUST have valid cross chain messages
 
-`cross-unsafe` represents the `unsafe` blocks that had their cross chain messages fully verified.
-The network can be represented as a graph where each block across all chains are represented as
-a node and then a directed edge between two blocks represents the source block of the initiating
-message and the block that included the executing message.
+`cross-unsafe` represents the `unsafe` blocks that have had their cross chain messages fully verified.
+The network can be represented as a graph, where each block across all chains is represented as a node. A directed edge between two blocks indicates the source block of the initiating message and the block that includes the executing message."
 
 An input can be promoted from `unsafe` to `cross-unsafe` when the full dependency graph is resolved
 such that all cross chain messages are verified to be valid and at least one message in the dependency

--- a/specs/interop/verifier.md
+++ b/specs/interop/verifier.md
@@ -24,7 +24,7 @@ to safe. A series of invariants are enforced before promotion.
 
 Safety is an abstraction that is useful for reasoning about the security of L2 blocks.
 It is a spectrum from `unsafe` to `finalized`. Users can choose to operate on L2 data
-based on its level of safety taking into account their risk profile and personal preferences.
+based on its level of safety, taking into account their risk profile and personal preferences.
 
 The following labels are used to describe both inputs and outputs:
 

--- a/specs/interop/verifier.md
+++ b/specs/interop/verifier.md
@@ -33,7 +33,7 @@ The following labels are used to describe both inputs and outputs:
 - `safe`
 - `finalized`
 
-Inputs correspond to the inputs to the state transition function while outputs correspond to the side
+Inputs correspond to the inputs to the state transition function while, outputs correspond to the side
 effects of the state transition function.
 
 Anything before `safe` technically uses a "preconfirmation" based security model which is not part

--- a/specs/interop/verifier.md
+++ b/specs/interop/verifier.md
@@ -71,7 +71,8 @@ particular software when building the block.
 
 `cross-unsafe` represents the `unsafe` blocks that have had their cross chain messages fully verified.
 The network can be represented as a graph, where each block across all chains is represented as a node.
-A directed edge between two blocks indicates the source block of the initiating message and the block that includes the executing message."
+A directed edge between two blocks indicates the source block of the initiating message
+and the block that includes the executing message."
 
 An input can be promoted from `unsafe` to `cross-unsafe` when the full dependency graph is resolved,
 such that all cross chain messages are verified to be valid and at least one message in the dependency


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

## Description

### Pull Request Summary:

This PR includes proofreading and formatting updates to specs/interop/messaging.md and specs/interop/predeploys.md, along with configuration adjustments to two Mermaid diagrams for better accessibility.

- **File Changes:**
  - **`specs/interop/messaging.md`:**
     - Clarified the sentence regarding raw log data by rephrasing it for better readability .
     - Corrected the phrase "initiating messages is" to "initiating messages have" for grammatical accuracy. 
     - Added a comma after "I.e." for consistency with standard punctuation rules.
 
    
  - **`specs/interop/predeploys.md`:**
    - Changed "ie" to "i.e." by adding periods for proper abbreviation.
    - Added a comma before "but" for clarity and consistency.
    - Added "which is" for clarity and "also" to improve sentence flow.
    - Corrected phrasing by changing "equal to" to "be equal to" for grammatical accuracy.
    - Rephrased a sentence by changing "to" to "of" for better clarity and accuracy.
    - Corrected a sentence by changing "include" to "includes" for subject-verb agreement.
    - Corrected a sentence by changing "are" to "is" to ensure subject-verb agreement when referring to "either `createOptimismMintableERC20` or `createStandardL2Token`".
    - Adjusted configurations for Mermaid graphs to **dark mode** and increased font size for better readability and accessibility.
       - Set `fontSize` to **28** for the first diagram and **48** for the second. The font sizing does not scale up for the second as it does for the first, possibly due to the diagram being more cluttered. The diagram with 48px actually displays a smaller font size. This can be revisited but for now it dramatically improves the accessibility of both diagrams.
    - Removed the extra backtick at the end of a sentence for proper formatting.

## Tests

- No new tests were added as part of this PR, as the changes are primarily focused on documentation, clarity, and visual accessibility improvements. All changes were reviewed for consistency, and no functional behavior was altered. The Mermaid configuration and grammar fixes do not impact existing functionality, so no new tests are required at this time.

## Additional Context

- The changes to the Mermaid diagrams (font size and theme) are aimed at improving the visual accessibility for readers. The `fontSize` adjustments were made to ensure that the diagrams are more legible, especially for users with visual impairments. Although the second diagram did not scale as expected, it still provides a significant improvement over the previous font size. Further adjustments may be needed for more complex diagrams with large amounts of content, but this change is a step toward improving accessibility.

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
