### PR TITLE
remove repetition in specification of `SystemConfig.ConfigUpdate` event

### DIFF
--- a/specs/protocol/holocene/system-config.md
+++ b/specs/protocol/holocene/system-config.md
@@ -22,15 +22,11 @@ The `SystemConfig` is updated to allow for dynamic EIP-1559 parameters.
 
 ### `ConfigUpdate`
 
-The following `ConfigUpdate` event is defined where the `CONFIG_VERSION` is `uint256(0)`:
+When the configuration is updated, a [`ConfigUpdate`](../system-config.html#system-config-updates) event MUST be emitted with the following parameters:
 
-| Name | Value | Definition | Usage |
+| `version` | `updateType` | `data` | Usage |
 | ---- | ----- | --- | -- |
-| `BATCHER` | `uint8(0)` | `abi.encode(address)` | Modifies the account that is authorized to progress the safe chain |
-| `FEE_SCALARS` | `uint8(1)` | `abi.encode(uint256(0), (uint256(0x01) << 248) \| (uint256(_blobbasefeeScalar) << 32) \| _basefeeScalar)` | Modifies the fee scalars |
-| `GAS_LIMIT` | `uint8(2)` | `abi.encode(uint64 _gasLimit)` | Modifies the L2 gas limit |
-| `UNSAFE_BLOCK_SIGNER` | `uint8(3)` | `abi.encode(address)` | Modifies the account that is authorized to progress the unsafe chain |
-| `EIP_1559_PARAMS` | `uint8(4)` | `abi.encode((uint256(_denominator) << 32) \| _elasticity)` | Modifies the EIP-1559 denominator and elasticity |
+| `uint256(0)` | `uint8(4)` | `abi.encode((uint256(_denominator) << 32) \| _elasticity)` | Modifies the EIP-1559 denominator and elasticity |
 
 Note that the above encoding is the format emitted by the SystemConfig event, which differs from the format in extraData
 from the block header.
@@ -47,7 +43,7 @@ The following actions should happen during the initialization of the `SystemConf
 Intentionally absent from this is `emit ConfigUpdate.EIP_1559_PARAMS`.
 As long as these values are unset, the default values will be used.
 Requiring 1559 parameters to be set during initialization would add a strict requirement
-that the L2 hardforks before the L1 contracts, and this is complicated to manage in a
+that the L2 hardforks before the L1 contracts are upgraded, and this is complicated to manage in a
 world of many chains.
 
 ### Modifying EIP-1559 Parameters

--- a/specs/protocol/holocene/system-config.md
+++ b/specs/protocol/holocene/system-config.md
@@ -22,7 +22,8 @@ The `SystemConfig` is updated to allow for dynamic EIP-1559 parameters.
 
 ### `ConfigUpdate`
 
-When the configuration is updated, a [`ConfigUpdate`](../system-config.html#system-config-updates) event MUST be emitted with the following parameters:
+When the configuration is updated, a [`ConfigUpdate`](../system-config.html#system-config-updates) event
+MUST be emitted with the following parameters:
 
 | `version` | `updateType` | `data` | Usage |
 | ---- | ----- | --- | -- |

--- a/specs/protocol/jovian/system-config.md
+++ b/specs/protocol/jovian/system-config.md
@@ -6,6 +6,7 @@
 
 - [Minimum Base Fee Configuration](#minimum-base-fee-configuration)
   - [`ConfigUpdate`](#configupdate)
+  - [Initialization](#initialization)
   - [Modifying Minimum Base Fee](#modifying-minimum-base-fee)
   - [Interface](#interface)
     - [Minimum Base Fee Parameters](#minimum-base-fee-parameters)

--- a/specs/protocol/jovian/system-config.md
+++ b/specs/protocol/jovian/system-config.md
@@ -33,7 +33,7 @@ function setMinBaseFee(uint64 minBaseFee) external onlyOwner;
 When the configuration is updated, a [`ConfigUpdate`](../system-config.html#system-config-updates) event MUST be emitted with the following parameters:
 
 | `version` | `updateType` | `data` | Usage |
-
+| ---- | ----- | --- | -- |
 | `uint256(0)` | `uint8(6)` | `abi.encode(uint64(_minBaseFee))` | Modifies the minimum base fee (wei) |
 
 ### Initialization

--- a/specs/protocol/jovian/system-config.md
+++ b/specs/protocol/jovian/system-config.md
@@ -30,7 +30,8 @@ function setMinBaseFee(uint64 minBaseFee) external onlyOwner;
 
 ### `ConfigUpdate`
 
-When the configuration is updated, a [`ConfigUpdate`](../system-config.html#system-config-updates) event MUST be emitted with the following parameters:
+When the configuration is updated, a [`ConfigUpdate`](../system-config.html#system-config-updates) event
+MUST be emitted with the following parameters:
 
 | `version` | `updateType` | `data` | Usage |
 | ---- | ----- | --- | -- |

--- a/specs/protocol/jovian/system-config.md
+++ b/specs/protocol/jovian/system-config.md
@@ -30,25 +30,34 @@ function setMinBaseFee(uint64 minBaseFee) external onlyOwner;
 
 ### `ConfigUpdate`
 
-The following `ConfigUpdate` event is defined where the `CONFIG_VERSION` is `uint256(0)`:
+When the configuration is updated, a [`ConfigUpdate`](../system-config.html#system-config-updates) event MUST be emitted with the following parameters:
 
-| Name | Value | Definition | Usage |
-| ---- | ----- | --- | -- |
-| `BATCHER` | `uint8(0)` | `abi.encode(address)` | Modifies the account that is authorized to progress the safe chain |
-| `FEE_SCALARS` | `uint8(1)` | `(uint256(0x01) << 248) \| (uint256(_blobbasefeeScalar) << 32) \| _basefeeScalar` | Modifies the fee scalars |
-| `GAS_LIMIT` | `uint8(2)` | `abi.encode(uint64 _gasLimit)` | Modifies the L2 gas limit |
-| `UNSAFE_BLOCK_SIGNER` | `uint8(3)` | `abi.encode(address)` | Modifies the account that is authorized to progress the unsafe chain |
-| `EIP_1559_PARAMS` | `uint8(4)` | `uint256(uint64(uint32(_denominator))) << 32 \| uint64(uint32(_elasticity))` | Modifies the EIP-1559 denominator and elasticity |
-| `OPERATOR_FEE_PARAMS` | `uint8(5)` | `uint256(_operatorFeeScalar) << 64 \| _operatorFeeConstant` | Modifies the operator fee scalar and constant |
-| `MIN_BASE_FEE` | `uint8(6)` | `abi.encode(uint64(_minBaseFee))` | Modifies the minimum base fee (wei) |
+| `version` | `updateType` | `data` | Usage |
+
+| `uint256(0)` | `uint8(6)` | `abi.encode(uint64(_minBaseFee))` | Modifies the minimum base fee (wei) |
+
+### Initialization
+
+The following actions should happen during the initialization of the `SystemConfig`:
+
+- `emit ConfigUpdate.BATCHER`
+- `emit ConfigUpdate.FEE_SCALARS`
+- `emit ConfigUpdate.GAS_LIMIT`
+- `emit ConfigUpdate.UNSAFE_BLOCK_SIGNER`
+
+Intentionally absent from this is `emit ConfigUpdate.EIP_1559_PARAMS` and `emit ConfigUpdate.MIN_BASE_FEE`.
+As long as these values are unset, the default values will be used.
+Requiring these parameters to be set during initialization would add a strict requirement
+that the L2 hardforks before the L1 contracts are upgraded, and this is complicated to manage in a
+world of many chains.
 
 ### Modifying Minimum Base Fee
 
-Upon update, the contract emits a `ConfigUpdate` event with a new `UpdateType` value `MIN_BASE_FEE`, enabling nodes
+Upon update, the contract emits the `ConfigUpdate` event above, enabling nodes
 to derive the configuration from L1 logs.
 
 Implementations MUST incorporate the configured value into the block header `extraData` as specified in
-`./exec-engine.md`.
+`./exec-engine.md`. Until the first such event is emitted, a default value of `0` should be used.
 
 ### Interface
 


### PR DESCRIPTION
1. The old "name" field is not part of the protocol specification, it is an implementation detail. 
2. We don't need to repeat all of the paramters each time we add a new set. 
3. The parameters should have more meaningful names.
4. We can reuse the logic about not emitting the config update event for min base fee during initialization
