### PR TITLE
holocene: clarify channel size metric in §Pruning

### DIFF
--- a/specs/protocol/holocene/derivation.md
+++ b/specs/protocol/holocene/derivation.md
@@ -112,9 +112,10 @@ frame loading becomes simpler in the channel bank:
 correct frame for this channel, the frame and channel are dropped, including all future frames for
 the channel that might still be in the frame queue. Note that the equivalent rule was already
 present pre-Holocene.
-- After adding a frame to the staging channel, the channel is dropped if its raw compressed size as
-defined in the Bedrock specification is larger than `MAX_RLP_BYTES_PER_CHANNEL`. This rule replaces
-the total limit of all channels' combined sizes by `MAX_CHANNEL_BANK_SIZE` before Holocene.
+- After adding a frame to the staging channel, the channel is dropped if its channel size (as defined
+in the Bedrock specification: the sum of `len(frame_data) + 200` bytes per frame) is larger than
+`MAX_RLP_BYTES_PER_CHANNEL`. This rule replaces the total limit of all channels' combined sizes by
+`MAX_CHANNEL_BANK_SIZE` before Holocene.
 
 ## Span Batches
 


### PR DESCRIPTION
## Summary

The §Pruning section of the Holocene derivation spec (§Reading & Frame Loading)
currently describes the channel size limit using the phrase:

> "its raw compressed size as defined in the Bedrock specification"

The word "compressed" is misleading. The Bedrock channel size metric (defined in
[§Pruning of the Bedrock spec](../specs/protocol/derivation.md)) is **not** the
bare compressed payload size. It is:

> the sum of all buffered frame data of the channel, with an additional
> frame-overhead of **200 bytes per frame**

That is: `total_size = Σ (len(frame_data) + 200)` over all frames of the channel.

A new implementor reading the Holocene spec in isolation could reasonably interpret
"raw compressed size" as meaning only the payload bytes, omitting the 200-byte
per-frame overhead. This would lead to an incorrect threshold check.

## What changed

The ambiguous phrase is replaced with the explicit formula, tying it directly to
the Bedrock definition:

> "its channel size (as defined in the Bedrock specification: the sum of
> `len(frame_data) + 200` bytes per frame)"

No other changes were made.

## Correctness note

Both the op-node (Go) and kona-node (Rust) implementations already use the correct
`len(frame_data) + 200` metric — this PR is purely a spec clarification to prevent
future misimplementations.