### PR TITLE
Fix glossary links for L2 Chain Derivation and L2 Chain Inception

### DIFF
--- a/specs/protocol/derivation.md
+++ b/specs/protocol/derivation.md
@@ -49,7 +49,7 @@
 
 <!-- All glossary references in this file. -->
 
-[g-derivation]: ../glossary.md#L2-chain-derivation
+[g-derivation]: ../glossary.md#l2-chain-derivation
 [g-payload-attr]: ../glossary.md#payload-attributes
 [g-block]: ../glossary.md#block
 [g-exec-engine]: ../glossary.md#execution-engine
@@ -67,7 +67,7 @@
 [g-sequencing-window]: ../glossary.md#sequencing-window
 [g-sequencer-batch]: ../glossary.md#sequencer-batch
 [g-l2-genesis]: ../glossary.md#l2-genesis-block
-[g-l2-chain-inception]: ../glossary.md#L2-chain-inception
+[g-l2-chain-inception]: ../glossary.md#l2-chain-inception
 [g-l2-genesis-block]: ../glossary.md#l2-genesis-block
 [g-batcher-transaction]: ../glossary.md#batcher-transaction
 [g-avail-provider]: ../glossary.md#data-availability-provider


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Element ID is improperly capitalized for L2 Chain Derivation and L2 Chain Inception links in this page, leading to links not going directly to the definition.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

Not tested, proper links can be seen by navigating to the glossary for each item:
https://specs.optimism.io/glossary.html#l2-chain-derivation
https://specs.optimism.io/glossary.html#l2-chain-inception

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
