### PR TITLE
holocene: also require non-zero elasticity in extraData

### DIFF
--- a/specs/protocol/holocene/exec-engine.md
+++ b/specs/protocol/holocene/exec-engine.md
@@ -42,9 +42,9 @@ With the Holocene upgrade, the `extraData` header field of each block must have 
 
 Additionally,
 
-- `version` must be 0
-- `denominator` must be non-zero
-- there is no additional data beyond these 9 bytes
+- `version` must be `0`,
+- `denominator` and `elasticity` must be non-zero,
+- there is no additional data beyond these 9 bytes.
 
 Note that `extraData` has a maximum capacity of 32 bytes (to fit in the L1 beacon-chain `extraData` data-type) and its
 format may be modified/extended by future upgrades.


### PR DESCRIPTION
**Description**

Extends the Holocene spec to also require the header `extraData`-embedded elasticity to be non-zero.

This is safe to do retroactively because during payload execution, the EIP1559params contained in the payload attributes are either both zero or both non-zero, which itself is guaranteed by how derivation sets those parameters: they are both 0 if nothing has been set yet at the `SystemConfig` contract or both non-zero, which is enforced by [`setEIP1559Params`](https://specs.optimism.io/protocol/holocene/system-config.html#seteip1559params). And if there ever had been a malicious unsafe block with a zero elasticity, it would have [caused a division by zero panic](https://github.com/ethereum-optimism/op-geth/blob/6cbfcd5161083bcd4052edc3022d9f99c6fe40e0/consensus/misc/eip1559/eip1559.go#L93).
