### PR TITLE
specs: add L2ProxyAdmin to upgrade spec

### DIFF
--- a/specs/protocol/l2-contract-upgrades.md
+++ b/specs/protocol/l2-contract-upgrades.md
@@ -24,6 +24,27 @@
       - [Impact](#impact-2)
     - [i04-004: Collision Detection Accuracy](#i04-004-collision-detection-accuracy)
       - [Impact](#impact-3)
+- [L2ProxyAdmin](#l2proxyadmin)
+  - [Overview](#overview-2)
+  - [Definitions](#definitions-1)
+    - [Depositor Account](#depositor-account)
+    - [Predeploy](#predeploy)
+  - [Assumptions](#assumptions-1)
+    - [a01-001: Depositor Account is Controlled by Protocol](#a01-001-depositor-account-is-controlled-by-protocol)
+      - [Mitigations](#mitigations-2)
+    - [a02-002: L2ContractsManager is Trusted](#a02-002-l2contractsmanager-is-trusted)
+      - [Mitigations](#mitigations-3)
+    - [a03-003: Predeploy Proxies Follow Expected Patterns](#a03-003-predeploy-proxies-follow-expected-patterns)
+      - [Mitigations](#mitigations-4)
+  - [Invariants](#invariants-1)
+    - [i01-001: Exclusive Depositor Authorization for Batch Upgrades](#i01-001-exclusive-depositor-authorization-for-batch-upgrades)
+      - [Impact](#impact-4)
+    - [i02-002: Safe Delegation to L2ContractsManager](#i02-002-safe-delegation-to-l2contractsmanager)
+      - [Impact](#impact-5)
+    - [i03-003: Backwards Compatibility Maintained](#i03-003-backwards-compatibility-maintained)
+      - [Impact](#impact-6)
+    - [i04-004: L2ContractsManager Address Immutability](#i04-004-l2contractsmanager-address-immutability)
+      - [Impact](#impact-7)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -152,4 +173,123 @@ and false positives (detecting non-existent contracts) are both prohibited.
 False negatives would cause the ConditionalDeployer to attempt redeployment to occupied addresses, resulting in
 failed deployments and breaking the upgrade process. False positives would prevent legitimate deployments from
 occurring, causing proxies to reference non-existent implementation addresses.
+
+## L2ProxyAdmin
+
+### Overview
+
+The L2ProxyAdmin is the administrative contract responsible for managing proxy upgrades for L2 predeploy contracts. It
+is deployed as a predeploy at address `0x4200000000000000000000000000000000000018` and serves as the `admin` for all
+upgradeable L2 predeploy proxies.
+
+The upgraded L2ProxyAdmin implementation extends the existing proxy administration interface with a new
+`upgradePredeploys()` function that orchestrates batch upgrades of multiple predeploys by delegating to an
+[L2ContractsManager](#l2contractsmanager) contract. This design enables deterministic, testable upgrade paths written
+entirely in Solidity.
+
+### Definitions
+
+#### Depositor Account
+
+The special system address `0xDeaDDEaDDeAdDeAdDEAdDEaddeAddEAdDEAd0001` controlled by the L2 protocol's derivation
+pipeline. This account is used to submit system transactions including L1 attributes updates and upgrade
+transactions.
+
+#### Predeploy
+
+A contract deployed at a predetermined address in the L2 genesis state. Predeploys provide core L2 protocol
+functionality and are typically deployed behind proxies to enable upgradability.
+
+### Assumptions
+
+#### a01-001: Depositor Account is Controlled by Protocol
+
+The [Depositor Account](#depositor-account) is exclusively controlled by the L2 protocol's derivation and execution
+pipeline. No external parties can submit transactions from this address.
+
+##### Mitigations
+
+- The [Depositor Account](#depositor-account) address has no known private key
+- Transactions from this address can only originate from the protocol's derivation pipeline processing L1 deposit events
+- The address is hardcoded in the protocol specification and client implementations
+
+#### a02-002: L2ContractsManager is Trusted
+
+The [L2ContractsManager](#l2contractsmanager) contract that receives the DELEGATECALL from `upgradePredeploys()`
+correctly implements the upgrade logic and does not perform malicious operations when executing in the context of the
+ProxyAdmin.
+
+##### Mitigations
+
+- The L2ContractsManager address is deterministically computed and verified during upgrade bundle generation
+- The L2ContractsManager implementation is developed, reviewed, and tested alongside the upgrade bundle
+- Fork-based testing validates the complete upgrade execution before production deployment
+- The L2ContractsManager bytecode is verifiable against source code on a specific commit
+
+#### a03-003: Predeploy Proxies Follow Expected Patterns
+
+[Predeploys](#predeploy) being upgraded follow the expected proxy patterns (ERC-1967 or similar) and correctly handle
+`upgradeTo()` and `upgradeToAndCall()` operations when called by the ProxyAdmin.
+
+##### Mitigations
+
+- All L2 predeploys use standardized proxy implementations from the contracts-bedrock package
+- Proxy implementations are thoroughly tested and audited
+- Fork-based testing validates upgrade operations against actual deployed proxies
+
+### Invariants
+
+#### i01-001: Exclusive Depositor Authorization for Batch Upgrades
+
+The `upgradePredeploys()` function MUST only be callable by the [Depositor Account](#depositor-account). No other
+address, including the current ProxyAdmin owner, can invoke this function.
+
+##### Impact
+
+**Severity: Critical**
+
+If unauthorized addresses could call `upgradePredeploys()`, attackers could execute arbitrary upgrade logic by
+deploying a malicious L2ContractsManager and triggering upgrades to compromised implementations. This would allow
+complete takeover of all L2 predeploy contracts, enabling theft of funds, manipulation of system configuration, and
+protocol-level attacks.
+
+#### i02-002: Safe Delegation to L2ContractsManager
+
+When `upgradePredeploys()` executes a DELEGATECALL to the [L2ContractsManager](#l2contractsmanager), the call MUST
+preserve the ProxyAdmin's storage context and MUST properly handle success and failure conditions. The function MUST
+revert if the DELEGATECALL fails.
+
+##### Impact
+
+**Severity: Critical**
+
+If the DELEGATECALL is not properly executed, upgrades could fail silently leaving proxies in inconsistent states, or
+worse, the ProxyAdmin's own storage could be corrupted. This could result in loss of admin control over predeploys or
+enable exploitation of corrupted state.
+
+#### i03-003: Backwards Compatibility Maintained
+
+The upgraded L2ProxyAdmin implementation MUST maintain the existing interface for standard proxy administration
+functions. Existing functionality for upgrading individual proxies, changing proxy admins, and querying proxy state
+MUST continue to work as before.
+
+##### Impact
+
+**Severity: High**
+
+If backwards compatibility is broken, existing tooling, scripts, and contracts that interact with the ProxyAdmin could
+fail. This could prevent emergency responses, break operational procedures, and cause confusion during the transition
+to the new upgrade system.
+
+#### i04-004: L2ContractsManager Address Immutability
+
+The address of the [L2ContractsManager](#l2contractsmanager) used by `upgradePredeploys()` MUST be deterministically
+provided in the upgrade transaction and MUST NOT be modifiable through storage manipulation during the DELEGATECALL.
+
+##### Impact
+
+**Severity: Critical**
+
+If the L2ContractsManager address could be manipulated, an attacker could redirect the DELEGATECALL to a malicious
+contract, achieving the same impact as i01-001 (complete compromise of all predeploys).
 


### PR DESCRIPTION
Adds L2ProxyAdmin component for batch upgrade orchestration:

- Defines upgradePredeploys() function for DELEGATECALL-based batch upgrades
- Exclusive Depositor Account authorization
- Backwards compatibility with existing ProxyAdmin interface

Includes 4 invariants, 3 assumptions, and interface definition.
Part 2 of 6-part specification.

---
**Stack:**
- #876 (Layer 1: Overview + ConditionalDeployer)
- **→ #877 (Layer 2: L2ProxyAdmin)** ← You are here