### PR TITLE
Isthmus: EIP-6110

### DIFF
--- a/specs/protocol/isthmus/exec-engine.md
+++ b/specs/protocol/isthmus/exec-engine.md
@@ -17,6 +17,7 @@
     - [Forwards Compatibility Considerations](#forwards-compatibility-considerations)
     - [Client Implementation Considerations](#client-implementation-considerations)
       - [Transaction Simulation](#transaction-simulation)
+- [Deposit Requests](#deposit-requests)
 - [Block Body Withdrawals List](#block-body-withdrawals-list)
 - [Engine API Updates](#engine-api-updates)
   - [Update to `ExecutableData`](#update-to-executabledata)
@@ -126,6 +127,17 @@ directly store this information.
 In response to RPC methods like `eth_simulateV1` that allow simulation of arbitrary transactions within one or more blocks,
 an empty withdrawals root should be included in the header of a block that consists of such simulated transactions. The same
 is applicable for scenarios where the actual withdrawals root value is not readily available.
+
+## Deposit Requests
+
+[EIP-6110] shifts deposit to the execution layer, introducing a new [EIP-7685] deposit request of type
+`DEPOSIT_REQUEST_TYPE`. Deposit requests then appear in the [EIP-7685] requests list. The OP Stack needs to ignore these
+requests. Requests generation must be modified to exclude [EIP-6110] deposit requests. Note that since the [EIP-6110]
+request type did _not_ exist prior to Pectra on L1 and the Isthmus hardfork on L2, no activation time is needed since these
+deposit type requests may always be excluded.
+
+[EIP-6110]: https://eips.ethereum.org/EIPS/eip-6110
+[EIP-7685]: https://eips.ethereum.org/EIPS/eip-7685
 
 ## Block Body Withdrawals List
 

--- a/specs/protocol/isthmus/overview.md
+++ b/specs/protocol/isthmus/overview.md
@@ -18,6 +18,7 @@ This document is not finalized and should be considered experimental.
   - [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702)
   - [EIP-2935](https://eips.ethereum.org/EIPS/eip-2935)
   - [EIP-7623](https://eips.ethereum.org/EIPS/eip-7623)
+  - [EIP-6110](https://eips.ethereum.org/EIPS/eip-6110)
 - [L2ToL1MessagePasser Storage Root in Header](./exec-engine.md##l2tol1messagepasser-storage-root-in-header)
 
 ## Consensus Layer


### PR DESCRIPTION
### Description

Specifies [EIP-6110](https://eips.ethereum.org/EIPS/eip-6110) changes required for L2 Pectra as part of the Isthmus hardfork.

Closes #505