### PR TITLE
system-config: remove batchInbox getter and setGasConfig

### DIFF
--- a/specs/protocol/configurability.md
+++ b/specs/protocol/configurability.md
@@ -83,10 +83,12 @@ The recommended way to deploy L1 contracts for an OP chain that meet the standar
 
 ## Consensus Parameters
 
-### [Batch Inbox address](https://github.com/ethereum-optimism/optimism/blob/c927ed9e8af501fd330349607a2b09a876a9a1fb/packages/contracts-bedrock/src/L1/SystemConfig.sol#L176)
+### Batch Inbox address
 
 **Description:** L1 address where calldata/blobs are posted (
-see [Batcher Transaction](../glossary.md#batcher-transaction)).<br/>
+see [Batcher Transaction](../glossary.md#batcher-transaction)). Defined in the rollup
+configuration; as of SystemConfig 4.0.0 it is no longer stored in or readable from the
+SystemConfig contract.<br/>
 **Administrator:** Static<br/>
 **Requirement:** Current convention is
 <code>versionByte &vert;&vert; keccak256(bytes32(chainId))\[:19\]</code>, where <code>&vert;&vert;</code> denotes

--- a/specs/protocol/configurability.md
+++ b/specs/protocol/configurability.md
@@ -87,8 +87,7 @@ The recommended way to deploy L1 contracts for an OP chain that meet the standar
 
 **Description:** L1 address where calldata/blobs are posted (
 see [Batcher Transaction](../glossary.md#batcher-transaction)). Defined in the rollup
-configuration; as of SystemConfig 4.0.0 it is no longer stored in or readable from the
-SystemConfig contract.<br/>
+configuration; as of `SystemConfig` v4.0.0 it is no longer stored onchain.<br/>
 **Administrator:** Static<br/>
 **Requirement:** Current convention is
 <code>versionByte &vert;&vert; keccak256(bytes32(chainId))\[:19\]</code>, where <code>&vert;&vert;</code> denotes

--- a/specs/protocol/stage-1.md
+++ b/specs/protocol/stage-1.md
@@ -117,15 +117,15 @@ identifier determines which systems or chains are affected by the pause:
 - When the identifier is a non-zero address, the pause applies specifically to the chain or set of
   chains associated with that identifier.
 
-(-v4.1.0) The identifier must be an `ETHLockbox` address or `address(0)`. This allows for targeted
+(-op-contracts/v4.1.0) The identifier must be an `ETHLockbox` address or `address(0)`. This allows for targeted
 pausing of either specific chains, the interop set (which shares an `ETHLockbox` contract), or all
 chains that share the same `SuperchainConfig` when `address(0)` is used as the identifier.
 
-(-v4.1.0) OP Chains are expected to integrate with the `SuperchainConfig` via their `SystemConfig`
+(-op-contracts/v4.1.0) OP Chains are expected to integrate with the `SuperchainConfig` via their `SystemConfig`
 contract, which will check for the status of the pause by passing along the address of the
 `ETHLockbox` being used within that system as the Pause Identifier.
 
-(+v4.1.0) The identifier must be an `ETHLockbox` address, an `OptimismPortal` address, or
+(+op-contracts/v4.1.0) The identifier must be an `ETHLockbox` address, an `OptimismPortal` address, or
 `address(0)`. This allows for targeted pausing of specific chains, the interop set (which shares an
 `ETHLockbox` contract), or all chains that share the same `SuperchainConfig` when `address(0)` is
 used as the identifier. When the `ETHLockbox`

--- a/specs/protocol/system-config.md
+++ b/specs/protocol/system-config.md
@@ -32,11 +32,13 @@
   - [optimismPortal](#optimismportal)
   - [optimismMintableERC20Factory](#optimismmintableerc20factory)
   - [getAddresses](#getaddresses)
+  - [batchInbox](#batchinbox)
   - [startBlock](#startblock)
   - [paused](#paused)
   - [superchainConfig](#superchainconfig)
   - [setUnsafeBlockSigner](#setunsafeblocksigner)
   - [setBatcherHash](#setbatcherhash)
+  - [setGasConfig](#setgasconfig)
   - [setGasConfigEcotone](#setgasconfigecotone)
   - [setGasLimit](#setgaslimit)
   - [setEIP1559Params](#seteip1559params)
@@ -104,8 +106,8 @@ After the Ecotone upgrade:
 
 - The **Scalar** attribute encodes additional scalar information in a versioned encoding scheme
 - The **Overhead** value is ignored and does not affect the L2 state-transition output. As of
-  SystemConfig 4.0.0 it is also immutable, since `setGasConfig` was the only function that
-  wrote it and has been removed
+  `SystemConfig` v4.0.0 it is also no longer writable, since `setGasConfig` was its only writer,
+  and `setGasConfigEcotone` emits zero in its place
 
 #### Post-Ecotone Scalar Encoding
 
@@ -183,7 +185,8 @@ In version `0`, the following update types are supported:
 - Type `0`: `batcherHash` overwrite, as `bytes32` payload
 - Type `1`: Pre-Ecotone, `overhead` and `scalar` overwrite, as two packed `uint256` entries. After
   Ecotone upgrade, `overhead` is ignored and `scalar` is interpreted as a versioned encoding that
-  updates `baseFeeScalar` and `blobBaseFeeScalar`
+  updates `baseFeeScalar` and `blobBaseFeeScalar`. As of `SystemConfig` v4.0.0 the `overhead` entry
+  is always zero, and the payload stays two words so its length is unchanged
 - Type `2`: `gasLimit` overwrite, as `uint64` payload
 - Type `3`: `unsafeBlockSigner` overwrite, as `address` payload
 - Type `4`: `eip1559Params` overwrite, as `uint256` payload encoding denomination and elasticity
@@ -195,6 +198,10 @@ If a System Config Update cannot be parsed for any reason, it is not applied and
 
 ## Function Specification
 
+Version markers below refer to op-contracts releases: `(+op-contracts/vX.Y.Z)` marks behavior
+introduced in that release, `(-op-contracts/vX.Y.Z)` marks behavior that applies before it. A
+version written as `SystemConfig` vX.Y.Z is the contract's own semver.
+
 ### initialize
 
 - MUST only be triggerable by the ProxyAdmin or its owner.
@@ -203,9 +210,11 @@ If a System Config Update cannot be parsed for any reason, it is not applied and
 - MUST set the SuperchainConfig contract address.
 - MUST set the batcher hash, gas config, gas limit, unsafe block signer, resource config,
   L1 contract addresses, and L2 chain ID.
+- (-op-contracts/v8.0.0) MUST set the [Batch Inbox](#batch-inbox) address.
+- (+op-contracts/v8.0.0) MUST clear the legacy batch inbox storage slot. The OP Stack reads the
+  batch inbox address from the rollup configuration, so the onchain copy was redundant and could
+  drift from it.
 - MUST set the start block to the current block number if it hasn't been set already.
-- MUST clear the legacy batch inbox storage slot. The OP Stack reads the batch inbox address from
-  the rollup configuration, so the value stored here was redundant and could drift from it.
 - MUST validate the resource configuration parameters against system constraints.
 
 ### upgrade
@@ -217,7 +226,7 @@ If a System Config Update cannot be parsed for any reason, it is not applied and
 
 ### setFeatureEnabled
 
-(+v4.1.0)
+(+op-contracts/v4.1.0)
 
 - Used to enable or disable a [Customizable Feature](#customizable-feature).
 - Takes a bytes32 feature string and a boolean as an input.
@@ -226,7 +235,7 @@ If a System Config Update cannot be parsed for any reason, it is not applied and
 
 ### isFeatureEnabled
 
-(+v4.1.0)
+(+op-contracts/v4.1.0)
 
 - Takes a bytes32 feature string as an input.
 - Returns true if the feature is enabled and false otherwise.
@@ -272,28 +281,34 @@ Returns the address of the OptimismMintableERC20Factory contract.
 
 Returns a consolidated struct containing all the L1 contract addresses.
 
+### batchInbox
+
+(-op-contracts/v8.0.0) Returns the address of the [Batch Inbox](#batch-inbox). Removed in
+`SystemConfig` v4.0.0, because the batch inbox address lives in the rollup configuration, which is
+what the OP Stack reads.
+
 ### startBlock
 
 Returns the block number at which the op-node can start searching for logs.
 
 ### paused
 
-(-v4.1.0) This function integrates with the [Pause Mechanism](./stage-1.md#pause-mechanism) by
+(-op-contracts/v4.1.0) This function integrates with the [Pause Mechanism](./stage-1.md#pause-mechanism) by
 using the chain's `ETHLockbox` address as the [Pause Identifier](./stage-1.md#pause-identifier).
 Returns the current pause state of the system by checking if the `SuperchainConfig` is paused for
 this chain's `ETHLockbox`.
 
-(+v4.1.0) This function integrates with the [Pause Mechanism](./stage-1.md#pause-mechanism) by
+(+op-contracts/v4.1.0) This function integrates with the [Pause Mechanism](./stage-1.md#pause-mechanism) by
 using either the chain's `ETHLockbox` address or the chain's `OptimismPortal` address as the
 [Pause Identifier](./stage-1.md#pause-identifier).
 
-- (-v4.1.0) MUST return true if `SuperchainConfig.paused(optimismPortal().ethLockbox())` returns
+- (-op-contracts/v4.1.0) MUST return true if `SuperchainConfig.paused(optimismPortal().ethLockbox())` returns
   true OR if `SuperchainConfig.paused(address(0))` returns true.
-- (+v4.1.0) MUST return true if `SuperchainConfig.paused(optimismPortal().ethLockbox())` returns
+- (+op-contracts/v4.1.0) MUST return true if `SuperchainConfig.paused(optimismPortal().ethLockbox())` returns
   true AND the system is configured to use the `ETHLockbox` contract.
-- (+v4.1.0) MUST return true if `SuperchainConfig.paused(optimismPortal())` returns true AND the
+- (+op-contracts/v4.1.0) MUST return true if `SuperchainConfig.paused(optimismPortal())` returns true AND the
   system is NOT configured to use the `ETHLockbox` contract.
-- (+v4.1.0) MUST return true if `SuperchainConfig.paused(address(0))` returns true.
+- (+op-contracts/v4.1.0) MUST return true if `SuperchainConfig.paused(address(0))` returns true.
 - MUST return false otherwise.
 
 ### superchainConfig
@@ -315,6 +330,16 @@ Allows the owner to update the [Batcher Hash](#batcher-hash).
 - MUST revert if called by an address other than the owner.
 - MUST update the batcher hash.
 - MUST emit a ConfigUpdate event with the UpdateType.BATCHER type.
+
+### setGasConfig
+
+(-op-contracts/v8.0.0) Allows the owner to update the gas configuration parameters (pre-Ecotone).
+Removed in `SystemConfig` v4.0.0; use [setGasConfigEcotone](#setgasconfigecotone) instead.
+
+- MUST revert if called by an address other than the owner.
+- MUST revert if the scalar exceeds the maximum allowed value (no upper 8 bits should be set).
+- MUST update the overhead and scalar values.
+- MUST emit a ConfigUpdate event with the UpdateType.FEE_SCALARS type.
 
 ### setGasConfigEcotone
 

--- a/specs/protocol/system-config.md
+++ b/specs/protocol/system-config.md
@@ -32,13 +32,11 @@
   - [optimismPortal](#optimismportal)
   - [optimismMintableERC20Factory](#optimismmintableerc20factory)
   - [getAddresses](#getaddresses)
-  - [batchInbox](#batchinbox)
   - [startBlock](#startblock)
   - [paused](#paused)
   - [superchainConfig](#superchainconfig)
   - [setUnsafeBlockSigner](#setunsafeblocksigner)
   - [setBatcherHash](#setbatcherhash)
-  - [setGasConfig](#setgasconfig)
   - [setGasConfigEcotone](#setgasconfigecotone)
   - [setGasLimit](#setgaslimit)
   - [setEIP1559Params](#seteip1559params)
@@ -105,7 +103,9 @@ Before the Ecotone upgrade, these include:
 After the Ecotone upgrade:
 
 - The **Scalar** attribute encodes additional scalar information in a versioned encoding scheme
-- The **Overhead** value is ignored and does not affect the L2 state-transition output
+- The **Overhead** value is ignored and does not affect the L2 state-transition output. As of
+  SystemConfig 4.0.0 it is also immutable, since `setGasConfig` was the only function that
+  wrote it and has been removed
 
 #### Post-Ecotone Scalar Encoding
 
@@ -201,9 +201,11 @@ If a System Config Update cannot be parsed for any reason, it is not applied and
 - MUST only be triggerable once.
 - MUST set the owner of the contract to the provided `_owner` address.
 - MUST set the SuperchainConfig contract address.
-- MUST set the batcher hash, gas config, gas limit, unsafe block signer, resource config, batch
-  inbox, L1 contract addresses, and L2 chain ID.
+- MUST set the batcher hash, gas config, gas limit, unsafe block signer, resource config,
+  L1 contract addresses, and L2 chain ID.
 - MUST set the start block to the current block number if it hasn't been set already.
+- MUST clear the legacy batch inbox storage slot. The OP Stack reads the batch inbox address from
+  the rollup configuration, so the value stored here was redundant and could drift from it.
 - MUST validate the resource configuration parameters against system constraints.
 
 ### upgrade
@@ -270,10 +272,6 @@ Returns the address of the OptimismMintableERC20Factory contract.
 
 Returns a consolidated struct containing all the L1 contract addresses.
 
-### batchInbox
-
-Returns the address of the [Batch Inbox](#batch-inbox).
-
 ### startBlock
 
 Returns the block number at which the op-node can start searching for logs.
@@ -317,15 +315,6 @@ Allows the owner to update the [Batcher Hash](#batcher-hash).
 - MUST revert if called by an address other than the owner.
 - MUST update the batcher hash.
 - MUST emit a ConfigUpdate event with the UpdateType.BATCHER type.
-
-### setGasConfig
-
-Allows the owner to update the gas configuration parameters (pre-Ecotone).
-
-- MUST revert if called by an address other than the owner.
-- MUST revert if the scalar exceeds the maximum allowed value (no upper 8 bits should be set).
-- MUST update the overhead and scalar values.
-- MUST emit a ConfigUpdate event with the UpdateType.FEE_SCALARS type.
 
 ### setGasConfigEcotone
 


### PR DESCRIPTION
Spec side of ethereum-optimism/optimism#21641, which removes `batchInbox()` and the deprecated `setGasConfig` from the SystemConfig at op-contracts v8.0.0.

Changes:

1. The `batchInbox` and `setGasConfig` sections stay as historical record rather than being deleted, each marked `(-op-contracts/v8.0.0)` and noting that it was removed in `SystemConfig` v4.0.0. Their TOC entries stay too.
2. `initialize`'s batch inbox MUST is split into a versioned pair: `(-op-contracts/v8.0.0)` sets the Batch Inbox address, `(+op-contracts/v8.0.0)` clears the legacy slot. Nothing in the OP Stack read that copy — derivation takes the batch inbox from the rollup config — and keeping it meant OPCMv2's reinitialization could recompute it with the new-chain addressing scheme, which is what rotated it for every pre-OPCM chain during U19.
3. Version markers now spell out which scheme they mean. `(+op-contracts/vX.Y.Z)` and `(-op-contracts/vX.Y.Z)` are op-contracts releases; a version written as `SystemConfig` vX.Y.Z is the contract's own semver. There is a one-line note to that effect at the top of the Function Specification section, and the existing markers in `system-config.md` and `stage-1.md` are normalized to the full identifier.

   The existing `(+v4.1.0)` markers were genuinely ambiguous, so to be explicit about why they are releases: at `op-contracts/v4.1.0` the feature-flag and optional-`ETHLockbox` pause behavior those markers describe is present, while `SystemConfig` is at 3.7.0 and `SuperchainConfig` at 2.3.0. Neither contract has ever been at 4.1.0 — `SuperchainConfig` is still at 2.4.3 today — and `setFeatureEnabled` is absent at `op-contracts/v4.0.0`.
4. `ConfigUpdate` type 1 records that as of `SystemConfig` v4.0.0 the `overhead` entry is always zero, and that the payload stays two words so its length is unchanged. `_setGasConfigEcotone` hardcodes the zero because op-node ignores the overhead after Ecotone, but the event data has to stay 64 bytes.
5. The post-Ecotone **Overhead** note says it is no longer writable, since `setGasConfig` was its only writer, and that `setGasConfigEcotone` emits zero in its place. The variable and getter are kept, so `overhead()` still works.
6. The Batch Inbox address heading in `configurability.md` loses its stale `SystemConfig.sol#L176` permalink and says the value is defined in the rollup configuration and, as of `SystemConfig` v4.0.0, is no longer stored onchain.

Not doing here, per the review discussion: a separate per-contract _Changelog_ section. The `(+v)`/`(-v)` markers already carry this change now that they say which versioning scheme they use. Happy to open a follow-up issue for the Changelog idea if we want it.
