### PR TITLE
feat: specify getOperatorFee() return value is capped

### DIFF
--- a/specs/protocol/isthmus/predeploys.md
+++ b/specs/protocol/isthmus/predeploys.md
@@ -8,6 +8,7 @@
   - [L1Block](#l1block)
     - [Interface](#interface)
       - [`setIsthmus`](#setisthmus)
+  - [GasPriceOracle](#gaspriceoracle)
   - [OperatorFeeVault](#operatorfeevault)
 - [Security Considerations](#security-considerations)
 
@@ -24,6 +25,14 @@
 This function is meant to be called once on the activation block of the holocene network upgrade.
 It MUST only be callable by the `DEPOSITOR_ACCOUNT` once. When it is called, it MUST call
 call each getter for the network specific config and set the returndata into storage.
+
+### GasPriceOracle
+
+Following the Isthmus upgrade, a new method is introduced: `getOperatorFee(uint256)`. This method
+returns the operator fee for the given `gasUsed`. The operator fee calculation follows the formula
+outlined in the [Operator Fee](./exec-engine.md#) section of the execution engine spec.
+
+The value returned by `getOperatorFee(uint256)` is capped at `U256` max value.
 
 ### OperatorFeeVault
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

As per @tynes request, add the fact that the value returned by GasPriceOracle `getOperatorFee()` is capped in the specs.

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
