### PR TITLE
fix(isthmus): P2P payload envelope encoding

### DIFF
--- a/specs/protocol/rollup-node-p2p.md
+++ b/specs/protocol/rollup-node-p2p.md
@@ -285,8 +285,9 @@ A block is structured as the concatenation of:
 - V4 topic
   - `signature`: A `secp256k1` signature, always 65 bytes, `r (uint256), s (uint256), y_parity (uint8)`
   - `parentBeaconBlockRoot`: L1 origin parent beacon block root, always 32 bytes
-  - `withdrawalsRoot`: L2 withdrawals root, always 32 bytes.
   - `payload`: A SSZ-encoded `ExecutionPayload`, always the remaining bytes.
+    - _Note_ - the `ExecutionPayload` is modified for the first time in Isthmus. See
+      ["Update to `ExecutionPayload`"](./isthmus/exec-engine.md#update-to-executionpayload) in the Isthmus spec.
 
 All topics use Snappy block-compression (i.e. no snappy frames):
 the above needs to be compressed after encoding, and decompressed before decoding.


### PR DESCRIPTION
## Overview

Adds a fix for the Isthmus P2P envelope spec, where it claimed that the `withdrawalsRoot` was inserted outside of the SSZ-encoded payload envelope.

See how it has been implemented in the reference impl: [`ExecutionPayload` type (includes `withdrawalsRoot`)](https://github.com/ethereum-optimism/optimism/blob/8d333f548e8e0c715063d6ad1de0cf20e00976df/op-service/eth/types.go#L271-L272) + [SSZ encoding of the outer envelope type](https://github.com/ethereum-optimism/optimism/blob/8d333f548e8e0c715063d6ad1de0cf20e00976df/op-service/eth/ssz.go#L507-L525)