### PR TITLE
jovian: add new parameters to configurability doc

### DIFF
--- a/specs/protocol/configurability.md
+++ b/specs/protocol/configurability.md
@@ -32,6 +32,8 @@
   - [Governance Token](#governance-token)
   - [Operator Fee Scalar](#operator-fee-scalar)
   - [Operator Fee Constant](#operator-fee-constant)
+  - [DA Footprint Gas Scalar](#da-footprint-gas-scalar)
+  - [Minimum Base Fee](#minimum-base-fee)
   - [Resource Config](#resource-config)
 - [Policy Parameters](#policy-parameters)
   - [Data Availability Type](#data-availability-type)

--- a/specs/protocol/configurability.md
+++ b/specs/protocol/configurability.md
@@ -306,13 +306,13 @@ like op-succinct, so their standard values are 0.
 
 **Description:** DA footprint gas scalar -- used to calculate the DA footprint<br/>
 **Administrator:** [System Config Owner](#admin-roles)<br/>
-**Requirement:** Requirements (if any) are declared in https://github.com/ethereum-optimism/superchain-registry/blob/main/validation/standard/standard-config-params-mainnet.toml
+**Requirement:** Requirements (if any) are declared in <https://github.com/ethereum-optimism/superchain-registry/blob/main/validation/standard/standard-config-params-mainnet.toml>
 
 ### [Minimum Base Fee](jovian/exec-engine.md#minimum-base-fee)
 
 **Description:** Minimum base fee -- sets the minimum base fee on L2<br/>
 **Administrator:** [System Config Owner](#admin-roles)<br/>
-**Requirement:** Requirements (if any) are declared in https://github.com/ethereum-optimism/superchain-registry/blob/main/validation/standard/standard-config-params-mainnet.toml
+**Requirement:** Requirements (if any) are declared in <https://github.com/ethereum-optimism/superchain-registry/blob/main/validation/standard/standard-config-params-mainnet.toml>
 
 [^chain-id-uniqueness]: The chain ID must be globally unique among all EVM chains.
 

--- a/specs/protocol/configurability.md
+++ b/specs/protocol/configurability.md
@@ -300,6 +300,18 @@ contracts deployed on layer 1.<br/>
 Note that the operator fee scalar and constant are primarily used for non-standard configurations,
 like op-succinct, so their standard values are 0.
 
+### [DA Footprint Gas Scalar](jovian/exec-engine.md#DA-footprint-block-limit)
+
+**Description:** DA footprint gas scalar -- used to calculate the DA footprint<br/>
+**Administrator:** [System Config Owner](#admin-roles)<br/>
+**Requirement:** Requirements (if any) are declared in https://github.com/ethereum-optimism/superchain-registry/blob/main/validation/standard/standard-config-params-mainnet.toml
+
+### [Minimum Base Fee](jovian/exec-engine.md#minimum-base-fee)
+
+**Description:** Minimum base fee -- sets the minimum base fee on L2<br/>
+**Administrator:** [System Config Owner](#admin-roles)<br/>
+**Requirement:** Requirements (if any) are declared in https://github.com/ethereum-optimism/superchain-registry/blob/main/validation/standard/standard-config-params-mainnet.toml
+
 [^chain-id-uniqueness]: The chain ID must be globally unique among all EVM chains.
 
 ### Resource Config


### PR DESCRIPTION
Closes https://github.com/ethereum-optimism/specs/issues/770

Defers to the superchain registry toml files, which can be updated via future governance votes. This avoids having two sources of truth. 