### PR TITLE
ci: use `utils/checkout-with-mise`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   slack: circleci/slack@4.10.1
-  utils: ethereum-optimism/circleci-utils@1.0.8
+  utils: ethereum-optimism/circleci-utils@1.0.13
 
 executors:
   default:
@@ -10,17 +10,6 @@ executors:
       image: ubuntu-2204:2024.08.1
 
 commands:
-  install-dependencies:
-    steps:
-      - run:
-          name: Install mise
-          command: curl https://mise.run | MISE_INSTALL_PATH=/home/circleci/bin/mise sh
-      - run:
-          name: Activate mise
-          command: echo 'eval "$(mise activate bash)"' >> $BASH_ENV
-      - run:
-          name: Install mise dependencies
-          command: mise install
 
   notify-failures-on-develop:
     description: "Notify Slack"
@@ -39,8 +28,7 @@ jobs:
   lint-specs:
     executor: default
     steps:
-      - checkout
-      - install-dependencies
+      - utils/checkout-with-mise
       - run:
           name: markdown lint
           command: just lint-specs-md-check
@@ -51,8 +39,7 @@ jobs:
   lint-links:
     executor: default
     steps:
-      - checkout
-      - install-dependencies
+      - utils/checkout-with-mise
       - run:
           name: Lint check
           command: just lint-links-check
@@ -62,8 +49,7 @@ jobs:
   build-book:
     executor: default
     steps:
-      - checkout
-      - install-dependencies
+      - utils/checkout-with-mise
       - run:
           name: Build
           command: just build


### PR DESCRIPTION
The linting job in CI is quite opinionated, and very slow to run, which causes pain in development. 

Here we are reusing some sweetness built into our CI utils, makes a huge difference to run time: 
<img width="1264" alt="Screenshot 2025-03-14 at 10 51 38" src="https://github.com/user-attachments/assets/55999359-5ead-4a90-91eb-8e6768d7d3d0" />
