### PR TITLE
Change interop expiry window to 30 days

### DIFF
--- a/specs/interop/messaging.md
+++ b/specs/interop/messaging.md
@@ -151,7 +151,7 @@ The expiry invariant invalidates inclusion of any executing message with
 
 - `id` is the [`Identifier`] encoded in the executing message, matching the block attributes of the initiating message.
 - `executing_block` is the block where the executing message was included in.
-- `EXPIRY_TIME = 180 * 24 * 60 * 60 = 15552000` seconds, i.e. 180 days.
+- `EXPIRY_TIME = 30 * 24 * 60 * 60 = 15552000` seconds, i.e. 30 days.
 
 ## Message Graph
 


### PR DESCRIPTION
It should be 30 days: https://github.com/ethereum-optimism/optimism/issues/13918#issuecomment-2785085550