### PR TITLE
Add codeowners for opcm doc

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,6 +22,7 @@ system-config.md @sebastianst @protolambda @tynes
 withdrawals.md @tynes @maurelian @clabby
 safe-extensions.md @mds1 @maurelian
 stage-1.md  @mds1 @maurelian
+op-contracts-manager.md @mds1 @maurelian
 
 # Fault Proofs
 /specs/fault-proof @ajsutton @clabby @inphi @refcell @mbaxter


### PR DESCRIPTION
Makes me and @mds1 owners of opcm doc.