### PR TITLE
interop: offchain derivation invariants

### DIFF
--- a/specs/interop/derivation.md
+++ b/specs/interop/derivation.md
@@ -13,10 +13,12 @@
       - [Deposits-complete Source-hash](#deposits-complete-source-hash)
 - [Replacing Invalid Blocks](#replacing-invalid-blocks)
   - [Optimistic Block Deposited Transaction](#optimistic-block-deposited-transaction)
+- [Expiry Window](#expiry-window)
 - [Security Considerations](#security-considerations)
   - [Gas Considerations](#gas-considerations)
   - [Depositing an Executing Message](#depositing-an-executing-message)
   - [Reliance on History](#reliance-on-history)
+  - [Expiry Window](#expiry-window-1)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -31,6 +33,9 @@ executing messages.
 - An executing message MUST have a corresponding initiating message
 - The initiating message referenced in an executing message MUST come from a chain in its dependency set
 - A block MUST be considered invalid if it is built with any invalid executing messages
+- The timestamp of the identifier MUST be greater than or equal to the interop network upgrade timestamp
+- The timestamp of the identifier MUST be less than or equal to the timestamp of the block that includes it
+- The timestamp of the identifier MUST be greater than timestamp of the block that includes it minus the expiry window
 
 L2 blocks that produce invalid executing messages MUST not be allowed to be considered safe.
 They MAY optimistically exist as unsafe blocks for some period of time. An L2 block that is invalidated
@@ -140,6 +145,14 @@ This transaction MUST have the following values:
 This system-initiated transaction for L1 attributes is not charged any ETH for its allocated
 `gasLimit`, as it is considered part of state-transition processing.
 
+## Expiry Window
+
+The expiry window is the time period after which an initiating message is no longer considered valid.
+
+| Constant | Value |
+| -------- | ----- |
+| `EXPIRY_WINDOW` | `TODO` |
+
 ## Security Considerations
 
 ### Gas Considerations
@@ -163,3 +176,10 @@ When fully executing historical blocks, a dependency on historical receipts from
 needing to execute increasingly long chain histories.
 
 [eip-4444]: https://eips.ethereum.org/EIPS/eip-4444
+
+### Expiry Window
+
+The expiry window ensures that the proof can execute in a reasonable amount of time.
+There is currently no way to prove old history with a sublinear proof size. The proof
+program needs to walk back and reexecute to reproduce the consumed logs. This means
+that very old logs are more expensive to prove.

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -8,7 +8,6 @@
 - [CrossL2Inbox](#crossl2inbox)
   - [Functions](#functions)
     - [validateMessage](#validatemessage)
-  - [Interop Start Timestamp](#interop-start-timestamp)
   - [`ExecutingMessage` Event](#executingmessage-event)
   - [Reference implementation](#reference-implementation)
   - [Deposit Handling](#deposit-handling)
@@ -104,17 +103,6 @@ The following fields are required for validating a cross chain message:
 ```solidity
 function validateMessage(Identifier calldata _id, bytes32 _msgHash)
 ```
-
-### Interop Start Timestamp
-
-The Interop Start Timestamp represents the earliest timestamp which an initiating message (identifier) can have to be
-considered valid. This is important because OP Mainnet migrated from a legacy system that is not provable. We cannot
-allow for interop messages to come from unproven parts of the chain history, since interop is secured by fault proofs.
-
-Interop Start Timestamp is stored in the storage of the CrossL2Inbox predeploy. During the Interop Network Upgrade,
-each chain sets variable via a call to `setInteropStart()` by the `DEPOSITOR_ACCOUNT` which sets Interop Start Timestamp
-to be the block.timestamp of the network upgrade block. Chains deployed after the network upgrade will have to enshrine
-that timestamp into the pre-determined storage slot.
 
 ### `ExecutingMessage` Event
 


### PR DESCRIPTION
**Description**

We are moving a bunch of stuff offchain rather than it being onchain. We now need to be explicit with the invariants as defined in the derivation pipeline. Previously we didn't need to do that because it would revert in the smart contract.

This creates a scaffold for where the expiry window should live.
