### PR TITLE
specs: extend `interop_blockRefByNumber` to `interop_l2BlockRefByNumber`

### DIFF
--- a/specs/interop/managed-node.md
+++ b/specs/interop/managed-node.md
@@ -26,7 +26,7 @@
   - [Sync Methods](#sync-methods)
     - [interop_fetchReceipts](#interop_fetchreceipts)
     - [interop_l2BlockRefByTimestamp](#interop_l2blockrefbytimestamp)
-    - [interop_blockRefByNumber](#interop_blockrefbynumber)
+    - [interop_l2BlockRefByNumber](#interop_l2blockrefbynumber)
     - [interop_chainID](#interop_chainid)
     - [interop_outputV0AtTimestamp](#interop_outputv0attimestamp)
     - [interop_pendingOutputV0AtTimestamp](#interop_pendingoutputv0attimestamp)
@@ -242,13 +242,13 @@ payload (uint64) -> BlockRef
 
 Fetches L2 BlockRef of the block that occurred at given timestamp
 
-#### interop_blockRefByNumber
+#### interop_l2BlockRefByNumber
 
 ```javascript
-payload (uint64) -> BlockRef
+payload (uint64) -> L2BlockRef
 ```
 
-Fetches the BlockRef from a given L2 block number
+Fetches the L2 BlockRef from a given L2 block number
 
 #### interop_chainID
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Supervisor must know the L1 origin of L2 block, which require rpc to return L2BlockRef using the L2 block number. Supervisor decides the local unsafe reset target, and while doing that we need an L1 origin field, to detect L1 reorg.  Extend the original `interop_blockRefByNumber` to `interop_l2BlockRefByNumber`.

Ref: comment at https://github.com/ethereum-optimism/optimism/pull/16557#discussion_r2171880900