### PR TITLE
specs: update expiry window

### DIFF
--- a/specs/interop/derivation.md
+++ b/specs/interop/derivation.md
@@ -287,7 +287,7 @@ The expiry window is the time period after which an initiating message is no lon
 
 | Constant | Value |
 | -------- | ----- |
-| `EXPIRY_WINDOW` | `2592000 secs` (30 days) |
+| `EXPIRY_WINDOW` | `604800 secs` (7 days) |
 
 ## Security Considerations
 

--- a/specs/interop/messaging.md
+++ b/specs/interop/messaging.md
@@ -161,7 +161,7 @@ The expiry invariant invalidates inclusion of any executing message with
 
 - `id` is the [`Identifier`] encoded in the executing message, matching the block attributes of the initiating message.
 - `executing_block` is the block where the executing message was included in.
-- `EXPIRY_TIME = 30 * 24 * 60 * 60 = 15552000` seconds, i.e. 30 days.
+- `EXPIRY_TIME = 7 * 24 * 60 * 60 = 604800` seconds, i.e. 7 days.
 
 ## Message Graph
 


### PR DESCRIPTION
Per the decision doc, we have agreed to update the expiry window to be 7
days.

- User experience of expired messages is minimal given the ability to re-emit.
  - The autorelayer handling cross-chain message passing dramatically reduces the
    probability of any message even reaching the 7 day expiry
  - We can clearly document how resendMessage() is only available for initiating
    messages that rely on the CDM, and that there is a significant risk of expiry
    if using a lower-level abstraction (e.g. CrossL2Inbox)
- While we *believe* that there is work to scale the proof system to support more
  than 2 chains, we have not benchmarked this yet – if it turns out that we can
  support more than 2 without needing to break up consolidation, reducing the expiry
  window proactively accelerates this timeline. There is no harm in shortening the expiry window.

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
