### PR TITLE
da footprint: clarify exec engine section

### DIFF
--- a/specs/protocol/jovian/exec-engine.md
+++ b/specs/protocol/jovian/exec-engine.md
@@ -99,7 +99,7 @@ where `intercept`, `minTransactionSize`, `fastLzCoef` and `fastlzSize`
 are defined in the [Fjord specs](../fjord/exec-engine.md) and `/` represents integer division.
 
 From Jovian, the `gasUsed` property of each block header is equal to the maximum over
-that block's `daFootprint` and the sum of the gas used by each transaction.
+that block's `daFootprint` and the sum of the gas used by each transaction (the pre-Jovian definition of a block's `gasUsed` field).
 As a result, blocks with high DA usage may cause the base fee to increase in subsequent blocks.
 
 The `gasUsed` must continue to be less than or equal to the block gas limit, meaning that

--- a/specs/protocol/jovian/exec-engine.md
+++ b/specs/protocol/jovian/exec-engine.md
@@ -83,6 +83,8 @@ contract values to the block builder via `PayloadAttributesV3` parameters.
 
 ## DA Footprint Block Limit
 
+A DA footprint block limit is introduced to limit the total amount of estimated compressed transaction data that can fit into a block. For each transaction, a new resource called DA footprint is tracked, next to its gas usage. It is scaled to the gas dimension so that its block total can also be limited by the block gas limit, like a block's total gas usage.
+
 Let a block's `daFootprint` be defined as follows:
 
 ```python

--- a/specs/protocol/jovian/exec-engine.md
+++ b/specs/protocol/jovian/exec-engine.md
@@ -104,7 +104,7 @@ As a result, blocks with high DA usage may cause the base fee to increase in sub
 
 The `gasUsed` must continue to be less than or equal to the block gas limit, meaning that
 (since the `daFootprint` must also be less than or equal to the block gas limit),
-blocks have an effective "DA footprint Block Limit" of `gasLimit/daFootprintGasScalar`.
+blocks may have no more than `gasLimit/daFootprintGasScalar` total estimated DA usage.
 
 ### Scalar loading
 

--- a/specs/protocol/jovian/exec-engine.md
+++ b/specs/protocol/jovian/exec-engine.md
@@ -83,7 +83,11 @@ contract values to the block builder via `PayloadAttributesV3` parameters.
 
 ## DA Footprint Block Limit
 
-A DA footprint block limit is introduced to limit the total amount of estimated compressed transaction data that can fit into a block. For each transaction, a new resource called DA footprint is tracked, next to its gas usage. It is scaled to the gas dimension so that its block total can also be limited by the block gas limit, like a block's total gas usage.
+A DA footprint block limit is introduced to limit the total amount of estimated compressed
+transaction data that can fit into a block.
+ For each transaction, a new resource called DA footprint is tracked, next to its gas usage.
+ It is scaled to the gas dimension so that its block total can also be limited by
+ the block gas limit, like a block's total gas usage.
 
 Let a block's `daFootprint` be defined as follows:
 
@@ -101,7 +105,8 @@ where `intercept`, `minTransactionSize`, `fastLzCoef` and `fastlzSize`
 are defined in the [Fjord specs](../fjord/exec-engine.md) and `/` represents integer division.
 
 From Jovian, the `gasUsed` property of each block header is equal to the maximum over
-that block's `daFootprint` and the sum of the gas used by each transaction (the pre-Jovian definition of a block's `gasUsed` field).
+that block's `daFootprint` and the sum of the gas used by each transaction
+(the pre-Jovian definition of a block's `gasUsed` field).
 As a result, blocks with high DA usage may cause the base fee to increase in subsequent blocks.
 
 The `gasUsed` must continue to be less than or equal to the block gas limit, meaning that
@@ -113,7 +118,8 @@ blocks may have no more than `gasLimit/daFootprintGasScalar` total estimated DA 
 The `daFootprintGasScalar` is loaded in a similar way to the `operatorFeeScalar` and `operatorFeeConstant`
 [included](../isthmus/exec-engine.md#operator-fee) in the Isthmus fork. It can be read in two interchangable ways:
 
-- read from the deposited L1 attributes (`daFootprintGasScalar`) of the current L2 block (decoded according to the schema [here](./l1-attributes.md))
+- read from the deposited L1 attributes (`daFootprintGasScalar`) of the current L2 block
+(decoded according to the [jovian schema](./l1-attributes.md))
 - read from the L1 Block Info contract (`0x4200000000000000000000000000000000000015`)
   - using the solidity getter function `daFootprintGasScalar`
   - using a direct storage-read: big-endian `uint16` in slot `9` at offset `0`.

--- a/specs/protocol/jovian/exec-engine.md
+++ b/specs/protocol/jovian/exec-engine.md
@@ -81,6 +81,7 @@ similarly to `gasLimit`, with the derivation pipeline providing the appropriate 
 contract values to the block builder via `PayloadAttributesV3` parameters.
 
 ## DA Footprint Block Limit
+
 Let a block's `scaledDAFootprint` be defined as follows:
 
 ```python
