### PR TITLE
Clarify extraData field requirements pre-Holocene

### DIFF
--- a/specs/protocol/deputy-pause-module.md
+++ b/specs/protocol/deputy-pause-module.md
@@ -261,7 +261,7 @@ the authorization of the social consensus process that typically triggers this p
 ### iDPM-002: Deputy must only be able to trigger the pause
 
 The Deputy must only be able to trigger the pause action by causing the module to call the `pause`
-function on the `SuperchainConfig`. The Deputy must not be able to trigger any other priviledged
+function on the `SuperchainConfig`. The Deputy must not be able to trigger any other privileged
 action on behalf of the Guardian.
 
 #### Impact

--- a/specs/protocol/exec-engine.md
+++ b/specs/protocol/exec-engine.md
@@ -5,6 +5,7 @@
 **Table of Contents**
 
 - [1559 Parameters](#1559-parameters)
+- [Extra Data](#extra-data)
 - [Deposited transaction processing](#deposited-transaction-processing)
   - [Deposited transaction boundaries](#deposited-transaction-boundaries)
 - [Fees](#fees)
@@ -45,7 +46,16 @@ The execution engine must be able to take a per chain configuration which specif
 and EIP-1559 elasticity. After Canyon it should also take a new value `EIP1559DenominatorCanyon` and use that as
 the denominator in the 1559 formula rather than the prior denominator.
 
-The formula for EIP-1559 is not otherwise modified.
+The formula for EIP-1559 is otherwise not modified.
+
+Starting with Holocene, the EIP-1559 parameters become [dynamically configurable](holocene/exec-engine.md#dynamic-eip-1559-parameters).
+
+## Extra Data
+
+Before Holocene, the genesis block may contain an arbitrary `extraData` value whereas all normal
+blocks must have an **empty** `extraData` field.
+
+With Holocene, the `extraData` field [encodes the EIP-1559 parameters](holocene/exec-engine.md#dynamic-eip-1559-parameters).
 
 ## Deposited transaction processing
 
@@ -213,7 +223,7 @@ to [`engine_forkchoiceUpdatedV2`][engine_forkchoiceUpdatedV2]: the extended `Pay
 ```js
 PayloadAttributesV2: {
     timestamp: QUANTITY
-    random: DATA (32 bytes)
+    prevRandao: DATA (32 bytes)
     suggestedFeeRecipient: DATA (20 bytes)
     withdrawals: array of WithdrawalV1
     transactions: array of DATA
@@ -269,13 +279,14 @@ to [`engine_forkchoiceUpdatedV3`][engine_forkchoiceUpdatedV3]: the extended `Pay
 ```js
 PayloadAttributesV3: {
     timestamp: QUANTITY
-    random: DATA (32 bytes)
+    prevRandao: DATA (32 bytes)
     suggestedFeeRecipient: DATA (20 bytes)
     withdrawals: array of WithdrawalV1
     parentBeaconBlockRoot: DATA (32 bytes)
     transactions: array of DATA
     noTxPool: bool
     gasLimit: QUANTITY or null
+    eip1559Params: DATA (8 bytes) or null
 }
 ```
 
@@ -284,6 +295,9 @@ the addition of `parentBeaconBlockRoot` which is the parent beacon block root fr
 
 Starting at Ecotone, the `parentBeaconBlockRoot` must be set to the L1 origin `parentBeaconBlockRoot`,
 or a zero `bytes32` if the Dencun functionality with `parentBeaconBlockRoot` is not active on L1.
+
+Starting with Holocene, the `eip1559Params` field must encode the EIP1559 parameters. It must be `null` before.
+See [Dynamic EIP-1559 Parameters](holocene/exec-engine.md#dynamic-eip-1559-parameters) for details.
 
 ### `engine_newPayloadV2`
 

--- a/specs/protocol/holocene/exec-engine.md
+++ b/specs/protocol/holocene/exec-engine.md
@@ -60,7 +60,7 @@ type is extended with an additional value, `eip1559Params`:
 ```rs
 PayloadAttributesV3: {
     timestamp: QUANTITY
-    random: DATA (32 bytes)
+    prevRandao: DATA (32 bytes)
     suggestedFeeRecipient: DATA (20 bytes)
     withdrawals: array of WithdrawalV1
     parentBeaconBlockRoot: DATA (32 bytes)
@@ -106,9 +106,9 @@ were [constants](../exec-engine.md#1559-parameters).
 With the Holocene upgrade, these parameters are instead determined as follows:
 
 - if Holocene is not active in `parent_header.timestamp`, the [prior EIP-1559
-  constants](../exec-engine.md#1559-parameters) constants are used. While `parent_header.extraData` is typically empty
-  prior to Holocene, there are some legacy cases where it may be set arbitrarily, so it must not be assumed to be empty.
-- if Holocene is active in `parent_header.timestamp`, then the parameters from `parent_header.extraData` are used.
+  constants](../exec-engine.md#1559-parameters) are used. Note that `parent_header.extraData` is empty
+  prior to Holocene, except possibly for the genesis block.
+- if Holocene is active at `parent_header.timestamp`, then the parameters from `parent_header.extraData` are used.
 
 ### Rationale
 

--- a/specs/protocol/isthmus/exec-engine.md
+++ b/specs/protocol/isthmus/exec-engine.md
@@ -229,6 +229,15 @@ Where:
 - `operatorFeeScalar` is a `uint32` scalar set by the chain operator, scaled by `1e6`.
 - `operatorFeeConstant` is a `uint64` scalar set by the chain operator.
 
+Note that the operator fee's maximum value has 77 bits, which can be calculated from the maximum input parameters:
+
+$$
+\text{operatorFee}\_{max} = (\text{uint64}\_{max} \times \text{uint32}\_{max} \div 10^6) + \text{uint64}\_{max}
+\approx 7.924660923989131 \times 10^{22}
+$$
+
+So implementations don't need to check for overflows if they perform the calculations with `uint256` types.
+
 #### Deposit Operator Fees
 
 Deposit transactions do not get charged operator fees. For all deposit transactions, regardless of the operator fee

--- a/specs/protocol/stage-1.md
+++ b/specs/protocol/stage-1.md
@@ -152,7 +152,7 @@ A Stage 1 OP Stack chain must have a Security Council.
 
 ### Upgrade Controller
 
-The [Upgrade Controller](#upgrade-controller) role in the OP Stack is a priviledged role that is
+The [Upgrade Controller](#upgrade-controller) role in the OP Stack is a privileged role that is
 allowed to upgrade the smart contracts that make up an OP Stack chain's onchain footprint. This
 role must require sign-off from the Security Council. This specifically means that the role can
 either be entirely held by the Security Council or by some other configuration as long as the
@@ -173,7 +173,7 @@ because the Security Council is a required signatory on this role.
 
 ### Guardian
 
-The [Guardian](#guardian) role in the OP Stack is a priviledged role that is allowed to execute
+The [Guardian](#guardian) role in the OP Stack is a privileged role that is allowed to execute
 certain safety-net actions in the case that a bug exists in the OP Stack smart contracts. This role
 must be held by the Security Council in the form of a 1/1 Safe owned by the Security Council.
 

--- a/words.txt
+++ b/words.txt
@@ -196,6 +196,7 @@ reposted
 returndata
 Rollups
 rollups
+runbooks
 Sched
 sched
 secp
@@ -216,6 +217,7 @@ subgame
 Subgames
 subgames
 sublinear
+SUPC
 Superchain
 superchain
 superfactory


### PR DESCRIPTION
**Description**

Clarifies `extraData` field requirements pre- and post-Holocene.

Also fixes the `PayloadAttributes` random field to `prevRandao`.

**Additional context**

First PR created with jj!

Stacked on top of #651 

**Metadata**

Fixes https://github.com/ethereum-optimism/specs/issues/649
