### PR TITLE
isthmus: Add upgrade gas specs

### DIFF
--- a/specs/glossary.md
+++ b/specs/glossary.md
@@ -60,6 +60,7 @@
   - [Unsafe L2 Head](#unsafe-l2-head)
   - [Unsafe Block Consolidation](#unsafe-block-consolidation)
   - [Finalized L2 Head](#finalized-l2-head)
+  - [Upgrade Gas](#upgrade-gas)
 - [Other L2 Chain Concepts](#other-l2-chain-concepts)
   - [Address Aliasing](#address-aliasing)
   - [Rollup Node](#rollup-node)
@@ -688,6 +689,16 @@ The finalized L2 head is the highest L2 block that can be derived from _[finaliz
 blocks older than two L1 epochs (64 L1 [time slots][time-slot]).
 
 [finality]: https://hackmd.io/@prysmaticlabs/finality
+
+## Upgrade Gas
+
+[upgrade-gas]: glossary.md#upgrade-gas
+
+Upgrade gas is added to the gas limit of upgrade blocks to account for additional gas requirements
+of upgrade transactions.
+
+See the [Upgrade Gas](protocol/isthmus/derivation.md#upgrade-gas) section of the Isthmus hardfork
+derivation specs for more details.
 
 ---
 


### PR DESCRIPTION
**Description**

Adds specs for the *upgrade gas* feature of Isthmus, plus a new rule for omission of user transactions in upgrade blocks, which is so far only implemented in the op-node sequencer as a policy, not a consensus rule.

**Additional context**

See https://github.com/ethereum-optimism/optimism/issues/14649

Note that upgrade gas is necessary because the `system transaction max gas` is only 1 Mio and upgrade transactions in total now tend to consume more, like 3.x Mio gas for Isthmus (plus there's the L1 info deposit, which only consumes 44k currently though). The only constraint by the protocol on the gas limit is: `maxResourceLimit` (user deposit gas, usually 2e7) + `systemTxMaxGas` (L1 info deposit and upgrade txs (so far), usually 1e6) <= `gasLimit`

This version of the specs _always_ adds the upgrade gas, which is the total sum of all upgrade transactions' gas limits, to the block gas limit. We could implement an alternative rule where we only update the gas limit of the block if it is smaller than `system transaction max gas + max resource limit + upgrade gas`. This would have the property that this rule would effectively not alter the block gas limit of chains with typical gas limits (e.g. 60 Mio for OP mainnet) for Isthmus, which needs < 4 Mio upgrade gas (+20 Mio max resource +1 Mio system tx max gas).

To clarify, this change is only necessary because we _allow_ small gas limits. Chains with typical gas limits like OPM wouldn't need this rule.

**Metadata**

Closes https://github.com/ethereum-optimism/specs/issues/609
