### PR TITLE
fix: remove value field from NUT bundle format

### DIFF
--- a/specs/protocol/l2-upgrades-1-execution.md
+++ b/specs/protocol/l2-upgrades-1-execution.md
@@ -421,7 +421,6 @@ The bundle is a JSON file with the following structure:
       "to": "0x1234...",
       "data": "0xabcd...",
       "gasLimit": "1000000",
-      "value": "0",
       "from": "0x0000000000000000000000000000000000000000"
     }
   ]
@@ -435,10 +434,12 @@ The bundle is a JSON file with the following structure:
 - `transactions[].to`: Target address (contract being called)
 - `transactions[].data`: Transaction calldata as hex string
 - `transactions[].gasLimit`: Gas limit for this transaction
-- `transactions[].value`: (Optional) ETH value to send, defaults to "0" if omitted
 - `transactions[].from`: (Optional) Sender address. Defaults to the [Depositor Account](./l2-upgrades-2-contracts.md#depositor-account).
   Must be set to `address(0)` for the L2ProxyAdmin upgrade transaction to utilize the zero-address upgrade path in the
   Proxy.sol implementation
+
+A `value` field MUST NOT be included in transaction objects. All NUT transactions are calls with zero ETH value, which
+is enforced by the execution layer rather than specified per-transaction.
 
 ### Bundle Generation Process
 


### PR DESCRIPTION
Remove the `value` field from the NUT bundle transaction format and add an explicit prohibition. Value is always zero for NUT transactions and is enforced by the execution layer.

This PR reflects a decision made in the op-node bundle parsing implementation: https://github.com/ethereum-optimism/optimism/pull/19165#discussion_r2804556742
