### PR TITLE
Typo/fix governor.md

### DIFF
--- a/specs/governance/governor.md
+++ b/specs/governance/governor.md
@@ -344,7 +344,7 @@ function getVotes(uint256 _account) external view returns (uint256);
 
 #### `getVotesWithParams`
 
-Returns the voting power of an account at a specific block nubmer given additional encoded parameters.
+Returns the voting power of an account at a specific block number given additional encoded parameters.
 
 ```solidity
 function getVotesWithParams(address _account, uint256 _blockNumber) external view returns (uint256);


### PR DESCRIPTION
# Fix Typo in governor.md

## Description
This pull request fixes a typo in the `governor.md` file. The word "nubmer" was corrected to "number" for better clarity and accuracy.

### Changes:
- **Before**:  
  > Returns the voting power of an account at a specific block **nubmer** given additional encoded parameters.
- **After**:  
  > Returns the voting power of an account at a specific block **number** given additional encoded parameters.

