### PR TITLE
Fix interop lookup identity byte packing

### DIFF
--- a/specs/experimental/standard-l2-genesis.md
+++ b/specs/experimental/standard-l2-genesis.md
@@ -5,7 +5,7 @@
 **Table of Contents**
 
 - [Overview](#overview)
-- [Constants](#constants)
+- [Chain Constants on L1](#chain-constants-on-l1)
   - [`ConfigType`](#configtype)
 - [`SystemConfig`](#systemconfig)
   - [`ConfigUpdate`](#configupdate)
@@ -20,12 +20,12 @@
     - [`setConfig`](#setconfig)
     - [`upgrade`](#upgrade)
 - [SuperchainConfig](#superchainconfig)
-  - [Constants](#constants-1)
+  - [SuperchainConfig Constants](#superchainconfig-constants)
   - [Interface](#interface-2)
   - [Initialization](#initialization-1)
+- [Deterministic genesis state](#deterministic-genesis-state)
+- [Chain Constants on L2](#chain-constants-on-l2)
 - [Predeploys](#predeploys)
-- [Constants](#constants-2)
-- [Predeploys](#predeploys-1)
   - [ProxyAdmin](#proxyadmin)
     - [Rationale](#rationale)
   - [L1Block](#l1block)
@@ -54,7 +54,7 @@
 The `SystemConfig` and `OptimismPortal` are updated with a new flow for chain
 configurability.
 
-## Constants
+## Chain Constants on L1
 
 ### `ConfigType`
 
@@ -191,7 +191,7 @@ The `SuperchainConfig` contract is updated with a new role that has the ability
 to issue deposit transactions from the identity of the `DEPOSITOR_ACCOUNT`
 that call the L2 `ProxyAdmin`.
 
-### Constants
+### SuperchainConfig Constants
 
 | Name | Value | Definition |
 | --------- | ------------------------- | -- |
@@ -207,14 +207,14 @@ function upgrader() public view returns (address)
 
 The `upgrader` can only be set during initialization.
 
-## Predeploys
+## Deterministic genesis state
 
 This upgrade enables a deterministic L2 genesis state by moving all network
 specific configuration out of the initial L2 genesis state. All network specific
 configuration is sourced from deposit transactions during the initialization
 of the `SystemConfig`.
 
-## Constants
+## Chain Constants on L2
 
 | Name | Value | Definition |
 | --------- | ------------------------- | -- |

--- a/specs/interop/predeploys.md
+++ b/specs/interop/predeploys.md
@@ -140,9 +140,9 @@ for verification of the `checksum` and is not verified in the protocol state-tra
 0..1: type byte, always 0x01
 1..4: reserved, zeroed by default
 4..12: big-endian uint64 chain ID
-12..16: big-endian uint64, block number
-16..24: big-endian uint64, timestamp
-24..32: big-endian uint32, log index
+12..20: big-endian uint64, block number
+20..28: big-endian uint64, timestamp
+28..32: big-endian uint32, log index
 ```
 
 Chain IDs larger than `uint64` are supported, with an additional chain-ID-extension entry.

--- a/specs/protocol/derivation.md
+++ b/specs/protocol/derivation.md
@@ -1028,7 +1028,7 @@ entries.
 [deposit-contract-spec]: deposits.md#deposit-contract
 
 Logs are derived from transactions following the future-proof best-effort process described in
-[On Future-Proof Transaction Log Derivation][#on-future-proof-transaction-log-derivation]
+[On Future Proof Transaction Log Derivation](#on-future-proof-transaction-log-derivation)
 
 ### Network upgrade automation transactions
 

--- a/specs/protocol/pectra-blob-schedule/derivation.md
+++ b/specs/protocol/pectra-blob-schedule/derivation.md
@@ -6,7 +6,7 @@
 
 - [If enabled](#if-enabled)
 - [If disabled (default)](#if-disabled-default)
-- [Motivation and Rationale](#motivation-and%C2%A0rationale)
+- [Motivation and Rationale](#motivation-and-rationale)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -26,7 +26,7 @@ For L2 blocks with an L1 origin less than the hard fork timestamp, the Cancun bl
 If the hardfork activation timestamp is nil, the blob base fee update rules which are active
 at any given L1 block will apply to the L1 Attributes Deposited Transaction.
 
-## Motivation and Rationale
+## Motivation and Rationale
 
 Due to a consensus layer bug, OPStack chains on Holesky and Sepolia running officially released op-node software
 did not update their blob base fee update fraction (for L1 Attributes Deposited Transaction)

--- a/specs/protocol/stage-1.md
+++ b/specs/protocol/stage-1.md
@@ -22,7 +22,7 @@
   - [Pause Deputy](#pause-deputy-1)
   - [Architecture Diagram](#architecture-diagram)
 - [Invariants](#invariants)
-  - [iS1-001: A permanent Withdrawal Liveness or Withdrawal Safety failure requires 75% of the Security Council (w/o bugs)](#is1-001-a-permanent-withdrawal-liveness-or-withdrawal-safety-failure-requires-75%25-of-the-security-council-wo-bugs)
+  - [iS1-001](#is1-001)
   - [Impact](#impact)
   - [iS1-002: The Pause Deputy can only cause a temporary Withdrawal Liveness failure](#is1-002-the-pause-deputy-can-only-cause-a-temporary-withdrawal-liveness-failure)
     - [Impact](#impact-1)
@@ -258,7 +258,9 @@ optional. It is included here for completeness, but it does not impact
 
 ## Invariants
 
-### iS1-001: A permanent Withdrawal Liveness or Withdrawal Safety failure requires 75% of the Security Council (w/o bugs)
+### iS1-001
+
+A permanent Withdrawal Liveness or Withdrawal Safety failure requires 75% of the Security Council (w/o bugs).
 
 This is the core invariant for Stage 1 and aligns with [the definition by L2BEAT][stage-1] from
 January 2025. We can define additional properties about roles specific to the OP Stack as long as

--- a/words.txt
+++ b/words.txt
@@ -114,6 +114,7 @@ inputbytes
 interchangable
 invis
 IPFS
+iSUPC
 IWANT
 justfile
 katex


### PR DESCRIPTION
implementation differs from spec
https://github.com/ethereum-optimism/optimism/blob/97fa1b5cd6dd5cbab093e31c2b31c236c1bdb432/op-supervisor/supervisor/types/types.go#L602-L605

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
