### PR TITLE
Clarify span batch outdated L1 origin rules

### DIFF
--- a/specs/protocol/delta/span-batches.md
+++ b/specs/protocol/delta/span-batches.md
@@ -332,7 +332,7 @@ Span-batch rules, in validation order:
         if and only if the L1 epoch hash is correct.
     - `start_epoch_num < prev_l2_block.l1_origin.number` -> `drop`:
       epoch number cannot be older than the origin of parent block
-- Max Sequencer time-drift checks:
+- Max Sequencer time-drift & other L1 origin checks:
   - Note: The max time-drift is enforced for the _batch as a whole_, to keep the possible output variants small.
   - Variables:
     - `block_input`: an L2 block from the span-batch,
@@ -341,6 +341,7 @@ Span-batch rules, in validation order:
       It may reach to the next origin outside the L1 origins of the span.
   - Rules:
     - For each `block_input` whose timestamp is greater than `safe_head.timestamp`:
+      - `block_input.l1_origin.number < safe_head.l1_origin.number` -> `drop`: enforce increasing L1 origins.
       - `block_input.timestamp < block_input.origin.time` -> `drop`: enforce the min L2 timestamp rule.
       - `block_input.timestamp > block_input.origin.time + max_sequencer_drift`: enforce the L2 timestamp drift rule,
         but with exceptions to preserve above min L2 timestamp invariant:

--- a/specs/protocol/holocene/derivation.md
+++ b/specs/protocol/holocene/derivation.md
@@ -147,6 +147,21 @@ which the span batch was derived, is also immediately dropped (see also [Fast Ch
 Invalidation](#fast-channel-invalidation)). However, a `past` span batch is only dropped, without
 dropping the remaining channel.
 
+> [!Note]
+> A word regarding overlapping span batches: the existing batch queue rules already contain the rule
+> to drop batches whose L1 origin is older than that of the L2 safe head. The Delta span batch
+> checks also have an equivalent rule that applies to all singular batcher past the safe head.
+> Now full span batch checks aren't done any more in Holocene, but the batch queue rules are still
+> applied to singular batches that are streamed out of span batches, so in particular this rule also
+> still applies to the first singular batch past the current safe head coming from an overlapping
+> span batch.
+>
+> It is a known footgun for implementations that the earliest point at which violations of this rule
+> are detected is when the full array of singular batches is extracted from the span batch and their
+> L1 origin hashes are populated. It is therefore important to treat singular batches with outdated
+> or otherwise invalid L1 origin numbers as invalid, and consequently the span batch as invalid, and
+> not generate a critical derivation error that stalls derivation.
+
 ## Batch Queue
 
 The batch queue is also simplified in that batches are required to arrive strictly ordered, and any

--- a/words.txt
+++ b/words.txt
@@ -33,6 +33,7 @@ Filecoin
 Flashblock
 Flashblock's
 Flashblocks
+footgun
 Forkchoice
 Futex
 Futexes


### PR DESCRIPTION
**Description**

This clarifies the specs regarding outdated L1 origin rules for span batches before and after Holocene.

This is technically not a spec change because the batch queue rules already had this rule which applies to the singular batches coming out of span batches.

A note is added regarding a footgun for implementations, which got fixed here:
- https://github.com/ethereum-optimism/optimism/pull/18283
- https://github.com/op-rs/kona/pull/3059