### PR TITLE
Wording Fixes in standard-l2-genesis.md and bond-incentives.md

### DIFF
--- a/specs/experimental/standard-l2-genesis.md
+++ b/specs/experimental/standard-l2-genesis.md
@@ -210,7 +210,7 @@ The `upgrader` can only be set during initialization.
 ## Deterministic genesis state
 
 This upgrade enables a deterministic L2 genesis state by moving all network
-specific configuration out of the initial L2 genesis state. All network specific
+specific configuration from the initial L2 genesis state. All network specific
 configuration is sourced from deposit transactions during the initialization
 of the `SystemConfig`.
 

--- a/specs/fault-proof/stage-one/bond-incentives.md
+++ b/specs/fault-proof/stage-one/bond-incentives.md
@@ -29,7 +29,7 @@
 
 ## Overview
 
-Bonds is an add-on to the core [Fault Dispute Game](fault-dispute-game.md). The core game mechanics are
+Bonds are an add-on to the core [Fault Dispute Game](fault-dispute-game.md). The core game mechanics are
 designed to ensure honesty as the best response to winning subgames. By introducing financial incentives,
 Bonds makes it worthwhile for honest challengers to participate.
 Without the bond reward incentive, the FDG will be too costly for honest players to participate in given the


### PR DESCRIPTION
This PR fixes minor wording issues for clarity and grammar:

Replaced "out of" with "from" in standard-l2-genesis.md for better phrasing.

Corrected "Bonds is" to "Bonds are" in bond-incentives.md for grammatical correctness.