@@ -92,10 +93,11 @@ def scaledDAFootprint(block)
         blockDAFootprint += txDAFootprint 
   return blockDAFootprint * daFootprintGasScalar
 ```
+
 where `intercept`, `minTransactionSize`, `fastLzCoef` and `fastlzSize`
 are defined in the [Fjord specs](../fjord/exec-engine.md).
 
-From Jovian, the `gasUsed` property of each block header is equal to the maximum over 
+From Jovian, the `gasUsed` property of each block header is equal to the maximum over
 that block's `scaledDAFootprint` and the sum of the gas used by each transaction.
 As a result, blocks with high DA usage may cause the base fee to increase in subsequent blocks.
 
@@ -104,6 +106,7 @@ The `gasUsed` must continue to be less than or equal to the block gas limit, mea
 blocks have an effective "DA footprint Block Limit" of `gasLimit/daFootprintGasScalar`.
 
 ### Scalar loading
+
 The `daFootprintGasScalar` is loaded in a similar way to the `operatorFeeScalar` and `operatorFeeConstant`
 [included](../isthmus/exec-engine.md#operator-fee) in the Isthmus fork. It can be read in two interchangable ways:
 

--- a/specs/protocol/jovian/exec-engine.md
+++ b/specs/protocol/jovian/exec-engine.md
@@ -9,6 +9,7 @@
   - [Minimum Base Fee in `PayloadAttributesV3`](#minimum-base-fee-in-payloadattributesv3)
   - [Rationale](#rationale)
 - [DA Footprint Block Limit](#da-footprint-block-limit)
+  - [Scalar loading](#scalar-loading)
   - [Rationale](#rationale-1)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->

--- a/specs/protocol/jovian/exec-engine.md
+++ b/specs/protocol/jovian/exec-engine.md
@@ -113,7 +113,7 @@ blocks may have no more than `gasLimit/daFootprintGasScalar` total estimated DA 
 The `daFootprintGasScalar` is loaded in a similar way to the `operatorFeeScalar` and `operatorFeeConstant`
 [included](../isthmus/exec-engine.md#operator-fee) in the Isthmus fork. It can be read in two interchangable ways:
 
-- read from the deposited L1 attributes (`daFootprintGasScalar`) of the current L2 block
+- read from the deposited L1 attributes (`daFootprintGasScalar`) of the current L2 block (decoded according to the schema [here](./l1-attributes.md))
 - read from the L1 Block Info contract (`0x4200000000000000000000000000000000000015`)
   - using the solidity getter function `daFootprintGasScalar`
   - using a direct storage-read: big-endian `uint16` in slot `9` at offset `0`.

--- a/specs/protocol/jovian/exec-engine.md
+++ b/specs/protocol/jovian/exec-engine.md
@@ -83,27 +83,27 @@ contract values to the block builder via `PayloadAttributesV3` parameters.
 
 ## DA Footprint Block Limit
 
-Let a block's `scaledDAFootprint` be defined as follows:
+Let a block's `daFootprint` be defined as follows:
 
 ```python
-def scaledDAFootprint(block)
-  blockDAFootprint = 0
+def daFootprint(block)
+  daFootprint = 0
   for tx in block.txs:
       if !tx.IsDepositTx
-        txDAFootprint = max(minTransactionSize, intercept + fastlzCoef * tx.fastlzSize * 1e-6)
-        blockDAFootprint += txDAFootprint 
-  return blockDAFootprint * daFootprintGasScalar
+        estimatedSize = max(minTransactionSize, intercept + fastlzCoef * tx.fastlzSize / 1e6)
+        daFootprint += estimatedSize * daFootprintGasScalar
+  return daFootprint 
 ```
 
 where `intercept`, `minTransactionSize`, `fastLzCoef` and `fastlzSize`
-are defined in the [Fjord specs](../fjord/exec-engine.md).
+are defined in the [Fjord specs](../fjord/exec-engine.md) and `/` represents integer division.
 
 From Jovian, the `gasUsed` property of each block header is equal to the maximum over
-that block's `scaledDAFootprint` and the sum of the gas used by each transaction.
+that block's `daFootprint` and the sum of the gas used by each transaction.
 As a result, blocks with high DA usage may cause the base fee to increase in subsequent blocks.
 
 The `gasUsed` must continue to be less than or equal to the block gas limit, meaning that
-(since the `scaledDAFootprint` must also be less than or equal to the block gas limit),
+(since the `daFootprint` must also be less than or equal to the block gas limit),
 blocks have an effective "DA footprint Block Limit" of `gasLimit/daFootprintGasScalar`.
 
 ### Scalar loading

--- a/specs/protocol/jovian/exec-engine.md
+++ b/specs/protocol/jovian/exec-engine.md
@@ -96,8 +96,8 @@ def daFootprint(block)
   daFootprint = 0
   for tx in block.txs:
       if !tx.IsDepositTx
-        estimatedSize = max(minTransactionSize, intercept + fastlzCoef * tx.fastlzSize / 1e6)
-        daFootprint += estimatedSize * daFootprintGasScalar
+        daUsageEstimate = max(minTransactionSize, intercept + fastlzCoef * tx.fastlzSize / 1e6)
+        daFootprint += daUsageEstimate * daFootprintGasScalar
   return daFootprint 
 ```
 

--- a/specs/protocol/jovian/overview.md
+++ b/specs/protocol/jovian/overview.md
@@ -20,7 +20,7 @@ This document is not finalized and should be considered experimental.
 ## Consensus Layer
 
 - [Network upgrade transactions](./derivation.md#network-upgrade-transactions) applied during derivation
-- Auto-upgrading and extension of the [L1 Attributes Predeployed Contract][./l1-attributes.md]
+- Auto-upgrading and extension of the [L1 Attributes Predeployed Contract](./l1-attributes.md)
   (also known as `L1Block` predeploy)
 
 ## Smart Contracts


### PR DESCRIPTION
* ordinary gas IS summed over deposit txs
* only da footprint is NOT summed over deposit txs
* link to Fjord specs to avoid duplication
* ~use "scaled DA footprint" , so that "DA Footprint Block Limit" makes sense~
* use more explicit pseudocode

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
