### PR TITLE
chore: update rejection criteria for blocks in rollup-node-p2p spec

### DIFF
--- a/specs/protocol/rollup-node-p2p.md
+++ b/specs/protocol/rollup-node-p2p.md
@@ -321,9 +321,9 @@ An [extended-validator] checks the incoming messages as follows, in order of ope
 - `[REJECT]` if the block is on a topic >= V2 and does not have an empty withdrawals list
 - `[REJECT]` if the block is on a topic <= V2 and has a blob gas-used value set
 - `[REJECT]` if the block is on a topic <= V2 and has an excess blob gas value set
+- `[REJECT]` if the block is on a topic <= V2 and the parent beacon block root is not nil
 - `[REJECT]` if the block is on a topic >= V3 and has a blob gas-used value that is not zero
 - `[REJECT]` if the block is on a topic >= V3 and has an excess blob gas value that is not zero
-- `[REJECT]` if the block is on a topic <= V2 and the parent beacon block root is not nil
 - `[REJECT]` if the block is on a topic >= V3 and the parent beacon block root is nil
 - `[REJECT]` if the block is on a topic <= V3 and the l2 withdrawals root is not nil
 - `[REJECT]` if the block is on a topic >= V4 and the l2 withdrawals root is nil


### PR DESCRIPTION
**Description**

This pull request includes a small change to the `specs/protocol/rollup-node-p2p.md` file. The change reorders the conditions for rejecting blocks based on the topic version and the parent beacon block root.

Reordering of rejection conditions:

* [`specs/protocol/rollup-node-p2p.md`](diffhunk://#diff-13b714d4f81421fbdc784be91da466078cabd7f04b932264205fc221c4753b84R324-L326): Moved the condition for rejecting blocks with a non-nil parent beacon block root on topic <= V2 up in the list to maintain logical order.<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->


**Tests**

N/A

**Additional context**

N/A


**Metadata**

N/A

