### PR TITLE
isthmus: experimental header

### DIFF
--- a/specs/protocol/isthmus/overview.md
+++ b/specs/protocol/isthmus/overview.md
@@ -10,8 +10,6 @@
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-This document is not finalized and should be considered experimental.
-
 ## Execution Layer
 
 - [Pectra](https://eips.ethereum.org/EIPS/eip-7600) (Execution Layer):


### PR DESCRIPTION
**Description**

Remove the experimental header from the isthmus specs because the scope
has been finalized.

