### PR TITLE
specs: add derivation based dep set updates

### DIFF
--- a/specs/interop/dependency-set.md
+++ b/specs/interop/dependency-set.md
@@ -4,6 +4,7 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**
 
+- [Overview](#overview)
 - [Chain ID](#chain-id)
 - [Updating the Dependency Set](#updating-the-dependency-set)
 - [Future Considerations](#future-considerations)
@@ -12,6 +13,8 @@
   - [Dependency Set Size](#dependency-set-size)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Overview
 
 The dependency set defines the set of chains that destination chains allow as source chains. Another way of
 saying it is that the dependency set defines the set of initiating messages that are valid to be used
@@ -46,6 +49,9 @@ It is a known issue that not all software in the Ethereum ecosystem can handle 3
 
 The dependency set is managed in the client software. Adding a chain to the dependency set is
 considered an upgrade to the network. It is not possible to remove chains from the dependency set.
+[Network upgrade transactions](./derivation.md#updating-the-dependency-set) that add chains to
+the dependency set are automatically generated as part of derivation at a timestamp hardcoded
+by the client software.
 
 ## Future Considerations
 

--- a/specs/interop/derivation.md
+++ b/specs/interop/derivation.md
@@ -57,9 +57,9 @@ The order of deposit transactions occurs as follows:
 
 1. L1 attributes transaction, [opening the deposit context](#opening-the-deposit-context).
 2. User deposits (if any).
-3. L1 attributes transaction, [closing the deposit context](#closing-the-deposit-context).
-4. During upgrades, additional deposits, inserted by derivation, may follow after the above.
-   See [upgrade specification](./upgrade.md).
+3. [Dependency set management transactions if necessary](#updating-the-dependency-set)
+4. L1 attributes transaction, [closing the deposit context](#closing-the-deposit-context).
+5. TODO: Network upgrade transactions. See [upgrade specification](./upgrade.md).
 
 The L1 attributes operations wrap user deposits,
 such that `isDeposit = true` occurs during the first L1 attributes transaction
@@ -146,7 +146,7 @@ This system-initiated transaction for L1 attributes is not charged any ETH for i
 ## Updating the Dependency Set
 
 The dependency set is updated as part of derivation. At the first L2 timestamp greater than a
-particular timestamp, chains can be added to the dependency set through a network upgrade transaction.
+particular timestamp, chains can be added to the dependency set through network upgrade transactions.
 If multiple chains are being added at the same time, there is a single network upgrade transaction per
 chain. The network upgrade transactions MUST be sorted by chain id in ascending order.
 

--- a/specs/interop/derivation.md
+++ b/specs/interop/derivation.md
@@ -172,7 +172,6 @@ function addDependency(address superchainConfig, uint256 chainId, address system
 | 32      | chainId uint256          |
 | 32      | systemConfig address     |
 
-
 ## Security Considerations
 
 ### Gas Considerations


### PR DESCRIPTION
**Description**

Update: We are putting this on hold until we have a better understanding of how we will do upgrades to the proof system

Adds the derivation based dependency update specs.
A prototype implementation can be found in
https://github.com/defi-wonderland/optimism/pull/197

tldr; derivation creates a system tx that updates the dep
set in L2 by calling the `DependencyManager` predeploy

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->


