### PR TITLE
broken link  Linux/MIPS Syscall 

### DIFF
--- a/specs/fault-proof/cannon-fault-proof-vm.md
+++ b/specs/fault-proof/cannon-fault-proof-vm.md
@@ -125,8 +125,9 @@ behavior in typical MIPS implementations, FPVM must raise an exception when step
 
 ## Syscalls
 
-Syscalls work similar to [Linux/MIPS](https://web.archive.org/web/20220529105937/https://www.linux-mips.org/wiki/Syscall), including the
-syscall calling conventions and general syscall handling behavior.
+Syscalls work similar to 
+[Linux/MIPS](https://web.archive.org/web/20220529105937/https://www.linux-mips.org/wiki/Syscall), 
+including the syscall calling conventions and general syscall handling behavior.
 However, the FPVM supports a subset of Linux/MIPS syscalls with slightly different behaviors.
 The following table list summarizes the supported syscalls and their behaviors.
 

--- a/specs/fault-proof/cannon-fault-proof-vm.md
+++ b/specs/fault-proof/cannon-fault-proof-vm.md
@@ -125,7 +125,7 @@ behavior in typical MIPS implementations, FPVM must raise an exception when step
 
 ## Syscalls
 
-Syscalls work similar to [Linux/MIPS](https://www.linux-mips.org/wiki/Syscall), including the
+Syscalls work similar to [Linux/MIPS](https://en.wikipedia.org/wiki/System_call), including the
 syscall calling conventions and general syscall handling behavior.
 However, the FPVM supports a subset of Linux/MIPS syscalls with slightly different behaviors.
 The following table list summarizes the supported syscalls and their behaviors.

--- a/specs/fault-proof/cannon-fault-proof-vm.md
+++ b/specs/fault-proof/cannon-fault-proof-vm.md
@@ -125,7 +125,7 @@ behavior in typical MIPS implementations, FPVM must raise an exception when step
 
 ## Syscalls
 
-Syscalls work similar to [Linux/MIPS](https://en.wikipedia.org/wiki/System_call), including the
+Syscalls work similar to [Linux/MIPS](https://web.archive.org/web/20220529105937/https://www.linux-mips.org/wiki/Syscall), including the
 syscall calling conventions and general syscall handling behavior.
 However, the FPVM supports a subset of Linux/MIPS syscalls with slightly different behaviors.
 The following table list summarizes the supported syscalls and their behaviors.

--- a/specs/fault-proof/cannon-fault-proof-vm.md
+++ b/specs/fault-proof/cannon-fault-proof-vm.md
@@ -125,11 +125,11 @@ behavior in typical MIPS implementations, FPVM must raise an exception when step
 
 ## Syscalls
 
-Syscalls work similar to 
-[Linux/MIPS](https://web.archive.org/web/20220529105937/https://www.linux-mips.org/wiki/Syscall), 
-including the syscall calling conventions and general syscall handling behavior.
-However, the FPVM supports a subset of Linux/MIPS syscalls with slightly different behaviors.
-The following table list summarizes the supported syscalls and their behaviors.
+Syscalls work similar to  
+[Linux/MIPS](https://web.archive.org/web/20220529105937/https://www.linux-mips.org/wiki/Syscall),  
+including the syscall calling conventions and general syscall handling behavior.  
+However, the FPVM supports a subset of Linux/MIPS syscalls with slightly different behaviors.  
+The following table summarizes the supported syscalls and their behaviors.
 
 | \$v0 | system call | \$a0            | \$a1       | \$a2         | Effect                                                                                                                                   |
 | ---- | ----------- | --------------- | ---------- | ------------ |------------------------------------------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
I recommend replacing the broken link to Linux/MIPS Syscall with this updated Wikipedia reference:

✅ New link: https://en.wikipedia.org/wiki/System_call

If you have a better suggestion or a more accurate reference, please share it, and I'll update the link accordingly. 🚀