### PR TITLE
spec: Add `DerivationCurrentL1Update`

### DIFF
--- a/specs/interop/managed-node.md
+++ b/specs/interop/managed-node.md
@@ -9,7 +9,7 @@
   - [Reset](#reset)
   - [UnsafeBlock](#unsafeblock)
   - [DerivationUpdate](#derivationupdate)
-  - [DerivationOriginUpdate](#derivationoriginupdate)
+  - [DerivationCurrentL1Update](#derivationcurrentl1update)
   - [ExhaustL1](#exhaustl1)
   - [ReplaceBlock](#replaceblock)
 - [Supervisor `->` Node](#supervisor---node)
@@ -66,7 +66,7 @@ ManagedEvent {
     Reset,
     UnsafeBlock,
     DerivationUpdate,
-    DerivationOriginUpdate,
+    DerivationCurrentL1Update,
     ExhaustL1,
     ReplaceBlock
 }
@@ -102,14 +102,16 @@ DerivationUpdate: DerivedBlockRefPair {
 
 Signals that an L2 block is considered local-safe.
 
-### DerivationOriginUpdate
+### DerivationCurrentL1Update
 
 ```javascript
-DerivationOriginUpdate: BlockRef
+DerivationCurrentL1Update: DerivedBlockRefPair {
+    source: BlockRef  //Newly observed L1
+    derived: BlockRef //L2's BlockRef
+}
 ```
 
-Signals that an L2 block is now local-safe because of the given L1 traversal. This would be accompanied with
-`DerivationUpdate`.
+Signals that an L2 block is considered local-safe following the observation of a new L1 block.
 
 ### ExhaustL1
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Based on the discussions at https://github.com/ethereum-optimism/optimism/issues/16275, add the `DerivationCurrentL1Update` event and remove the `DerivationOriginUpdate` event.

**Additional context**

Specs should be updated before the actual code is updated. Monorepo PR for update: https://github.com/ethereum-optimism/optimism/pull/16501 
