### PR TITLE
isthmus: add max operator fee calculation

### DIFF
--- a/specs/protocol/deputy-pause-module.md
+++ b/specs/protocol/deputy-pause-module.md
@@ -261,7 +261,7 @@ the authorization of the social consensus process that typically triggers this p
 ### iDPM-002: Deputy must only be able to trigger the pause
 
 The Deputy must only be able to trigger the pause action by causing the module to call the `pause`
-function on the `SuperchainConfig`. The Deputy must not be able to trigger any other priviledged
+function on the `SuperchainConfig`. The Deputy must not be able to trigger any other privileged
 action on behalf of the Guardian.
 
 #### Impact

--- a/specs/protocol/isthmus/exec-engine.md
+++ b/specs/protocol/isthmus/exec-engine.md
@@ -229,6 +229,15 @@ Where:
 - `operatorFeeScalar` is a `uint32` scalar set by the chain operator, scaled by `1e6`.
 - `operatorFeeConstant` is a `uint64` scalar set by the chain operator.
 
+Note that the operator fee's maximum value has 77 bits, which can be calculated from the maximum input parameters:
+
+$$
+\text{operatorFee}\_{max} = (\text{uint64}\_{max} \times \text{uint32}\_{max} \div 10^6) + \text{uint64}\_{max}
+\approx 7.924660923989131 \times 10^{22}
+$$
+
+So implementations don't need to check for overflows if they perform the calculations with `uint256` types.
+
 #### Deposit Operator Fees
 
 Deposit transactions do not get charged operator fees. For all deposit transactions, regardless of the operator fee

--- a/specs/protocol/stage-1.md
+++ b/specs/protocol/stage-1.md
@@ -152,7 +152,7 @@ A Stage 1 OP Stack chain must have a Security Council.
 
 ### Upgrade Controller
 
-The [Upgrade Controller](#upgrade-controller) role in the OP Stack is a priviledged role that is
+The [Upgrade Controller](#upgrade-controller) role in the OP Stack is a privileged role that is
 allowed to upgrade the smart contracts that make up an OP Stack chain's onchain footprint. This
 role must require sign-off from the Security Council. This specifically means that the role can
 either be entirely held by the Security Council or by some other configuration as long as the
@@ -173,7 +173,7 @@ because the Security Council is a required signatory on this role.
 
 ### Guardian
 
-The [Guardian](#guardian) role in the OP Stack is a priviledged role that is allowed to execute
+The [Guardian](#guardian) role in the OP Stack is a privileged role that is allowed to execute
 certain safety-net actions in the case that a bug exists in the OP Stack smart contracts. This role
 must be held by the Security Council in the form of a 1/1 Safe owned by the Security Council.
 

--- a/words.txt
+++ b/words.txt
@@ -196,6 +196,7 @@ reposted
 returndata
 Rollups
 rollups
+runbooks
 Sched
 sched
 secp
@@ -216,6 +217,7 @@ subgame
 Subgames
 subgames
 sublinear
+SUPC
 Superchain
 superchain
 superfactory


### PR DESCRIPTION
**Description**

Adds a paragraph to the operator fee spec calculating its max value and implications for implementations.

**Metadata**

Closes https://github.com/ethereum-optimism/specs/issues/646
