### PR TITLE
fix(supervisor/rpc): clarify null representation for BlockRef and BlockID in `syncStatus` method

### DIFF
--- a/specs/interop/supervisor.md
+++ b/specs/interop/supervisor.md
@@ -180,6 +180,9 @@ chains in `chains`.
 - `finalizedTimestamp`: `Int` - finalized timestamp
 - `chains`: `OBJECT` with `ChainID` keys and `SupervisorChainSyncStatus` values
 
+> **Note:**  
+> If `minSyncedL1` does not exist, it MUST be represented as a `BlockRef` with a `hash` and `parentHash` of `0x0000000000000000000000000000000000000000000000000000000000000000`, a `number` of `0`, and a `timestamp` of `0`.
+
 #### `SupervisorChainSyncStatus`
 
 Describes the sync status for a specific chain
@@ -190,6 +193,9 @@ Describes the sync status for a specific chain
 - `crossUnsafe`: `BlockID` - cross-unsafe ref for the given chain
 - `safe`: `BlockID` - cross-safe ref for the given chain
 - `finalized`: `BlockID` - finalized ref for the given chain
+
+> **Note:**  
+> For the fields `localSafe`, `crossUnsafe`, `safe`, and `finalized`, if the referenced block does not exist yet, the `BlockID` MUST be represented with a `hash` of `0x0000000000000000000000000000000000000000000000000000000000000000` and a `number` of `0`.
 
 #### `SuperRootResponse`
 

--- a/specs/interop/supervisor.md
+++ b/specs/interop/supervisor.md
@@ -181,7 +181,9 @@ chains in `chains`.
 - `chains`: `OBJECT` with `ChainID` keys and `SupervisorChainSyncStatus` values
 
 > **Note:**  
-> If `minSyncedL1` does not exist, it MUST be represented as a `BlockRef` with a `hash` and `parentHash` of `0x0000000000000000000000000000000000000000000000000000000000000000`, a `number` of `0`, and a `timestamp` of `0`.
+> If `minSyncedL1` does not exist, it MUST be represented as a `BlockRef` with a `hash` and `parentHash` of  
+> `0x0000000000000000000000000000000000000000000000000000000000000000`, a `number` of `0`,  
+> and a `timestamp` of `0`.
 
 #### `SupervisorChainSyncStatus`
 
@@ -195,7 +197,9 @@ Describes the sync status for a specific chain
 - `finalized`: `BlockID` - finalized ref for the given chain
 
 > **Note:**  
-> For the fields `localSafe`, `crossUnsafe`, `safe`, and `finalized`, if the referenced block does not exist yet, the `BlockID` MUST be represented with a `hash` of `0x0000000000000000000000000000000000000000000000000000000000000000` and a `number` of `0`.
+> For the fields `localSafe`, `crossUnsafe`, `safe`, and `finalized`, if the referenced block does not exist yet,  
+> the `BlockID` MUST be represented with a `hash` of  
+> `0x0000000000000000000000000000000000000000000000000000000000000000` and a `number` of `0`.
 
 #### `SuperRootResponse`
 


### PR DESCRIPTION
This PR updates the Supervisor API specification to clarify how missing or non-existent block references should be represented in API responses.

- Adds a note to `SupervisorSyncStatus` specifying that if `minSyncedL1` does not exist, it must be represented as a `BlockRef` with all-zero hash and parentHash, number: 0, and timestamp: 0.
- Adds a note to `SupervisorChainSyncStatus` specifying that for the fields localSafe, crossUnsafe, safe, and finalized, if the referenced block does not exist, the `BlockID` must be represented with an all-zero hash and number: 0.