### PR TITLE
fix: update 404 link to contracts-bedrock VERSIONING.md

### DIFF
--- a/specs/experimental/op-contracts-manager.md
+++ b/specs/experimental/op-contracts-manager.md
@@ -1,7 +1,7 @@
 # OP Contracts Manager
 
 [Optimism Monorepo releases]: https://github.com/ethereum-optimism/optimism/releases
-[contract releases]: https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/VERSIONING.md
+[contract releases]: https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/meta/VERSIONING.md
 [standard configuration]: ../protocol/configurability.md
 [superchain registry]: https://github.com/ethereum-optimism/superchain-registry
 [ethereum-lists/chains]: https://github.com/ethereum-lists/chains


### PR DESCRIPTION
## Description
Hi! I fixes a broken link in the `op-contracts-manager.md` file. The old link pointed to a deprecated or non-existent path for the `VERSIONING.md` file in the `contracts-bedrock` package. It has been updated to the correct and current path.
