### PR TITLE
isthmus: EIP-7623

### DIFF
--- a/specs/SUMMARY.md
+++ b/specs/SUMMARY.md
@@ -56,6 +56,8 @@
       - [System Config](./protocol/holocene/system-config.md)
     - [Isthmus](./protocol/isthmus/overview.md)
       - [Execution Engine](./protocol/isthmus/exec-engine.md)
+      - [Derivation](./protocol/isthmus/derivation.md)
+      - [Predeploys](./protocol/isthmus/predeploys.md)
       - [Superchain Config](./protocol/isthmus/superchain-config.md)
 - [Governance]()
   - [Governance Token](./governance/gov-token.md)

--- a/specs/protocol/exec-engine.md
+++ b/specs/protocol/exec-engine.md
@@ -495,8 +495,10 @@ For the Ecotone upgrade, this entails that:
 [engine_forkchoiceUpdatedV2]: https://github.com/ethereum/execution-apis/blob/584905270d8ad665718058060267061ecfd79ca5/src/engine/shanghai.md#engine_forkchoiceupdatedv2
 [engine_newPayloadV2]: https://github.com/ethereum/execution-apis/blob/584905270d8ad665718058060267061ecfd79ca5/src/engine/shanghai.md#engine_newpayloadv2
 [engine_newPayloadV3]: https://github.com/ethereum/execution-apis/blob/cea7eeb642052f4c2e03449dc48296def4aafc24/src/engine/cancun.md#engine_newpayloadv3
+[engine_newPayloadV4]: https://github.com/ethereum/execution-apis/blob/869b7f062830ba51a7fd8a51dfa4678c6d36b6ec/src/engine/prague.md#engine_newpayloadv4
 [engine_getPayloadV2]: https://github.com/ethereum/execution-apis/blob/584905270d8ad665718058060267061ecfd79ca5/src/engine/shanghai.md#engine_getpayloadv2
 [engine_getPayloadV3]: https://github.com/ethereum/execution-apis/blob/a0d03086564ab1838b462befbc083f873dcf0c0f/src/engine/cancun.md#engine_getpayloadv3
+[engine_getPayloadV4]: https://github.com/ethereum/execution-apis/blob/869b7f062830ba51a7fd8a51dfa4678c6d36b6ec/src/engine/prague.md#engine_getpayloadv4
 [HEX value encoding]: https://eth.wiki/json-rpc/API#hex-value-encoding
 [JSON-RPC-API]: https://github.com/ethereum/execution-apis
 

--- a/specs/protocol/isthmus/overview.md
+++ b/specs/protocol/isthmus/overview.md
@@ -21,6 +21,8 @@ This document is not finalized and should be considered experimental.
 
 ## Consensus Layer
 
+- [Isthmus Derivation](./derivation.md)
+
 ## Smart Contracts
 
 - [SuperchainConfig](./superchain-config.md)

--- a/specs/protocol/isthmus/overview.md
+++ b/specs/protocol/isthmus/overview.md
@@ -17,6 +17,7 @@ This document is not finalized and should be considered experimental.
 - [Pectra](https://eips.ethereum.org/EIPS/eip-7600) (Execution Layer):
   - [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702)
   - [EIP-2935](https://eips.ethereum.org/EIPS/eip-2935)
+  - [EIP-7623](https://eips.ethereum.org/EIPS/eip-7623)
 - [L2ToL1MessagePasser Storage Root in Header](./exec-engine.md##l2tol1messagepasser-storage-root-in-header)
 
 ## Consensus Layer


### PR DESCRIPTION
**Description**

* Add EIP-7623 functionality in Isthmus to support the upcoming Pectra upgrade of the OP Stack
* Update Isthmus TOC
* Add missing references for the V4 API's (see [here](https://specs.optimism.io/protocol/exec-engine.html#engine_newpayloadv4))


**Metadata**

- Fixes https://github.com/ethereum-optimism/specs/issues/508
