### PR TITLE
Remove CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @ethereum-optimism/specs-reviewers @ethereum-optimism/security-reviewers


### PR DESCRIPTION
In response to feedback from our most recent retro, we're removing the CODEOWNERS file from this repo. Teams know who to tag in to get spec review; we don't need to lock down the reviewer set on this repo specifically.