### PR TITLE
feat: Add EIP-8130 spec

### DIFF
--- a/specs/SUMMARY.md
+++ b/specs/SUMMARY.md
@@ -110,6 +110,7 @@
   - [Alt-DA](./experimental/alt-da.md)
   - [OP Contracts Manager](./experimental/op-contracts-manager.md)
   - [Governance Token](./experimental/gov-token.md)
+  - [EIP-8130 Account Abstraction Transactions](./experimental/eip-8130.md)
   - [Contract Specifications]()
     - [Safe]()
       - [LivenessGuard](./experimental/contracts/safe/liveness-guard.md)

--- a/specs/experimental/eip-8130.md
+++ b/specs/experimental/eip-8130.md
@@ -2,7 +2,6 @@
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
 **Table of Contents**
 
 - [Overview](#overview)

--- a/specs/experimental/eip-8130.md
+++ b/specs/experimental/eip-8130.md
@@ -1,0 +1,336 @@
+# EIP-8130 Account Abstraction Transactions
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+**Table of Contents**
+
+- [Overview](#overview)
+- [Activation](#activation)
+- [Chain Parameters](#chain-parameters)
+- [The Account Abstraction Transaction Type](#the-account-abstraction-transaction-type)
+  - [Encoding](#encoding)
+  - [Transaction Hash](#transaction-hash)
+  - [Signature and Sender Resolution](#signature-and-sender-resolution)
+  - [Generic Transaction Interface Representation](#generic-transaction-interface-representation)
+- [Derivation](#derivation)
+  - [Span Batch Encoding](#span-batch-encoding)
+  - [Authorization Data Column](#authorization-data-column)
+  - [Decoding Rules](#decoding-rules)
+- [Receipt](#receipt)
+- [Enshrined Addresses](#enshrined-addresses)
+- [Rationale](#rationale)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+<!-- All glossary references in this file. -->
+
+[g-transaction-type]: ../glossary.md#transaction-type
+[g-span-batch]: ../glossary.md#span-batch
+[g-derivation]: ../glossary.md#L2-chain-derivation
+
+## Overview
+
+[EIP-8130] introduces account abstraction through onchain account configuration and a new
+[EIP-2718] [transaction type][g-transaction-type]. An account authorizes actors - credentials
+permitted to act on its behalf - each bound to an authenticator contract that checks a signature
+and returns the actor's identity. A transaction names the authenticator that authenticates it, so a
+node can determine exactly what computation the transaction requires before executing any code.
+
+This document specifies how the OP Stack integrates EIP-8130. It covers activation, the chain
+parameters the EIP leaves to the chain, how `0x79` transactions are encoded in
+[span batches][g-span-batch] so they survive [derivation][g-derivation], the receipt surface, and
+the enshrined system addresses.
+
+It does **not** restate the account model, the authenticator set, the actor scope rules, the
+intrinsic gas schedule, or the execution semantics. Those are normative in [EIP-8130] itself and
+apply unchanged. Where this document is silent, the EIP governs.
+
+[EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
+[EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
+
+## Activation
+
+EIP-8130 is not yet assigned to a network upgrade. This document specifies the behavior the
+protocol requires once it is, and the behavior every chain exhibits until then.
+
+While EIP-8130 is unscheduled, and before the activation timestamp on any chain that later
+schedules it:
+
+- A block MUST NOT contain a `0x79` transaction.
+- A batch carrying a `0x79` transaction MUST be dropped during derivation.
+- `NONCE_MANAGER_ADDRESS` and `TX_CONTEXT_ADDRESS` have no code, and a `STATICCALL` to either
+  returns zero-length data per ordinary EVM rules.
+
+Implementations gate the feature on a single dedicated predicate rather than on a fork accessor, so
+that assigning EIP-8130 to an upgrade is one change per client rather than one per call site. Until
+an upgrade is chosen that predicate returns false unconditionally, which makes the unscheduled
+behavior above the only reachable behavior.
+
+## Chain Parameters
+
+[EIP-8130] designates two values as chain parameters rather than node policy, because both decide
+block validity: a node that disagreed on either would diverge. They MUST be identical for every
+node on the chain.
+
+| Parameter                  | Description                                                    |
+| -------------------------- | -------------------------------------------------------------- |
+| `REPLAY_BUFFER_CAPACITY`   | Fixed capacity of the nonce-free `replay_id` ring buffer.      |
+| `NONCE_FREE_EXPIRY_WINDOW` | Maximum `expiry` window accepted for a nonce-free transaction. |
+
+The two MUST be sized together so that a ring entry always expires before its slot is reused:
+`peak accepted nonce-free throughput × NONCE_FREE_EXPIRY_WINDOW` MUST stay within
+`REPLAY_BUFFER_CAPACITY`. Because the buffer is fixed-size and its entries are ephemeral, the
+replay state does not grow without bound.
+
+Values are pinned per chain in the rollup configuration. Nodes MAY additionally apply stricter
+_local_ admission limits (for example rejecting a transaction whose `expiry` is too near to be
+reliably included, or bounding the number of account-change entries accepted from the mempool)
+provided those limits only ever reject transactions a node would otherwise have accepted into its
+own pool, and never affect the validity of a block or batch.
+
+## The Account Abstraction Transaction Type
+
+An account abstraction transaction is an [EIP-2718] typed transaction with type byte `0x79`.
+
+`0x7A` is reserved as the payer signature domain-separation prefix and `0x7901` as the `replay_id`
+domain prefix; neither is an EIP-2718 transaction type, and no transaction is ever encoded with
+either.
+
+### Encoding
+
+The EIP-2718 encoding is `0x79 || rlp_encoded_payload`, where the payload is the RLP list defined
+by [EIP-8130]:
+
+```text
+0x79 || rlp([
+  chain_id,
+  sender,                    // 20 bytes, or empty for the EOA path
+  nonce_key,
+  nonce_sequence,
+  expiry,
+  max_priority_fee_per_gas,
+  max_fee_per_gas,
+  gas_limit,
+  account_changes,
+  calls,
+  metadata,
+  payer,                     // 20 bytes, or empty for self-pay
+  sender_auth,
+  payer_auth
+])
+```
+
+`sender` and `payer` are nullable: an absent value is encoded as a zero-length byte string and a
+present value as a 20-byte string. The distinction is load-bearing and MUST be preserved through
+every encoding and decoding path. An absent `sender` selects the EOA path, where the sender is
+recovered from `sender_auth`; an absent `payer` selects self-pay. A _present but zero_ address is a
+distinct, non-equivalent value.
+
+### Transaction Hash
+
+The transaction hash is `keccak256(0x79 || rlp_encoded_payload)`, computed over the full EIP-2718
+encoding with the type byte included, as for every other typed transaction.
+
+The hash commits to `sender_auth` and `payer_auth`. It therefore MUST NOT be used to deduplicate or
+replace nonce-free transactions, which key on `replay_id` instead; see
+[EIP-8130][EIP-8130] for the `replay_id` preimage and the rationale.
+
+### Signature and Sender Resolution
+
+An account abstraction transaction has no `(v, r, s)` triple. Authorization is carried in
+`sender_auth` and `payer_auth`, each either a raw ECDSA signature (EOA path) or
+`authenticator || data` (configured-actor path). When surfaced through interfaces that expect
+signature values, they are reported as zero.
+
+Sender resolution depends on the path:
+
+- **Configured-actor path** (`sender` non-empty): the sender is the `sender` field.
+- **EOA path** (`sender` empty): the sender is recovered from `sender_auth` over the EIP-8130
+  sender signature payload.
+
+### Generic Transaction Interface Representation
+
+An EIP-8130 transaction has no top-level recipient, calldata, or value. Its destinations
+are the `to` field of each entry in `calls`, and it carries no value at all. ETH transfers are
+performed by the account's own code via the `CALL` opcode.
+
+| Field   | Value               |
+| ------- | ------------------- |
+| `type`  | `0x79`              |
+| `from`  | the resolved sender |
+| `to`    | omitted             |
+| `input` | omitted             |
+| `value` | `0`                 |
+| `nonce` | `nonce_sequence`    |
+| `gas`   | `gas_limit`         |
+
+Note that `nonce` surfaces only `nonce_sequence`; the channel it belongs to is `nonce_key`, and the
+pair identifies the sequence. A consumer that reads `nonce` alone cannot distinguish two
+transactions in different nonce channels.
+
+## Derivation
+
+Account abstraction transactions are ordinary sequenced user transactions. They reach L1 inside
+span batches and MUST round-trip through span-batch encoding, compression, and reconstruction
+byte-identically to their original EIP-2718 encoding.
+
+Before activation, a batch containing a `0x79` transaction is dropped. This mirrors the existing
+per-type gates that drop `SetCode` transactions before Isthmus and post-execution transactions
+before Sequencer-Defined Metering.
+
+### Span Batch Encoding
+
+The span-batch `txs` payload gains one trailing column:
+
+```text
+txs := contract_creation_bits ++ y_parity_bits ++ tx_sigs ++ tx_tos ++ tx_datas ++ tx_nonces
+       ++ tx_gases ++ protected_bits ++ eip8130_auth_data
+```
+
+A `0x79` transaction reuses the existing columns as follows:
+
+| Column                   | Value for a `0x79` transaction                             |
+| ------------------------ | ---------------------------------------------------------- |
+| `contract_creation_bits` | `1`, because there is no top-level recipient               |
+| `tx_tos`                 | no slot consumed, following from the contract-creation bit |
+| `tx_sigs`                | a zeroed slot, since there is no `(v, r, s)` triple        |
+| `y_parity_bits`          | `0`                                                        |
+| `tx_nonces`              | `nonce_sequence`                                           |
+| `tx_gases`               | `gas_limit`                                                |
+
+`chain_id` is dropped and restored from the batch's chain ID at decode time. The remaining
+type-specific fields are RLP-encoded into that transaction's `tx_datas` entry:
+
+```text
+0x79 || rlp([
+  sender,
+  nonce_key,
+  expiry,
+  max_priority_fee_per_gas,
+  max_fee_per_gas,
+  payer,
+  account_changes,
+  calls,
+  metadata,
+  sender_authenticator,
+  payer_authenticator
+])
+```
+
+Note that `payer` precedes `account_changes` here, whereas in the EIP-2718 encoding it follows
+`metadata`. The span-batch body is an independent encoding and its field order is normative as
+written above.
+
+### Authorization Data Column
+
+The `sender_auth` and `payer_auth` blobs are split so that the compressible part stays in
+`tx_datas` and the incompressible part is quarantined:
+
+| Part                            | Entropy | Location            |
+| ------------------------------- | ------- | ------------------- |
+| authenticator (20-byte address) | low     | `tx_datas` body     |
+| proof bytes                     | high    | `eip8130_auth_data` |
+
+On the configured-actor path the blob is `authenticator || proof`, so the leading 20 bytes move to
+the body and the remainder to the column. On the EOA and self-pay paths there is no leading
+authenticator and the entire blob is proof.
+
+`eip8130_auth_data` carries one bundle per `0x79` transaction, in transaction order, and is empty
+when the batch contains no `0x79` transactions. Each bundle is:
+
+```text
+bundle := uvarint(len(sender_proof)) || sender_proof || uvarint(len(payer_proof)) || payer_proof
+```
+
+Because the column trails every other column, a decoder learns which transactions are `0x79` from
+the leading type byte of each `tx_datas` entry before it reads the bundles. No additional bitlist is
+required, and a batch with no `0x79` transactions encodes byte-identically to one produced before
+activation.
+
+A decoded length prefix that exceeds the maximum span-batch element count MUST be rejected rather
+than allocated.
+
+### Decoding Rules
+
+A batch MUST be dropped when any of the following holds:
+
+1. A `0x79` transaction appears in a batch whose timestamp precedes activation.
+2. `eip8130_auth_data` contains fewer bundles than there are `0x79` transactions.
+3. A length prefix in `eip8130_auth_data` exceeds the maximum span-batch element count, or the
+   column ends before the declared number of proof bytes.
+4. The authenticator column disagrees with the corresponding actor: a configured actor (`sender` or
+   `payer` present) MUST carry exactly a 20-byte authenticator, and an EOA or self-pay actor
+   (`sender` or `payer` absent) MUST carry none.
+
+Rule 4 is the decode-side counterpart of the encode-side split. Without it, a batch could declare a
+configured actor while carrying an empty authenticator, and reconstruction would silently produce a
+corrupt authorization blob rather than failing.
+
+## Receipt
+
+An account abstraction transaction emits a receipt with type byte `0x79`. Its RLP-encoded consensus
+fields are identical to those of an EIP-1559 receipt:
+
+- `postStateOrStatus` ([EIP-658])
+- `cumulativeGasUsed`
+- `logsBloom`
+- `logs`
+
+`status` reports success only when every phase of `calls` succeeded, or when `calls` was empty. A
+failed status does **not** imply the transaction was a no-op: committed earlier phases, applied
+`account_changes`, auto-delegation, nonce consumption, and gas payment all persist through a later
+phase revert. Consumers MUST NOT treat a failed receipt as having made no state change.
+
+Per [EIP-8130], applied account changes inject log entries into the receipt, following the
+protocol-injected log pattern of [EIP-7708]. These logs are emitted only for `0x79` transactions.
+
+Two further fields are surfaced at the RPC layer and are **not** part of the consensus receipt:
+`payer`, the address that paid for gas, and `phaseStatuses`, the per-phase status array. They are
+excluded from the receipt's RLP encoding and therefore from the receipts root.
+
+[EIP-658]: https://eips.ethereum.org/EIPS/eip-658
+[EIP-7708]: https://eips.ethereum.org/EIPS/eip-7708
+
+## Enshrined Addresses
+
+[EIP-8130] specifies two precompiles at fixed addresses and a set of system contracts at
+deterministic CREATE2 addresses:
+
+| Address                                      | Role                                                   |
+| -------------------------------------------- | ------------------------------------------------------ |
+| `0x813000000000000000000000000000000000aa01` | Nonce Manager precompile                               |
+| `0x813000000000000000000000000000000000aa02` | Transaction Context precompile                         |
+| `address(1)`                                 | `K1_AUTHENTICATOR` sentinel, not a contract            |
+| CREATE2-derived                              | Account Configuration, default account, authenticators |
+
+The enshrined execution path writes persistent state to accounts that hold storage but carry no
+code, which leaves them [EIP-161]-empty and liable to be reaped by end-of-block state clearing,
+discarding that storage. The activation block MUST therefore ensure these accounts are non-empty.
+
+`K1_AUTHENTICATOR` is a protocol-reserved sentinel handled by native `ecrecover` rather than a
+`STATICCALL`. The other canonical authenticators short-circuit a `STATICCALL` to a deployed
+contract; where a client implements an authenticator natively, that implementation MUST produce
+results identical to the contract at the corresponding address, which remains callable from
+ordinary EVM code.
+
+[EIP-161]: https://eips.ethereum.org/EIPS/eip-161
+
+## Rationale
+
+**Why the auth column trails the others.** Placing `eip8130_auth_data` last lets the decoder
+identify `0x79` transactions from `tx_datas` before reading the column, which avoids an additional
+bitlist and makes a batch with no `0x79` transactions byte-identical to the pre-activation format.
+
+**Why the auth blob is split.** Span batches exist to improve data availability efficiency, and
+compression is their main lever. Signature proofs are incompressible, so leaving them inline would
+dilute the compressibility of the surrounding body. Separating the low-entropy authenticator
+address from the high-entropy proof keeps the body compressible.
+
+**Why the fields ride in `tx_datas` rather than getting their own columns.** The span-batch columns
+are shaped for the four fields every standard transaction carries, and EIP-8130 fits them poorly: it
+has no top-level recipient, its authorization is variable-length, and its recurring fields get no
+columnar grouping. Carrying the type-specific fields in `tx_datas` is correctness-complete and keeps
+the initial consensus-critical surface small. Giving EIP-8130's recurring fields their own columns
+(sender, payer, fee caps, and the call targets inside `calls`) is a data-availability optimization
+that can follow in a later upgrade, once real traffic exists to size it against.

--- a/words.txt
+++ b/words.txt
@@ -282,6 +282,7 @@ singlethreaded
 standardbridge
 standardbridgeaddress
 statelessly
+STATICCALL
 struct
 structs
 subgame


### PR DESCRIPTION
**Description**

Specifies how the OP Stack integrates [EIP-8130](https://eips.ethereum.org/EIPS/eip-8130), which
introduces account abstraction through onchain account configuration and a new EIP-2718 transaction
type (`0x79`).

Adds `specs/experimental/eip-8130.md` covering the parts that are OP-specific: activation, the chain
parameters the EIP leaves to the chain, span-batch encoding so `0x79` transactions survive
derivation, the receipt surface, and the enshrined system addresses.

It deliberately does **not** restate the account model, the authenticator set, the actor scope rules,
the intrinsic gas schedule, or the execution semantics. Those are normative in the EIP and apply
unchanged. The document says so explicitly and states that where it is silent, the EIP governs.
EIP-8130 is still a Draft, so this keeps the spec from drifting as the EIP moves and keeps the review
surface here to what the OP Stack actually adds.

EIP-8130 is not yet assigned to a network upgrade, so the spec names none and lives under
`experimental/` alongside the other unscheduled specs.

**Tests**

No automated tests. This is a specification-only change. `just lint-check` passes: markdownlint,
doctoc, cspell, and the filename check are all clean, and the five external EIP links return 200.

The wire format the document specifies is not novel and is not being introduced here. It is
specified as already implemented and tested in Base's stack, in both Rust and Go, so there are two
interoperating implementations behind it rather than a paper design. Client-side test coverage lands
with the implementation PRs.

**Additional context**

The consensus-critical parts, in rough order of risk, are where review attention is most useful:

- **Span-batch encoding.** The `txs` payload gains one trailing column, `eip8130_auth_data`. Each
  transaction's `sender_auth`/`payer_auth` blob is split: the low-entropy 20-byte authenticator
  address stays in the `tx_datas` body and the high-entropy proof bytes move to the new column. The
  column trails every other column so a decoder can identify `0x79` transactions from the leading
  type byte of each `tx_datas` entry before reading it. That avoids an additional bitlist and means
  a batch with no `0x79` transactions encodes byte-identically to one produced before activation.
- **Decode rules**, particularly rule 4: a configured actor must carry exactly a 20-byte
  authenticator and an EOA or self-pay actor must carry none. Without that binding, a batch can
  declare a configured actor while carrying an empty authenticator and reconstruction silently
  produces a corrupt authorization blob instead of failing.
- **Chain parameters.** `REPLAY_BUFFER_CAPACITY` and `NONCE_FREE_EXPIRY_WINDOW` are consensus, not
  node policy — the EIP is explicit that a per-node buffer capacity would split consensus. The spec
  requires they be sized together so a ring entry always expires before its slot is reused, and
  separates them from limits a node may legitimately apply locally.
- **Receipt layering.** The consensus receipt is a plain EIP-1559-shaped receipt; `payer` and
  `phaseStatuses` are RPC-only and excluded from the RLP encoding, and therefore from the receipts
  root. The spec also states that a failed status does not imply a no-op, since committed earlier
  phases, applied account changes, auto-delegation, nonce consumption, and gas payment all persist
  through a later phase revert.
- **Nullable address encoding.** Absent `sender`/`payer` are zero-length byte strings and a
  present-but-zero address is a distinct value. This separates the EOA path from the configured-actor
  path and self-pay from sponsored pay, so it has to survive every codec.

Open items I'd like input on:

1. **Should the trailing column be explicitly fork-gated?** The byte-compatibility argument says it
   needn't be, since a batch with no `0x79` transactions is unchanged. Flagging in case reviewers
   want an explicit gate anyway.
2. **`payer` field ordering.** It precedes `account_changes` in the span-batch body but follows
   `metadata` in the EIP-2718 encoding. Specified as implemented, but the asymmetry looks accidental
   rather than designed, and normalizing it is far cheaper now than after clients ship.
3. **Chain parameter values.** The spec pins the requirement and the sizing relationship but not the
   numbers, which need choosing per chain.