### PR TITLE
feat: bls precompile input size limits and specify acceleration

### DIFF
--- a/specs/protocol/isthmus/exec-engine.md
+++ b/specs/protocol/isthmus/exec-engine.md
@@ -138,9 +138,16 @@ Similar to the `bn256Pairing` precompile in the [granite hardfork](../granite/ex
 [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537) introduces a BLS
 precompile that short-circuits depending on input size in the EVM.
 
-The `BLS12-381` curve operation precompile reverts if its input is
-larger than `235008` bytes. This is the input size that consumes
-approximately `20M` gas given the latest `BLS12-381` gas schedule on L2.
+The input size limits of the BLS precompile contracts are listed below:
+
+- G1 multiple-scalar-multiply: `input_size <= 513760 bytes`
+- G2 multiple-scalar-multiply: `input_size <= 488448 bytes`
+- Pairing check: `input_size <= 235008 bytes`
+
+The rest of the BLS precompiles are fixed-size operations which have a fixed gas cost.
+
+All of the BLS precompiles should be [accelerated](../../fault-proof/index.md#precompile-accelerators) in fault proof
+programs so they call out to the L1 instead of calculating the result inside the program.
 
 ## Engine API Updates
 


### PR DESCRIPTION
Add precompile limits and acceleration specification to Isthmus BLS precompile spec.

## Calculation for Size Limits

- G1 MSM:
  - (k * multiplication_cost * max_discount) // 1000 < 20000000 
  - (k * 12000 * 519) // 1000 < 20000000
  - k < 3211.3, so k <= 3211
  - bytes = 160 * k
  - bytes <= 513760

- G2 MSM:
  - (k * multiplication_cost * max_discount) // 1000 < 20000000 
  - (k * 22500 * 524) // 1000 < 20000000
  - k < 1696.35, so k <= 1696
  - bytes = 288 * k
  - bytes <= 488448

- Pairing check:
  - 32600 * k + 37700 < 20000000
  - k <= 612
  - bytes = 384 * k
  - bytes <= 235008