### PR TITLE
specs: interop sequencer + overview

### DIFF
--- a/specs/interop/overview.md
+++ b/specs/interop/overview.md
@@ -3,7 +3,10 @@
 # Interop
 
 The ability for a blockchain to easily read the state of another blockchain is called interoperability.
-Low latency interoperability allows for horizontally scalable blockchains, a key feature of the superchain.
+Relatively trustless interop is possible between rollups by using L1 Ethereum as a hub. A message is
+withdrawn from one chain to L1 and then deposited to another chain. The goal of OP Stack native interop
+is to enable cross chain messaging at a much lower latency than going through L1. Low latency interoperability
+allows for a horizontally scalable blockchain network.
 
 Note: this document references an "interop network upgrade" as a temporary name. The pending name of the
 network upgrade is isthmus.
@@ -17,18 +20,22 @@ network upgrade is isthmus.
 | Executing Message   | An event emitted from a destination chain's `CrossL2Inbox` that includes an initiating message and identifier |
 | Cross Chain Message | The cumulative execution and side effects of the initiating message and executing message           |
 | Dependency Set      | The set of chains that originate initiating transactions where the executing transactions are valid |
+| Log                 | The Ethereum consensus object created by the `LOG*` opcodes                                         |
+| Event               | The solidity representation of a log                                                                |
 
 A total of two transactions are required to complete a cross chain message.
-The first transaction is submitted to the source chain and emits an event (initiating message) that can be
-consumed on a destination chain. The second transaction is submitted to the destination chain and includes the
+The first transaction is submitted to the source chain and any log that is emitted can be
+used as an initiating message that can be consumed on a destination chain. The second
+transaction is submitted to the destination chain and includes the
 initiating message as well as the identifier that uniquely points to the initiating message.
 
-The chain's fork choice rule will reorg out any blocks that contain an executing message that is not valid,
-meaning that the identifier actually points to the initiating message that was passed into the remote chain.
-This means that the block builder SHOULD only include an executing message if they have already checked its validity.
+The chain's fork choice rule will reorg out any blocks that contain an executing message that is not valid.
+A valid executing message means that the identifier correctly references its initiating message.
+This means that the sequencer SHOULD only include an executing message if they have checked its validity.
+The integrity of a message is guaranteed at the application layer without the need for any sort of confirmation
+depth.
 
-The term "block builder" is used interchangeably with the term "sequencer" for the purposes of this document but
-they need not be the same entity in practice.
+The proof system is able to check the validity of all executing messages.
 
 ## Specifications
 


### PR DESCRIPTION
**Description**

Cleanup and simplify the sequencer and overview specs. This deletes
the section on shreds, which is an interesting idea, but we can bring
it back in a more fleshed out way.

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->


