### PR TITLE
Fix broken lint-specs-md-check in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,16 @@ executors:
 
 commands:
 
+  install-npm-deps:
+    description: "Install npm dependencies"
+    steps:
+      - run:
+          name: install npm dependencies
+          command: |
+            npm install -g corepack
+            corepack enable
+            pnpm install --frozen-lockfile
+
   notify-failures-on-develop:
     description: "Notify Slack"
     parameters:
@@ -29,6 +39,7 @@ jobs:
     executor: default
     steps:
       - utils/checkout-with-mise
+      - install-npm-deps
       - run:
           name: markdown lint
           command: just lint-specs-md-check


### PR DESCRIPTION
`just lint-specs-md-check` was working locally but failing in CI, because:

- package.json specifies markdownlint-cli2 version 0.4.0
- CI runs npx markdownlint-cli2 without running pnpm install first
- npx downloads the latest version (0.20.0) which has new rules MD059/MD060 that didn't exist in 0.4.0

This attempts to fix it by explicitly running `pnpm i --frozen-lockfile`.

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
