### PR TITLE
fix: update link to OptimismMintableERC721Factory.sol

### DIFF
--- a/specs/protocol/predeploys.md
+++ b/specs/protocol/predeploys.md
@@ -302,7 +302,7 @@ and burn tokens, depending on if the user is depositing from L1 to L2 or withdra
 
 ## OptimismMintableERC721Factory
 
-[Implementation](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/universal/OptimismMintableERC721Factory.sol)
+[Implementation](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L2/OptimismMintableERC721Factory.sol)
 
 Address: `0x4200000000000000000000000000000000000017`
 


### PR DESCRIPTION
Replaced the outdated and broken link to the OptimismMintableERC721Factory.sol contract (previously in the universal folder) with the correct and working link from the L2 folder in the ethereum-optimism/optimism repository. The link now correctly points to the contract source code.