### PR TITLE
include chainID in ExecutingDescriptor

### DIFF
--- a/specs/interop/supervisor.md
+++ b/specs/interop/supervisor.md
@@ -108,6 +108,7 @@ Object:
 - `timeout`: `HexUint64` - optional, requests verification to still hold at `timestamp+timeout` (inclusive).
   The message expiry-window may invalidate messages.
   Default interpretation is a `0` timeout: what is valid at `timestamp` may not be valid at `timestamp+1`.
+- `chainId`: `ChainID` - optional, the chain ID of the executing message.
 
 #### `HexUint64`
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Includes an optional field `chainID` in `ExecutingDescriptor` following the go implementation [here](https://github.com/ethereum-optimism/optimism/blob/6971ada2d9dcaa29b53ae5c2f9781c37a89d933b/op-supervisor/supervisor/types/types.go#L307)


Fixes #731

