### PR TITLE
feat: specification for the AnchorStateRegistry as source of truth

### DIFF
--- a/specs/fault-proof/stage-one/anchor-state-registry.md
+++ b/specs/fault-proof/stage-one/anchor-state-registry.md
@@ -143,17 +143,25 @@ A Dispute Game is considered to be a **Proper Game** if it has not been invalida
 the mechanisms defined by the `AnchorStateRegistry` contract. A Proper Game is, in a sense, a
 "clean" game that exists in the set of games that are playing out correctly in a bug-free manner. A
 Dispute Game can be a Proper Game even if it has not yet resolved or resolves in favor of the
-Challenger. A Game that was previously a Proper Game can no longer be a Proper Game if it is later
-invalidated.
+Challenger.
 
-Specifically, a game is considered to be a Proper Game if all of the following are true:
+A Dispute Game that is **NOT** a Proper Game can also be referred to as an **Improper Game** for
+brevity. A Dispute Game can go from being a Proper Game to later *not* being an **Improper Game**
+if it is invalidated by being [blacklisted](#blacklisted-game) or [retired](#retired-game).
+
+**ALL** Dispute Games **TEMPORARILY** become Improper Games while the Superchain-wide pause
+mechanism is active. However, this is a *temporary* condition such that Registered Games that are
+not invalidated by [blacklisting](#blacklisted-game) or [retirement](#retired-game) will become
+Proper Games again once the pause is lifted. The Superchain-wide pause is therefore a way to
+*temporarily* prevent Dispute Games from being used by consumers like the `OptimismPortal` while
+relevant parties coordinate the use of some other invalidation mechanism.
+
+A Game is considered to be a Proper Game if all of the following are true:
 
 - The game is a [Registered Game](#registered-game)
 - The game is **NOT** a [Blacklisted Game](#blacklisted-game)
 - The game is **NOT** a [Retired Game](#retired-game)
-
-Additionally, ALL games will NOT be considered to be Proper Games while the Superchain-wide pause
-is active.
+- The Superchain-wide pause is not active
 
 ### Resolved Game
 

--- a/specs/fault-proof/stage-one/optimism-portal.md
+++ b/specs/fault-proof/stage-one/optimism-portal.md
@@ -11,8 +11,6 @@
   - [Finalized Withdrawal](#finalized-withdrawal)
   - [Valid Withdrawal](#valid-withdrawal)
   - [Invalid Withdrawal](#invalid-withdrawal)
-  - [Respected Game Type](#respected-game-type)
-  - [Retirement Timestamp](#retirement-timestamp)
   - [L2 Withdrawal Sender](#l2-withdrawal-sender)
 - [Assumptions](#assumptions)
   - [aOP-001: Dispute Game contracts properly report important properties](#aop-001-dispute-game-contracts-properly-report-important-properties)
@@ -21,14 +19,22 @@
     - [Mitigations](#mitigations-1)
   - [aOP-003: Incorrectly resolving games will be invalidated within the airgap delay period](#aop-003-incorrectly-resolving-games-will-be-invalidated-within-the-airgap-delay-period)
     - [Mitigations](#mitigations-2)
+- [Dependencies](#dependencies)
 - [Invariants](#invariants)
   - [iOP-001: Invalid Withdrawals can never be finalized](#iop-001-invalid-withdrawals-can-never-be-finalized)
     - [Impact](#impact)
   - [iOP-002: Valid Withdrawals can always be finalized in bounded time](#iop-002-valid-withdrawals-can-always-be-finalized-in-bounded-time)
     - [Impact](#impact-1)
 - [Function Specification](#function-specification)
-  - [setRespectedGameType](#setrespectedgametype)
-  - [blacklistDisputeGame](#blacklistdisputegame)
+  - [constructor](#constructor)
+  - [initialize](#initialize)
+  - [paused](#paused)
+  - [guardian](#guardian)
+  - [proofMaturityDelaySeconds](#proofmaturitydelayseconds)
+  - [disputeGameFinalityDelaySeconds](#disputegamefinalitydelayseconds)
+  - [respectedGameType](#respectedgametype)
+  - [respectedGameTypeUpdatedAt](#respectedgametypeupdatedat)
+  - [l2Sender](#l2sender)
   - [proveWithdrawalTransaction](#provewithdrawaltransaction)
   - [checkWithdrawal](#checkwithdrawal)
   - [finalizeWithdrawalTransaction](#finalizewithdrawaltransaction)
@@ -67,10 +73,6 @@ conditions:
 Notably, the `OptimismPortal` allows users to prove withdrawals against games that are currently
 in progress (games that are not [Resolved Games](./anchor-state-registry.md#resolved-game)).
 
-Note that the `OptimismPortal` currently allows users to prove withdrawals against games that have
-been blacklisted, though these withdrawals cannot be [finalized](#finalized-withdrawal). To avoid
-user confusion, this functionality will likely be removed in a future release.
-
 Users may re-prove a withdrawal at any time. User withdrawals are stored on a per-user basis such
 that re-proving a withdrawal cannot cause the timer for
 [finalizing a withdrawal](#finalized-withdrawal) to be reset for another user.
@@ -96,18 +98,6 @@ would be reported by a perfect oracle for the query.
 ### Invalid Withdrawal
 
 An **Invalid Withdrawal** is any withdrawal that is not a [Valid Withdrawal](#valid-withdrawal).
-
-### Respected Game Type
-
-See [Respected Game Type](./anchor-state-registry.md#respected-game-type). The Respected Game Type
-can only be set by the Guardian.
-
-### Retirement Timestamp
-
-Any game whose creation timestamp is less than or equal to the **Retirement Timestamp** is
-considered to be a [Retired Game](./anchor-state-registry.md#retired-game). Retired Games cannot be
-used to [prove](#proven-withdrawal) or [finalize](#finalized-withdrawal) withdrawals. The
-Retirement Timestamp can only be set by the Guardian.
 
 ### L2 Withdrawal Sender
 
@@ -160,6 +150,11 @@ period.
 - Incident response plan
 - Monitoring
 
+## Dependencies
+
+- [iASR-001](./anchor-state-registry.md#iasr-001-games-are-represented-as-proper-games-accurately)
+- [iASR-002](./anchor-state-registry.md#iasr-002-all-valid-claims-are-truly-valid-claims)
+
 ## Invariants
 
 ### iOP-001: Invalid Withdrawals can never be finalized
@@ -188,35 +183,73 @@ see this as a critical system risk.
 
 ## Function Specification
 
-### setRespectedGameType
+### constructor
 
-Allows the Guardian to change the [Respected Game Type](#respected-game-type) and to update the
-[Retirement Timestamp](#retirement-timestamp).
+- MUST set the value of the [Proof Maturity Delay](#proof-maturity-delay).
 
-- MUST revert if the sender is not the Guardian.
-- If the game type is `type(uint32).max`, MUST update the Retirement Timestamp to the current
-  block timestamp and MUST NOT update the Respected Game Type.
-- If the game type is not `type(uint32).max`, MUST set the Respected Game Type to the provided game
-  type and MUST NOT update the Retirement Timestamp.
+### initialize
 
-### blacklistDisputeGame
+- MUST only be triggerable once.
+- MUST set the value of the `DisputeGameFactory` contract.
+- MUST set the value of the `SystemConfig` contract.
+- MUST set the value of the `SuperchainConfig` contract.
+- MUST set the value of the `AnchorStateRegistry` contract.
+- MUST set the value of the [L2 Withdrawal Sender](#l2-withdrawal-sender) variable to the default
+  value if the value is not set already.
+- MUST initialize the resource metering configuration.
 
-Allows the Guardian to [blacklist](./anchor-state-registry.md#blacklisted-game) a Dispute Game.
+### paused
 
-- MUST revert if the sender is not the Guardian.
-- MUST set the provided dispute game as blacklisted.
+Returns the current state of the `SuperchainConfig.paused()` function.
+
+### guardian
+
+Returns the address of the Guardian as per `SuperchainConfig.guardian()`.
+
+### proofMaturityDelaySeconds
+
+Returns the value of the [Proof Maturity Delay](#proof-maturity-delay).
+
+### disputeGameFinalityDelaySeconds
+
+**Legacy Function**
+
+Returns the value of the
+[Dispute Game Finality Delay](./anchor-state-registry.md#dispute-game-finality-delay-airgap) as per
+a call to `AnchorStateRegistry.disputeGameFinalityDelaySeconds()`.
+
+### respectedGameType
+
+**Legacy Function**
+
+Returns the value of the current
+[Respected Game Type](./anchor-state-registry.md#respected-game-type) as per a call to
+`AnchorStateRegistry.respectedGameType`.
+
+### respectedGameTypeUpdatedAt
+
+**Legacy Function**
+
+Returns the value of the current
+[Retirement Timestamp](./anchor-state-registry.md#retirement-timestamp) as per a call to
+`AnchorStateRegistry.retirementTimestamp.
+
+### l2Sender
+
+Returns the address of the [L2 Withdrawal Sender](#l2-withdrawal-sender). If the `OptimismPortal`
+has not been initialized then this value will be `address(0)` and should not be used. If the
+`OptimismPortal` is not currently executing an withdrawal transaction then this value will be
+`0x000000000000000000000000000000000000dEaD` and should not be used.
 
 ### proveWithdrawalTransaction
 
 Allows a user to [prove](#proven-withdrawal) a withdrawal transaction.
 
+- MUST revert if the withdrawal target is the address of the `OptimismPortal` itself.
 - MUST revert if the withdrawal is being proven against a game that is not a
-  [Registered Game](./anchor-state-registry.md#registered-game).
-- MUST revert if the withdrawal is being proven against a game that has a game type not equal to
-  the current [Respected Game Type](#respected-game-type).
+  [Proper Game](./anchor-state-registry.md#proper-game).
 - MUST revert if the withdrawal is being proven against a game that is not a
   [Respected Game](./anchor-state-registry.md#respected-game).
-- MUST revert if the withdrawal is a [Retired Game](./anchor-state-registry.md#retired-game).
 - MUST revert if the withdrawal is being proven against a game that has resolved in favor of the
   Challenger.
 - MUST revert if the provided merkle trie proof that the withdrawal was included within the root
@@ -229,13 +262,14 @@ Allows a user to [prove](#proven-withdrawal) a withdrawal transaction.
 
 Checks that a withdrawal transaction can be [finalized](#finalized-withdrawal).
 
+- MUST revert if the withdrawal being finalized has already been finalized.
 - MUST revert if the withdrawal being finalized has not been proven.
+- MUST revert if the withdrawal was proven at a timestamp less than the creation timestamp of the
+  dispute game it was proven against, which would signal an unexpected proving bug.
 - MUST revert if the withdrawal being finalized has been proven less than
   [Proof Maturity Delay](#proof-maturity-delay) seconds ago.
-- MUST revert if the withdrawal being finalized was proven against a game that is not a
-  [Valid Game](./anchor-state-registry.md#valid-game).
-- MUST revert if the withdrawal being finalized has already been finalized.
-- MUST otherwise return `true`.
+- MUST revert if the withdrawal being finalized was proven against a game that does not have a
+  [Valid Claim](./anchor-state-registry.md#valid-claim).
 
 ### finalizeWithdrawalTransaction
 

--- a/specs/fault-proof/stage-one/optimism-portal.md
+++ b/specs/fault-proof/stage-one/optimism-portal.md
@@ -17,7 +17,7 @@
     - [Mitigations](#mitigations)
   - [aOP-002: DisputeGameFactory properly reports its created games](#aop-002-disputegamefactory-properly-reports-its-created-games)
     - [Mitigations](#mitigations-1)
-  - [aOP-003: Incorrectly resolving games will be invalidated within the airgap delay period](#aop-003-incorrectly-resolving-games-will-be-invalidated-within-the-airgap-delay-period)
+  - [aOP-003: Incorrectly resolving games will be invalidated before they have Valid Claims](#aop-003-incorrectly-resolving-games-will-be-invalidated-before-they-have-valid-claims)
     - [Mitigations](#mitigations-2)
 - [Dependencies](#dependencies)
 - [Invariants](#invariants)
@@ -139,10 +139,20 @@ created.
 - Existing audit on the `DisputeGameFactory` contract
 - Integration testing
 
-### aOP-003: Incorrectly resolving games will be invalidated within the airgap delay period
+### aOP-003: Incorrectly resolving games will be invalidated before they have Valid Claims
 
-We assume that any games that are resolved incorrectly will be invalidated within the airgap delay
-period.
+We assume that any games that are resolved incorrectly will be invalidated either by
+[blacklisting](./anchor-state-registry.md#blacklisted-game) or by
+[retirement](./anchor-state-registry.md#retired-game) BEFORE they are considered to have
+[Valid Claims](./anchor-state-registry.md#valid-claim).
+
+Proper Games that resolve in favor the Defender will be considered to have Valid Claims after the
+[Dispute Game Finality Delay](./anchor-state-registry.md#dispute-game-finality-delay-airgap) has
+elapsed UNLESS the Superchain-wide pause mechanism is active. Therefore, in the absence of the
+Superchain-wide pause mechanism, parties responsible for game invalidation have exactly the Dispute
+Game Finality Delay to invalidate a withdrawal after it resolves incorrectly. If the
+Superchain-wide pause is active, then any incorrectly resolving games must be invalidated before
+the pause is deactivated.
 
 #### Mitigations
 


### PR DESCRIPTION
Updates the AnchorStateRegistry and OptimismPortal specifications such that the AnchorStateRegistry acts as the source of truth for the validity of dispute game contracts.