### PR TITLE
Update preimage hints

### DIFF
--- a/words.txt
+++ b/words.txt
@@ -107,6 +107,7 @@ bitlists
 blobbasefee
 BLOBBASEFEE
 blobdata
+blobhash
 blockhash
 Blockhash
 blockheaders


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

- Adds documentation for the `l1-blob` hint.
- Updates the format of the `l1-precompile` hint, and also renames it to `l1-precompile-v2` which is used in op-program, but not in Kona (which has the same format but named `l1-precompile`). 

Question for reviewers: should the spec keep the name as `l1-precompile` instead of `l1-precompile-v2`, since that's what Kona uses, which will become the default fault proof program?

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
