### PR TITLE
Fix broken EAS.sol link to official Ethereum Attestation Service repository

### DIFF
--- a/specs/protocol/predeploys.md
+++ b/specs/protocol/predeploys.md
@@ -341,7 +341,7 @@ protocol.
 
 ## EAS
 
-[Implementation](https://github.com/ethereum-attestation-service/eas-contracts/blob/master/contracts/EAS.sol)
+[Implementation](https://github.com/ethereum-optimism/optimism/tree/develop/packages/contracts-bedrock/src/vendor/eas)
 
 Address: `0x4200000000000000000000000000000000000021`
 

--- a/specs/protocol/predeploys.md
+++ b/specs/protocol/predeploys.md
@@ -341,7 +341,7 @@ protocol.
 
 ## EAS
 
-[Implementation](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/EAS/EAS.sol)
+[Implementation](https://github.com/ethereum-attestation-service/eas-contracts/blob/master/contracts/EAS.sol)
 
 Address: `0x4200000000000000000000000000000000000021`
 


### PR DESCRIPTION


Replaced the outdated and broken link to EAS.sol in the predeploys documentation with the correct URL pointing to the official Ethereum Attestation Service (EAS) contract in the ethereum-attestation-service/eas-contracts repository. This ensures that readers can access the latest and authoritative implementation of the EAS contract.

