### PR TITLE
docs: sync Jovian L1Block methods and repair spec links

### DIFF
--- a/specs/protocol/jovian/l1-attributes.md
+++ b/specs/protocol/jovian/l1-attributes.md
@@ -36,7 +36,8 @@ In the activation block, there are two possibilities:
 and therefore no L1 Block Attributes transaction to consider.
 - If Jovian activates after genesis [`setL1BlockValuesIsthmus()`](../isthmus/l1-attributes.md) method must be used.
  This is because the L1 Block contract will not yet have been upgraded.
-In each subsequent L2 block, the setL1BlockValuesJovian() method must be used. When using this method, the pre-Jovian values are migrated over 1:1 and the transaction also sets daFootprintGasScalar to the value from the SystemConfig.
+
+- In each subsequent L2 block, the setL1BlockValuesJovian() method must be used. When using this method, the pre-Jovian values are migrated over 1:1 and the transaction also sets daFootprintGasScalar to the value from the SystemConfig.
 In each subsequent L2 block, the `setL1BlockValuesJovian()` method must be used.
 
 When using this method, the pre-Jovian values are migrated over 1:1

--- a/specs/protocol/jovian/l1-attributes.md
+++ b/specs/protocol/jovian/l1-attributes.md
@@ -36,7 +36,7 @@ In the activation block, there are two possibilities:
 and therefore no L1 Block Attributes transaction to consider.
 - If Jovian activates after genesis [`setL1BlockValuesIsthmus()`](../isthmus/l1-attributes.md) method must be used.
  This is because the L1 Block contract will not yet have been upgraded.
-
+In each subsequent L2 block, the setL1BlockValuesJovian() method must be used. When using this method, the pre-Jovian values are migrated over 1:1 and the transaction also sets daFootprintGasScalar to the value from the SystemConfig.
 In each subsequent L2 block, the `setL1BlockValuesJovian()` method must be used.
 
 When using this method, the pre-Jovian values are migrated over 1:1


### PR DESCRIPTION
This PR updates the protocol specifications to reflect the Jovian activation (March 2026). It corrects the L1Block hydration method name and transitions the tokenRatio description from 'proposed' to 'active' to match the current state of the OP Stack. These changes are necessary for technical accuracy following the Jovian hardfork.

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
