### PR TITLE
Typo in fault-dispute-game.md

### DIFF
--- a/specs/fault-proof/stage-one/fault-dispute-game.md
+++ b/specs/fault-proof/stage-one/fault-dispute-game.md
@@ -418,7 +418,7 @@ grandchild's clock, the max possible extension for the game is bounded, and scal
 
 If the potential grandchild is an execution trace bisection root claim and their clock has less than `CLOCK_EXTENSION`
 seconds remaining, exactly `CLOCK_EXTENSION * 2` seconds are allocated for the potential grandchild. This extra time
-is alloted to allow for completion of the off-chain FPVM run to generate the initial instruction trace.
+is allotted to allow for completion of the off-chain FPVM run to generate the initial instruction trace.
 
 A move against a particular claim is no longer possible once the parent of the disputed claim's Clock
 has accumulated `MAX_CLOCK_DURATION` seconds. By which point, the claim's clock has _expired_.


### PR DESCRIPTION
# **Typo Fix in `fault-dispute-game.md`**

## **Description**
This pull request fixes a typo in the `fault-dispute-game.md` file. The word **"alloted"** was corrected to **"allotted"** to ensure proper spelling.

## **Changes**
- Corrected the typo in the following section:
  - **Before:** `This extra time is alloted to allow for completion of the off-chain FPVM run...`
  - **After:** `This extra time is allotted to allow for completion of the off-chain FPVM run...`

## **Impact**
- This is a minor documentation correction with no functional impact on the project.

## **Testing**
- No testing required, as this is a documentation update.
