### PR TITLE
feat(karst): document bn256Pairing input size reduction

### DIFF
--- a/specs/SUMMARY.md
+++ b/specs/SUMMARY.md
@@ -75,6 +75,8 @@
       - [Derivation](./protocol/jovian/derivation.md)
       - [L1 Attributes](./protocol/jovian/l1-attributes.md)
       - [System Config](./protocol/jovian/system-config.md)
+    - [Karst](./protocol/karst/overview.md)
+      - [Execution Engine](./protocol/karst/exec-engine.md)
 - [Governance]()
   - [Governance Token](./governance/gov-token.md)
   - [MintManager](./governance/mint-manager.md)

--- a/specs/protocol/karst/exec-engine.md
+++ b/specs/protocol/karst/exec-engine.md
@@ -1,0 +1,25 @@
+# Karst: Execution Engine
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**
+
+- [EVM Changes](#evm-changes)
+  - [Precompile Input Size Restrictions](#precompile-input-size-restrictions)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## EVM Changes
+
+### Precompile Input Size Restrictions
+
+The `bn256Pairing` precompile input size is reduced from the
+[Jovian limit](../jovian/exec-engine.md#precompile-input-size-restrictions) of 81,984 bytes (427 pairs) to
+57,600 bytes (300 pairs).
+
+The lower limit restores Jovian-era headroom under the
+[EIP-7825](https://eips.ethereum.org/EIPS/eip-7825) L1 transaction gas cap, accommodating the
+[EIP-7904](https://eips.ethereum.org/EIPS/eip-7904) pairing cost increase plus plausible variance without
+requiring a further adjustment.
+
+The other variable-input precompile limits are unchanged from Jovian.

--- a/specs/protocol/karst/overview.md
+++ b/specs/protocol/karst/overview.md
@@ -13,4 +13,6 @@ This document is not finalized and should be considered experimental.
 
 ## Execution Layer
 
+- [Reduce `bn256Pairing` precompile input size](./exec-engine.md#precompile-input-size-restrictions)
+
 ## Consensus Layer


### PR DESCRIPTION
Documents the Karst execution-engine change reducing the `bn256Pairing` precompile input size limit from the Jovian value of 81,984 bytes (427 pairs) to 57,600 bytes (300 pairs).

Implementation merged in ethereum-optimism/optimism#20250.

## Rationale (mirrored in the spec)

The lower limit restores Jovian-era headroom under the [EIP-7825](https://eips.ethereum.org/EIPS/eip-7825) L1 transaction gas cap, accommodating the [EIP-7904](https://eips.ethereum.org/EIPS/eip-7904) pairing cost increase plus plausible variance — without forcing another adjustment if the cost shifts again.

Other variable-input precompile limits are unchanged from Jovian.

## Files

- `specs/protocol/karst/exec-engine.md` (new)
- `specs/protocol/karst/overview.md` — Execution Layer bullet
- `specs/SUMMARY.md` — Karst entries (the existing overview was orphaned in nav)