### PR TITLE
fix(isthmus): Make V4 New Payload Consistent

### DIFF
--- a/specs/protocol/exec-engine.md
+++ b/specs/protocol/exec-engine.md
@@ -303,8 +303,9 @@ The additional parameters should be set as follows:
 
 ### `engine_newPayloadV4`
 
-[`engine_newPayloadV4`][engine_newPayloadV4] applies an Isthmus L2 block to the engine state. There are no
-modifications to this API.
+[`engine_newPayloadV4`][engine_newPayloadV4] applies an Isthmus L2 block to the engine state.
+The `ExecutionPayload` parameter will contain an extra field, `withdrawalsRoot`, after the Isthmus hardfork.
+
 `engine_newPayloadV4` **must only be called with Isthmus payload.**
 
 The additional parameters should be set as follows:

--- a/specs/protocol/isthmus/exec-engine.md
+++ b/specs/protocol/isthmus/exec-engine.md
@@ -180,14 +180,15 @@ specific hardfork as this type does not exist pre-Pectra.
 
 ## Engine API Updates
 
-### Update to `ExecutableData`
+### Update to `ExecutionPayload`
 
-`ExecutableData` will contain an extra field for `withdrawalsRoot` after Isthmus hard fork.
+`ExecutionPayload` will contain an extra field for `withdrawalsRoot` after Isthmus hard fork.
 
 ### `engine_newPayloadV4` API
 
-Post Isthmus, `engine_newPayloadV4` will be used with the additional `ExecutionPayload` attribute. This attribute
-is omitted prior to Isthmus.
+Post Isthmus, `engine_newPayloadV4` will be used.
+
+The `executionRequests` parameter MUST be an empty array.
 
 ## Fees
 

--- a/specs/protocol/isthmus/exec-engine.md
+++ b/specs/protocol/isthmus/exec-engine.md
@@ -22,7 +22,7 @@
 - [EVM Changes](#evm-changes)
 - [Block Sealing](#block-sealing)
 - [Engine API Updates](#engine-api-updates)
-  - [Update to `ExecutableData`](#update-to-executabledata)
+  - [Update to `ExecutionPayload`](#update-to-executionpayload)
   - [`engine_newPayloadV4` API](#engine_newpayloadv4-api)
 - [Fees](#fees)
   - [Operator Fee](#operator-fee)


### PR DESCRIPTION
### Description

Makes the `newPayloadV4` specs consistent across the Isthmus hardfork execution engine docs and the protocol execution engine docs.

Closes #574 