### PR TITLE
docs(ecotone): clarify first field element's top two bits are not enforced

### DIFF
--- a/specs/protocol/ecotone/derivation.md
+++ b/specs/protocol/ecotone/derivation.md
@@ -100,6 +100,11 @@ with a total of `(4 * 31 + 3) * 1024 = 130048` bytes of data.
 
 When decoding a blob, the top-most two bits of each field-element must be 0,
 to make the encoding/decoding bijective.
+This is enforced for every field element except the first one:
+the first field element is special-cased for the version and length (see below),
+and its top-most two bits are ignored (masked to 0) on decode rather than validated.
+As a result, those two bits do not affect the decoded output and the encoding is not
+strictly bijective for the first field element; the encoder always writes them as 0.
 
 The first byte of rollup-data (second byte in first field element) is used as a version-byte.
 


### PR DESCRIPTION
## Overview

Clarifies the Ecotone blob-encoding spec to match the reference implementations.

The spec states:

> When decoding a blob, the top-most two bits of each field-element must be 0, to make the encoding/decoding bijective.

But the reference decoders enforce this for **every field element except the first**. The first field element is special-cased (it carries the version byte and length), and its top two bits are **masked to 0 rather than validated**:

- **op-node** — `op-service/eth/blob.go`: `encodedByte[0] = b[0]` (no high-bit check), then `reassembleBytes` applies `encodedByte[0] & 0b0011_1111`.
- **kona** — `rust/kona/crates/protocol/derive/src/sources/blob_data.rs`: `encoded_byte[0] = data[0]` (no check), same `& 0b0011_1111` mask.

`decodeFieldElement` / `decode_field_element` (which *does* reject `& 0b1100_0000 != 0`) is only called for field elements 1..N, never element 0. So the two high bits of `blob[0]` do not affect the decoded output, and the encoding is not strictly bijective there. The encoder always writes them as 0, so this is unobservable in honest operation.

## Why documentation, not enforcement

Both clients already agree (both lenient), so the chain is consistent. Adding validation for field element 0 would be a consensus/derivation-affecting change — a blob with those bits set would flip from valid to invalid — and would require a hardfork gate plus lockstep client updates for no practical benefit. Documenting the existing behavior is the safe, correct fix.

## Context

Surfaced by a flaky test in the monorepo (ethereum-optimism/optimism#21539); test fix in ethereum-optimism/optimism#21647.

🤖 Generated with [Claude Code](https://claude.com/claude-code)