### PR TITLE
Link Operator Fee predeploy spec to Fee Vaults section

### DIFF
--- a/specs/protocol/isthmus/predeploys.md
+++ b/specs/protocol/isthmus/predeploys.md
@@ -41,4 +41,6 @@ No special logic is needed in order to insert or withdraw funds.
 
 Its address will be `0x420000000000000000000000000000000000001b`.
 
+See also [Fee Vaults](./exec-engine.md#fee-vaults).
+
 ## Security Considerations


### PR DESCRIPTION
Adds link from Isthmus predeploy's Operator Fee section to section on Fee Vaults, for helpful context.

Ref https://github.com/ethereum-optimism/specs/issues/727