### PR TITLE
chore: Update CircleCI utils orb to version 1.0.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   slack: circleci/slack@4.10.1
-  utils: ethereum-optimism/circleci-utils@0.0.13
+  utils: ethereum-optimism/circleci-utils@1.0.8
 
 executors:
   default:
@@ -81,7 +81,6 @@ jobs:
       - checkout
       - attach_workspace:
           at: /tmp/book
-      - utils/get-github-access-token
       - utils/github-pages-deploy:
           src-pages-dir: /tmp/book/html
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

This pull request includes updates to the `.circleci/config.yml` file to use a newer version of the `utils` orb and remove an unnecessary job step.

* Updated `utils` orb version from `0.0.13` to `1.0.8` in the `.circleci/config.yml` file.
* Removed the `utils/get-github-access-token` job step from the `jobs` section in the `.circleci/config.yml` file.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
