### PR TITLE
feat: specify requests hash must be empty

### DIFF
--- a/specs/protocol/isthmus/exec-engine.md
+++ b/specs/protocol/isthmus/exec-engine.md
@@ -50,16 +50,21 @@ at the given block number.
 
 ### Header Validity Rules
 
-Prior to isthmus activation, the L2 block header's `withdrawalsRoot` field must be:
+Prior to isthmus activation:
 
-- `nil` if Canyon has not been activated.
-- `keccak256(rlp(empty_string_code))` if Canyon has been activated.
+- the L2 block header's `withdrawalsRoot` field must be:
+  - `nil` if Canyon has not been activated.
+  - `keccak256(rlp(empty_string_code))` if Canyon has been activated.
+- the L2 block header's `requestsHash` field must be omitted.
 
-After Isthmus activation, an L2 block header's `withdrawalsRoot` field is valid iff:
+After Isthmus activation, an L2 block header is valid iff:
 
-1. It is exactly 32 bytes in length.
-1. The [`L2ToL1MessagePasser`][l2-to-l1-mp] account storage root, as committed to in the `storageRoot` within the block
-   header, is equal to the header's `withdrawalsRoot` field.
+1. The `withdrawalsRoot` field
+    1. Is 32 bytes in length.
+    1. Matches the [`L2ToL1MessagePasser`][l2-to-l1-mp] account storage root,
+    as committed to in the `storageRoot` within the block header
+1. The `requestsHash` field is equal to `sha256('') = 0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`
+indicating no requests in the block.
 
 ### Header Withdrawals Root
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

Specifies that `requests_hash` should be set to `calcRequestsHash([]) = sha256('') = 0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855` after Isthmus.

EIP ref: https://eips.ethereum.org/EIPS/eip-7685#execution-layer

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
Fixes #568