### PR TITLE
fix: remove trailing comma in .markdownlint.json

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -4,7 +4,7 @@
     "strict": false,
     "stern": false,
     "code_blocks": false,
-    "tables": false,
+    "tables": false
   },
   "no-duplicate-heading": {
     "siblings_only": true


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Removes the trailing comma after the "tables": false property in the line_length object, fixing a JSON syntax error. This ensures the file is valid according to JSON specification and will work correctly with strict JSON parsers.