### PR TITLE
pcd: align specs with the shipped deployment pipeline

### DIFF
--- a/specs/experimental/predictive-chain-deployments/contracts.md
+++ b/specs/experimental/predictive-chain-deployments/contracts.md
@@ -285,19 +285,7 @@ Before PCD, enabling any permissionless game type during an initial deployment r
 `OPContractsManagerV2_InvalidGameConfigs`, on the premise that no prestate exists yet. PCD invalidates that premise.
 A real prestate now exists at deployment time.
 
-The game-type check is replaced by one scoped to the OPCM's mode:
-
-```solidity
-// Initial deployments must select game types compatible with the active mode.
-bool validForInitialDeploy = superRootGamesMigrationEnabled
-    ? (isSuperPermissionedGame || isSuperCannonKonaGame)
-    : (isPermissionedCannonGame || isCannonKonaGame);
-if (_isInitialDeployment && _cfg.disputeGameConfigs[i].enabled && !validForInitialDeploy) {
-    revert OPContractsManagerV2_InvalidGameConfigs();
-}
-```
-
-PCD then:
+The game-type check is replaced by one scoped to the OPCM's mode. PCD then:
 
 - MUST allow the permissionless game type of the OPCM's mode to be `enabled` during an initial deployment.
 - MUST reject a game type from the other mode, and MUST keep `CANNON` and `ZK_DISPUTE_GAME` rejected at initial

--- a/specs/experimental/predictive-chain-deployments/contracts.md
+++ b/specs/experimental/predictive-chain-deployments/contracts.md
@@ -27,7 +27,7 @@
   - [DeployOPChain script](#deployopchain-script)
     - [Address prediction](#address-prediction)
     - [Broadcasting a permissionless deployment](#broadcasting-a-permissionless-deployment)
-    - [Script input struct](#script-input-struct)
+    - [Script inputs](#script-inputs)
   - [OPCMv2 config validation](#opcmv2-config-validation)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -238,12 +238,11 @@ substitutions are safe (see [aPCD-001](#apcd-001-opcm-address-determinism)).
 
 #### Broadcasting a permissionless deployment
 
-Today the script hard-codes a permissioned-only initial deployment:
+Before PCD the script hard-coded a permissioned-only initial deployment:
 
-- It `require`s the input game type to be `PERMISSIONED_CANNON`, reverting with *"only PERMISSIONED_CANNON game type
-  is supported for initial deployment"*.
-- It builds the six `disputeGameConfigs` with the permissionless types disabled.
-- It sets `startingRespectedGameType` to the permissioned type and `startingAnchorRoot` to a placeholder.
+- It rejected any input game type other than `PERMISSIONED_CANNON`.
+- It built the six `disputeGameConfigs` with the permissionless types disabled.
+- It set `startingRespectedGameType` to the permissioned type and `startingAnchorRoot` to a placeholder.
 
 In order to support permissionless deployments the script is updated to:
 
@@ -263,24 +262,17 @@ In order to support permissionless deployments the script is updated to:
   addresses match the prediction (see
   [iOPD-001](./op-deployer.md#iopd-001-the-deployed-l1-system-matches-the-committed-artifacts)).
 
-#### Script input struct
+#### Script inputs
 
-Carrying those values into the script requires extending its Solidity input struct. `Types.DeployOPChainInput`
-(`scripts/libraries/Types.sol`) today exposes a single `disputeGameType` and `disputeAbsolutePrestate`. It gains two
-fields, and one existing field changes meaning:
+A permissionless deployment supplies three values the script did not previously take:
 
-| Field | Exists | Meaning |
-| --- | --- | --- |
-| `startingAnchorRoot` | new | The `Proposal` seeded into the `AnchorStateRegistry` |
-| `cannonAbsolutePrestate` | new | The [fallback prestate](./overview.md#fallback-prestate) for the guardian fallback game |
-| `disputeAbsolutePrestate` | repurposed | The [selected prestate](./overview.md#selected-prestate) of the respected game type |
+- the [starting anchor root](./overview.md#starting-anchor-root) seeded into the `AnchorStateRegistry`,
+- the [selected prestate](./overview.md#selected-prestate) of the respected game type, and
+- for the output root family only, the [fallback prestate](./overview.md#fallback-prestate) of the guardian fallback
+  game.
 
-`cannonAbsolutePrestate` is the **fallback**, not the permissionless prestate.
-The permissionless prestate is carried in `disputeAbsolutePrestate`, which previously carried the permissioned game's
-prestate.
-
-The script MUST reject a `CANNON_KONA` input whose two prestate values are equal. They commit to different fault-proof
-programs, **so equal values always indicate a misconfigured producer.**
+The script MUST reject an output root family input whose selected prestate equals its fallback prestate. They commit
+to different fault-proof programs, **so equal values always indicate a misconfigured producer.**
 
 ### OPCMv2 config validation
 
@@ -310,18 +302,19 @@ PCD then:
 - MUST allow the permissionless game type of the OPCM's mode to be `enabled` during an initial deployment.
 - MUST reject a game type from the other mode, and MUST keep `CANNON` and `ZK_DISPUTE_GAME` rejected at initial
   deployment (see [Supported initial game types](#supported-initial-game-types)).
-- MUST validate the values a permissionless initial deployment now carries. These checks are new, before PCD both
-  values were always placeholders:
+- MUST apply the checks PCD adds:
   - `startingAnchorRoot.root` MUST be non-zero on any initial deployment, and its `l2SequenceNumber` MUST leave room
     for a `uint64` successor.
   - The `0xdead` placeholder root MUST be rejected when an enabled config is one of `CANNON`, `CANNON_KONA` or
     `SUPER_CANNON_KONA`. Only a permissioned-only deployment may still carry the placeholder.
   - An enabled config among those same three game types MUST carry a non-zero `absolutePrestate`, decoded from its
     `gameArgs`.
-- MUST keep every other pre-existing validation intact:
+  - `SUPER_PERMISSIONED` MUST carry a zero init bond, whether or not it is enabled.
+- MUST keep every other validation OPCM already performs intact:
   - exactly six configs in the fixed game-type order,
-  - the init-bond rules, including `SUPER_PERMISSIONED` carrying a zero init bond,
-  - the `ZK_DISPUTE_GAME` dev-flag gate, and
+  - the init-bond rules for every other game type,
+  - the `ZK_DISPUTE_GAME` dev-flag gate plus its non-zero prestate requirement, both reachable only through the
+    upgrade path, and
   - `startingRespectedGameType` must correspond to an enabled config.
 
 The value checks reject an unset or placeholder input. They cannot reject a wrong one, since any non-zero prestate and

--- a/specs/experimental/predictive-chain-deployments/contracts.md
+++ b/specs/experimental/predictive-chain-deployments/contracts.md
@@ -8,6 +8,7 @@
 - [Definitions](#definitions)
   - [ChainContracts struct](#chaincontracts-struct)
   - [FullConfig](#fullconfig)
+  - [Supported initial game types](#supported-initial-game-types)
 - [Assumptions](#assumptions)
   - [aPCD-001: OPCM address determinism](#apcd-001-opcm-address-determinism)
     - [Mitigations](#mitigations)
@@ -26,6 +27,7 @@
   - [DeployOPChain script](#deployopchain-script)
     - [Address prediction](#address-prediction)
     - [Broadcasting a permissionless deployment](#broadcasting-a-permissionless-deployment)
+    - [Script input struct](#script-input-struct)
   - [OPCMv2 config validation](#opcmv2-config-validation)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -33,8 +35,8 @@
 ## Overview
 
 This document describes the contracts changes that are part of the implementation of the
-[Predictive Chain Deployments (PCD) design](https://github.com/ethereum-optimism/design-docs/pull/385). The bulk of
-the work is on the `op-deployer` side and the Solidity surface is deliberately minimal: one on-chain contract change
+[Predictive Chain Deployments (PCD) design](https://github.com/ethereum-optimism/design-docs/blob/main/ecosystem/op-deployer/predictive-chain-deployments/pcd-design.md).
+The bulk of the work is on the `op-deployer` side. The Solidity surface is limited to one on-chain contract
 (`OPContractsManagerV2`) and one Forge script (`DeployOPChain.s.sol`).
 
 1. **[`DeployOPChain` script](#deployopchain-script)**: broadcasts a permissionless deployment with a real
@@ -46,7 +48,8 @@ the work is on the `op-deployer` side and the Solidity surface is deliberately m
 
 ## Definitions
 
-See [Salt Mixer](./overview.md#salt-mixer) and [Anchor Block](./overview.md#anchor-block).
+See [Salt Mixer](./overview.md#salt-mixer), [Anchor Block](./overview.md#anchor-block),
+[Selected Prestate](./overview.md#selected-prestate) and [Fallback Prestate](./overview.md#fallback-prestate).
 
 ### ChainContracts struct
 
@@ -71,6 +74,7 @@ struct ChainContracts {
 ```
 
 The `op-deployer` consumes a subset of these addresses when building the genesis and rollup artifacts:
+
 - `l1CrossDomainMessenger`, `l1StandardBridge`, `l1ERC721Bridge` are inputs to `L2Genesis.s.sol` (the
   [L2 allocs](./overview.md#l2-allocs)).
 - `optimismPortal` and `systemConfig` are written into `rollup.json`.
@@ -100,10 +104,25 @@ struct FullConfig {
 }
 ```
 
-Once the PCD pipeline has built the `startingAnchorRoot` and the `absolutePrestate`, it fills these fields with real
-values instead of placeholders. `startingAnchorRoot` is the genesis [output root](./overview.md#output-root) with
-`l2SequenceNumber = 0`. The `absolutePrestate` is carried inside the permissionless `disputeGameConfigs`
-entry we are currently enabling.
+Once the PCD pipeline has built the [starting anchor root](./overview.md#starting-anchor-root) and the
+[selected prestate](./overview.md#selected-prestate), it fills these fields with real values instead of placeholders.
+The prestate is carried inside the permissionless `disputeGameConfigs` entry being enabled.
+
+### Supported initial game types
+
+`disputeGameConfigs` always holds six entries in a fixed order. Which of them may be `enabled` at initial deployment
+depends on whether the OPCM has the `SUPER_ROOT_GAMES_MIGRATION` dev feature on:
+
+| Index | Game type | Enabled at initial deployment |
+| --- | --- | --- |
+| 0 | `CANNON` | Never. Legacy slot |
+| 1 | `PERMISSIONED_CANNON` | Output root mode only |
+| 2 | `CANNON_KONA` | Output root mode only |
+| 3 | `SUPER_PERMISSIONED` | Super root mode only |
+| 4 | `SUPER_CANNON_KONA` | Super root mode only |
+| 5 | `ZK_DISPUTE_GAME` | Never at initial deployment. Reachable through the upgrade path |
+
+`startingRespectedGameType` must be one of the four selectable types and **must belong to the OPCM's mode**.
 
 ## Assumptions
 
@@ -111,22 +130,27 @@ entry we are currently enabling.
 
 OPCM deploys proxies with CREATE2 using a salt derived from `msg.sender` and `saltMixer`, and no other inputs that
 change across executions.
-Given the same sender and config, against the same OPCM, the produced addresses are identical.
+Given the same sender and salt mixer, against the same OPCM, the produced addresses are identical.
 
 #### Mitigations
 
 - The dry-run executes the full `OPCM.deploy()` logic without broadcasting, exercising the same code path as the
   real broadcast.
+- The remaining `FullConfig` fields do not feed the salt, so the placeholders the dry-run substitutes for them (see
+  [Address prediction](#address-prediction)) cannot change the predicted addresses.
 
 ### aPCD-002: Dry-run and broadcast use the same sender and `saltMixer`
 
-The address prediction is only valid if the dry-run uses the same `from` address and `saltMixer` as the eventual broadcast,
-since `msg.sender` and `saltMixer` are inputs to the CREATE2 salt.
+The address prediction is only valid if the dry-run uses the same `from` address and `saltMixer` as the eventual
+broadcast, since `msg.sender` and `saltMixer` are inputs to the CREATE2 salt.
 
 #### Mitigations
 
 - op-deployer MUST use the same `from` address and `saltMixer` for the dry-run and the broadcast (see
   [FM2](./op-deployer.md#failure-modes)).
+- The salt mixer is generated once and stored in op-deployer state, so separate command invocations reuse it rather
+  than deriving it again (see [Salt Mixer](./overview.md#salt-mixer)).
+- `prepare` and `continue` both reject a run whose deployer or OPCM differs from the one recorded in state.
 - A pre-broadcast preflight re-checks the predicted addresses against current L1 state before deploying.
 
 ### aPCD-003: Trusted L1 RPC
@@ -136,8 +160,8 @@ The dry-run result is only trustworthy if the L1 RPC is not compromised and retu
 #### Mitigations
 
 - Use an independent, trusted RPC.
-- Cross-check the dry-run against a second, independent L1 RPC. Divergent addresses flag a compromised endpoint before
-  broadcast (see [FM3](./op-deployer.md#failure-modes)).
+- `continue` re-simulates the deployment against a fresh fork before broadcasting, and post-deploy validation re-reads
+  the deployed system from live L1 (see [FM3](./op-deployer.md#failure-modes)).
 
 ## Invariants
 
@@ -151,12 +175,14 @@ to predict.
 **Severity: High**
 
 A L1 state write at prediction time also costs the deployer real ETH on what should be a dry-run. Worse, it deploys a
-chain that can never be used. Prediction runs before the prestate and the genesis output root are known, so the
+chain that can never be used. Prediction runs before the prestate and the starting anchor root are known, so the
 deployment would be seeded with neither.
 
 ### iPCD-002: Permissioned deployments remain valid
 
-The updated `_assertValidFullConfig` MUST still accept every `FullConfig` that was valid before this change.
+The updated `_assertValidFullConfig` MUST still accept every permissioned `FullConfig` that was valid before this
+change **for an OPCM in the matching mode**: `PERMISSIONED_CANNON` in output root mode, `SUPER_PERMISSIONED` in super
+root mode.
 
 #### Impact
 
@@ -167,7 +193,7 @@ If violated, valid configurations for permissioned deployments would be blocked.
 ### iPCD-003: Invalid configurations stay rejected
 
 The updated `_assertValidFullConfig` MUST still reject every `FullConfig` that was invalid before this change, apart
-from enabling other dispute game types at initial deployment.
+from enabling the permissionless game type of the OPCM's mode at initial deployment.
 
 #### Impact
 
@@ -179,7 +205,7 @@ If violated, OPCM could accept an invalid dispute configuration at deployment.
 
 Two changes are needed on the Solidity surface. `DeployOPChain` predicts the L1 addresses that seed the genesis
 pipeline and later broadcasts the deployment. The OPCM change lets that broadcast enable a permissionless game at
-initial deployment.
+initial deployment, and checks the values such a deployment now carries.
 
 ### DeployOPChain script
 
@@ -195,33 +221,66 @@ Using the same script for both ensures the predicted addresses are equal to the 
 **Behavior:**
 
 - MUST execute `OPCM.deploy()` against the current L1 state.
-- MUST use the same `from` address that will be used for the real broadcast.
+- MUST use the same `from` address and `saltMixer` that will be used for the real broadcast.
 - MUST NOT broadcast or otherwise write state to L1.
 - MUST return the predicted [`ChainContracts`](#chaincontracts-struct) addresses to the caller.
+
+The dry-run uses placeholders for some of the values. The six chain roles are substituted because prediction must not
+depend on them, and the `startingAnchorRoot` because its real value is not known yet:
+
+| Field | Dry-run value | Why |
+| --- | --- | --- |
+| all six chain roles | a single placeholder address | Roles do not feed the CREATE2 salt |
+| `startingAnchorRoot` | a sentinel root for permissionless deploys, the `0xdead` placeholder otherwise | The real root is derived from the addresses being predicted |
+
+Only `msg.sender`, `saltMixer`, `l2ChainId` and the OPCM address determine the deployed addresses, so these
+substitutions are safe (see [aPCD-001](#apcd-001-opcm-address-determinism)).
 
 #### Broadcasting a permissionless deployment
 
 Today the script hard-codes a permissioned-only initial deployment:
 
-- It `require`s the initial game type to be `PERMISSIONED_CANNON` (or `SUPER_PERMISSIONED_CANNON` in super-root mode),
-  reverting with *"only PERMISSIONED_CANNON game type is supported for initial deployment"*.
+- It `require`s the input game type to be `PERMISSIONED_CANNON`, reverting with *"only PERMISSIONED_CANNON game type
+  is supported for initial deployment"*.
 - It builds the six `disputeGameConfigs` with the permissionless types disabled.
 - It sets `startingRespectedGameType` to the permissioned type and `startingAnchorRoot` to a placeholder.
 
 In order to support permissionless deployments the script is updated to:
 
-- MUST permit an arbitrary dispute game type as `startingRespectedGameType` at initial deployment.
-- MUST enable the permissionless `disputeGameConfigs` entry, carrying its real `absolutePrestate`.
-- MUST pass the real genesis output root as `startingAnchorRoot` instead of the placeholder.
+- MUST accept any of the four [supported initial game types](#supported-initial-game-types) as
+  `startingRespectedGameType`, and MUST revert on any other game type.
+- MUST revert when the requested game type does not belong to the OPCM's mode, so the caller's prestate and proposal
+  format always match the games the OPCM installs.
+- MUST enable the permissionless `disputeGameConfigs` entry, carrying its real
+  [selected prestate](./overview.md#selected-prestate).
+- MUST also enable the permissioned game of the same family as a guardian fallback, so a permissionless deployment
+  enables **two** configs. `CANNON_KONA` enables `PERMISSIONED_CANNON`, `SUPER_CANNON_KONA` enables
+  `SUPER_PERMISSIONED`. The fallback carries the [fallback prestate](./overview.md#fallback-prestate).
+- MUST pass the real [starting anchor root](./overview.md#starting-anchor-root) instead of the placeholder, and MUST
+  reject the placeholder for a permissionless deployment.
 - MUST continue to support permissioned-only deployments.
 - MUST use a `from` address consistent with the [address-prediction](#address-prediction) dry-run, so the deployed
   addresses match the prediction (see
   [iOPD-001](./op-deployer.md#iopd-001-the-deployed-l1-system-matches-the-committed-artifacts)).
 
+#### Script input struct
+
 Carrying those values into the script requires extending its Solidity input struct. `Types.DeployOPChainInput`
-(`scripts/libraries/Types.sol`) today exposes only a single `disputeGameType` and
-`disputeAbsolutePrestate`. It MUST gain a `startingAnchorRoot` field and the permissionless game's prestate hash so a
-permissionless config can be included.
+(`scripts/libraries/Types.sol`) today exposes a single `disputeGameType` and `disputeAbsolutePrestate`. It gains two
+fields, and one existing field changes meaning:
+
+| Field | Exists | Meaning |
+| --- | --- | --- |
+| `startingAnchorRoot` | new | The `Proposal` seeded into the `AnchorStateRegistry` |
+| `cannonAbsolutePrestate` | new | The [fallback prestate](./overview.md#fallback-prestate) for the guardian fallback game |
+| `disputeAbsolutePrestate` | repurposed | The [selected prestate](./overview.md#selected-prestate) of the respected game type |
+
+`cannonAbsolutePrestate` is the **fallback**, not the permissionless prestate.
+The permissionless prestate is carried in `disputeAbsolutePrestate`, which previously carried the permissioned game's
+prestate.
+
+The script MUST reject a `CANNON_KONA` input whose two prestate values are equal. They commit to different fault-proof
+programs, **so equal values always indicate a misconfigured producer.**
 
 ### OPCMv2 config validation
 
@@ -230,22 +289,41 @@ permissionless config can be included.
 script guard in [`DeployOPChain`](#deployopchain-script) alone is not enough, because `OPCM.deploy()` would still
 revert here.
 
-During an initial deployment, enabling any permissionless game type reverts with
-`OPContractsManagerV2_InvalidGameConfigs`, on the premise that no prestate exists yet:
+Before PCD, enabling any permissionless game type during an initial deployment reverted with
+`OPContractsManagerV2_InvalidGameConfigs`, on the premise that no prestate exists yet. PCD invalidates that premise.
+A real prestate now exists at deployment time.
+
+The game-type check is replaced by one scoped to the OPCM's mode:
 
 ```solidity
-// During initial deployment, only permissioned types can be enabled, because no
-// prestate exists for permissionless games.
-if (_isInitialDeployment && !isPermissioned && _cfg.disputeGameConfigs[i].enabled) {
+// Initial deployments must select game types compatible with the active mode.
+bool validForInitialDeploy = superRootGamesMigrationEnabled
+    ? (isSuperPermissionedGame || isSuperCannonKonaGame)
+    : (isPermissionedCannonGame || isCannonKonaGame);
+if (_isInitialDeployment && _cfg.disputeGameConfigs[i].enabled && !validForInitialDeploy) {
     revert OPContractsManagerV2_InvalidGameConfigs();
 }
 ```
 
-PCD invalidates that premise. A real prestate now exists at deployment time. The change:
+PCD then:
 
-- MUST allow a permissionless game type to be `enabled` during an initial deployment.
-- MUST keep every other validation intact:
+- MUST allow the permissionless game type of the OPCM's mode to be `enabled` during an initial deployment.
+- MUST reject a game type from the other mode, and MUST keep `CANNON` and `ZK_DISPUTE_GAME` rejected at initial
+  deployment (see [Supported initial game types](#supported-initial-game-types)).
+- MUST validate the values a permissionless initial deployment now carries. These checks are new, before PCD both
+  values were always placeholders:
+  - `startingAnchorRoot.root` MUST be non-zero on any initial deployment, and its `l2SequenceNumber` MUST leave room
+    for a `uint64` successor.
+  - The `0xdead` placeholder root MUST be rejected when an enabled config is one of `CANNON`, `CANNON_KONA` or
+    `SUPER_CANNON_KONA`. Only a permissioned-only deployment may still carry the placeholder.
+  - An enabled config among those same three game types MUST carry a non-zero `absolutePrestate`, decoded from its
+    `gameArgs`.
+- MUST keep every other pre-existing validation intact:
   - exactly six configs in the fixed game-type order,
-  - the init-bond rules,
+  - the init-bond rules, including `SUPER_PERMISSIONED` carrying a zero init bond,
   - the `ZK_DISPUTE_GAME` dev-flag gate, and
   - `startingRespectedGameType` must correspond to an enabled config.
+
+The value checks reject an unset or placeholder input. They cannot reject a wrong one, since any non-zero prestate and
+any non-placeholder root pass (see
+[iOPD-003](./op-deployer.md#iopd-003-absoluteprestate-matches-the-committed-chain-config)).

--- a/specs/experimental/predictive-chain-deployments/op-deployer.md
+++ b/specs/experimental/predictive-chain-deployments/op-deployer.md
@@ -27,6 +27,8 @@
     - [Impact](#impact-2)
   - [iOPD-004: A permissionless deployment requires a committed prestate](#iopd-004-a-permissionless-deployment-requires-a-committed-prestate)
     - [Impact](#impact-3)
+  - [iOPD-005: The reserved fallback prestate is never a selected prestate](#iopd-005-the-reserved-fallback-prestate-is-never-a-selected-prestate)
+    - [Impact](#impact-4)
 - [Pipeline](#pipeline)
   - [prepare](#prepare)
   - [prestate](#prestate)
@@ -115,7 +117,8 @@ The [anchor block](./overview.md#anchor-block) chosen during `prepare` stays on 
 ### aOPD-003: op-deployer state is trusted
 
 The artifacts and hashes that `prepare` and `prestate` write are not tampered with before `continue` reads them. The
-[state](#op-deployer-state) is the only channel between the off-chain computation and the eventual broadcast.
+[state](#op-deployer-state) is the only channel between the off-chain computation and the eventual broadcast. The
+artifact bundles the state references are outside this assumption.
 
 #### Mitigations
 
@@ -133,7 +136,7 @@ prestate itself.
 
 - The recipe embeds the chain config at compile time, so the hash is a pure function of the committed artifacts.
 - A reviewer rebuilds the prestate and compares the hash against the value in the state before `continue` (see
-  [FM4](#failure-modes)).
+  [FM4](#failure-modes)). This is the only check that catches a prestate that is set but incorrect.
 
 ## Invariants
 
@@ -182,24 +185,33 @@ The prestate hash written to the [state](#op-deployer-state) and carried into th
 **Severity: Critical**
 
 A mismatched prestate makes the two sides of a dispute disagree on the starting state. Fault proofs are broken from
-block 0. Recovering from this is expensive.
-
-OPCM rejects a **zero** prestate on an enabled Cannon-family game (see
-[OPCMv2 config validation](./contracts.md#opcmv2-config-validation)), so an unset prestate cannot reach L1. It cannot
-reject a wrong one, since any nonzero value passes. Reproducing the prestate before `continue` is the only thing that
-catches a prestate that is set but incorrect. See [FM4](#failure-modes) and [FM6](#failure-modes).
+block 0. Recovering from this is expensive. See [FM4](#failure-modes) and [FM6](#failure-modes).
 
 ### iOPD-004: A permissionless deployment requires a committed prestate
 
 `continue` MUST halt any attempt to make a permissionless deployment when the prestate is unset.
-A permissioned-only deployment carries no selected prestate and MUST be able to proceed without one.
+A permissioned-only deployment has no committed prestate and MUST be able to proceed without one, carrying the
+[selected prestate](./overview.md#selected-prestate) its chain configuration already supplies.
 
 #### Impact
 
 **Severity: High**
 
-If a permissionless deployment proceeded without a prestate, it would broadcast `OPCM.deploy()` with a missing
-`absolutePrestate`. This check is conditional on a permissionless game type being enabled.
+The deployment cannot succeed, since the enabled permissionless game would have no prestate to commit to. The failure
+surfaces during the deployment attempt rather than before any transaction is prepared.
+
+### iOPD-005: The reserved fallback prestate is never a selected prestate
+
+The [fallback prestate](./overview.md#fallback-prestate) value is reserved for the guardian fallback game. It MUST
+never be committed as the [selected prestate](./overview.md#selected-prestate) of a permissionless deployment.
+
+#### Impact
+
+**Severity: Critical**
+
+The respected game would be seeded with a prestate that commits to no real fault-proof program, leaving it unplayable
+from block 0. Fault proofs are broken exactly as in
+[iOPD-003](#iopd-003-absoluteprestate-matches-the-committed-chain-config).
 
 ## Pipeline
 
@@ -249,8 +261,10 @@ anything itself. It only commits the built hash into op-deployer state, which `c
   - a **per-chain intent override**, the chain's `deployOverrides.faultGameAbsolutePrestate`.
 - MUST fail when two or more sources are set and disagree.
 - MUST fail if no source is provided for a chain whose game type requires a prestate.
-- MUST reject the reserved [fallback prestate](./overview.md#fallback-prestate) value as a selected prestate.
-- A permissioned-only chain MUST be left without a selected prestate.
+- MUST reject the reserved [fallback prestate](./overview.md#fallback-prestate) value as a selected prestate (see
+  [iOPD-005](#iopd-005-the-reserved-fallback-prestate-is-never-a-selected-prestate)).
+- A permissioned-only chain MUST be left without a committed prestate. Its respected game keeps the
+  [selected prestate](./overview.md#selected-prestate) the chain configuration supplies.
 
 ### continue
 
@@ -262,13 +276,16 @@ any of them, so a configuration error stops the run before it can produce a part
 - MUST verify the current intent still agrees with the frozen snapshot, and that the dependency set still matches.
 - MUST re-download both artifact bundles by locator and verify their content digests against the frozen values.
 - MUST fail when the deployer or OPCM differs from the one recorded by `prepare`.
-- MUST halt a permissionless deployment when the prestate is unset or holds the reserved fallback value. The prestate
-  gate is conditional on a permissionless game type: a **permissioned-only** deployment carries no selected prestate
-  and proceeds without one.
+- MUST halt a permissionless deployment when the prestate is unset or holds the reserved fallback value (see
+  [iOPD-005](#iopd-005-the-reserved-fallback-prestate-is-never-a-selected-prestate)). The prestate gate is conditional
+  on a permissionless game type: a **permissioned-only** deployment has no committed prestate and proceeds
+  without one.
 - MUST halt a permissionless deployment when the starting anchor root is unset or still holds the `0xdead` placeholder.
 - MUST re-check the predicted addresses by simulating the deployment against a fresh fork of L1 (pre-broadcast
   preflight) and abort on mismatch.
 - MUST verify the simulated broadcast is exactly one call, to the pinned OPCM, from the pinned deployer.
+- SHOULD warn, without halting, when the committed genesis time has already elapsed against the L1 head. `prepare` is
+  the only hard gate on the [deployment window](#deployment-window), and it compares against the safe head.
 
 **Broadcasting:**
 
@@ -303,7 +320,7 @@ the `prepare` flow.
 The two flows MUST NOT be mixed on one working directory. `prepare` MUST refuse a state produced by `apply`, and
 `apply` MUST refuse a prepared state.
 
-A permissioned-only chain may still go through `prepare` / `prestate` / `continue`. It carries no selected prestate
+A permissioned-only chain may still go through `prepare` / `prestate` / `continue`. It has no committed prestate
 and broadcasts the same `0xdead` placeholder anchor that `apply` would. The real anchor root is substituted only for
 permissionless deployments.
 

--- a/specs/experimental/predictive-chain-deployments/op-deployer.md
+++ b/specs/experimental/predictive-chain-deployments/op-deployer.md
@@ -21,7 +21,7 @@
 - [Invariants](#invariants)
   - [iOPD-001: The deployed L1 system matches the committed artifacts](#iopd-001-the-deployed-l1-system-matches-the-committed-artifacts)
     - [Impact](#impact)
-  - [iOPD-002: `startingAnchorRoot` equals the genesis output root](#iopd-002-startinganchorroot-equals-the-genesis-output-root)
+  - [iOPD-002: `startingAnchorRoot` equals the committed starting anchor root](#iopd-002-startinganchorroot-equals-the-committed-starting-anchor-root)
     - [Impact](#impact-1)
   - [iOPD-003: `absolutePrestate` matches the committed chain config](#iopd-003-absoluteprestate-matches-the-committed-chain-config)
     - [Impact](#impact-2)
@@ -31,6 +31,7 @@
   - [prepare](#prepare)
   - [prestate](#prestate)
   - [continue](#continue)
+  - [Relationship to `apply`](#relationship-to-apply)
 - [Deployment guards](#deployment-guards)
 - [Genesis block header fields](#genesis-block-header-fields)
 - [depsets.json](#depsetsjson)
@@ -42,12 +43,12 @@
 ## Overview
 
 op-deployer orchestrates PCD by computing all chain artifacts off-chain before broadcasting, then submitting
-`OPCM.deploy()` with the real `startingAnchorRoot` and `absolutePrestate`. This replaces the previous
-`startingAnchorRoot = 0xdead` flow.
+`OPCM.deploy()` with the real [starting anchor root](./overview.md#starting-anchor-root) and
+[selected prestate](./overview.md#selected-prestate).
 
-The pipeline is three stages: `prepare` (off-chain computation), `prestate` (commit the prestate
-hash), and `continue` (re-validate and broadcast). This page specifies the orchestration and the behavior of the
-three commands. The Solidity surface changes the pipeline drives are specified in [Contracts](./contracts.md).
+The pipeline is three stages: `prepare` (off-chain computation), `prestate` (commit the prestate hash), and `continue`
+(re-validate and broadcast). This page specifies the orchestration and the behavior of the three commands. The
+Solidity surface changes the pipeline drives are specified in [Contracts](./contracts.md).
 
 ## Definitions
 
@@ -55,15 +56,19 @@ three commands. The Solidity surface changes the pipeline drives are specified i
 
 `state.json` is op-deployer's canonical state file, written to the working directory alongside `intent.toml`. It is
 the only channel between the off-chain computation and the eventual broadcast. `prepare` records the predicted L1
-addresses, the L2 allocs, the anchor block reference, and the genesis [output root](./overview.md#output-root).
+addresses, the L2 allocs, the anchor block reference, the genesis block hash, and the starting anchor root.
 `prestate` records the prestate hash. `continue` reads these to run its preflight, set `startingAnchorRoot` and
 `absolutePrestate`, and broadcast `OPCM.deploy()`.
 
 ### Anchor offset (`X`)
 
 The number of seconds added to the [anchor block](./overview.md#anchor-block) timestamp to set the L2 genesis
-timestamp: `genesis_time = l1AnchorBlock.timestamp + X`. The operator commits to `X` at deploy time. Every artifact
-that is built down the pipeline derives deterministically from it.
+timestamp: `genesis_time = l1AnchorBlock.timestamp + X`. The operator commits to `X` at deploy time.
+Every artifact that is built down the pipeline
+derives deterministically from it.
+
+`X` sizes the [deployment window](#deployment-window). It has to cover address prediction, the external prestate
+build, and the broadcast.
 
 ### Deployment window
 
@@ -78,7 +83,7 @@ to still be in the future when `OPCM.deploy()` is mined (see [FM5](#failure-mode
 Given the same [anchor block](./overview.md#anchor-block), [anchor offset](#anchor-offset-x), chain config, and L1
 state, the pipeline reproduces identical artifacts: the predicted L1 addresses, the
 [L2 allocs](./overview.md#l2-allocs), the [genesis block](./overview.md#genesis-block), its
-[output root](./overview.md#output-root), and the prestate hash.
+[starting anchor root](./overview.md#starting-anchor-root), and the prestate hash.
 
 #### Mitigations
 
@@ -86,6 +91,8 @@ state, the pipeline reproduces identical artifacts: the predicted L1 addresses, 
   `OPCM.deploy()` code path.
 - Address prediction reuses the same `DeployOPChain` script that performs the broadcast (see
   [aPCD-001](./contracts.md#apcd-001-opcm-address-determinism)).
+- The CREATE2 salt is generated once and persisted in state, so re-runs cannot derive a different one (see
+  [Salt Mixer](./overview.md#salt-mixer)).
 - The prestate comes from the reproducible `reproducible-prestate-kona` recipe (see
   [aOPD-004](#aopd-004-the-prestate-build-is-reproducible)).
 
@@ -98,8 +105,12 @@ The [anchor block](./overview.md#anchor-block) chosen during `prepare` stays on 
 
 - Only blocks at the `safe` tag or deeper are eligible. Any attempt to use a shallower block fails the pipeline with a
   clear error.
-- A `BLOCKHASH` check in the deploy transaction reverts if the anchor is no longer retrievable, aborting before
-  `OPCM.deploy()` runs (see [FM1](#failure-modes)).
+- An anchor supplied by hash is re-fetched by number and compared, since a hash lookup alone can return a block that
+  has already been reorg'd out.
+- `continue` re-fetches the `safe` tag and re-verifies the pinned anchor is canonical at its height immediately before
+  each broadcast, aborting the broadcast on drift (see [FM1](#failure-modes)).
+- The deployment receipt's block is checked to be canonical after the transaction is mined, catching a reorg that
+  lands after the pre-broadcast check.
 
 ### aOPD-003: op-deployer state is trusted
 
@@ -141,10 +152,17 @@ invariant, and the on-chain determinism it depends on is
 [aPCD-001](./contracts.md#apcd-001-opcm-address-determinism). See [FM2](#failure-modes) and
 [FM3](#failure-modes).
 
-### iOPD-002: `startingAnchorRoot` equals the genesis output root
+### iOPD-002: `startingAnchorRoot` equals the committed starting anchor root
 
-The `startingAnchorRoot` passed to `OPCM.deploy()` MUST equal the [output root](./overview.md#output-root) recomputed
-from the committed [genesis block](./overview.md#genesis-block), with `l2SequenceNumber = 0`.
+The `startingAnchorRoot` passed to `OPCM.deploy()` MUST equal the
+[starting anchor root](./overview.md#starting-anchor-root) recomputed from the committed
+[genesis block](./overview.md#genesis-block). Both the root and its `l2SequenceNumber` MUST match, and what they hold
+depends on the game family:
+
+- **Output root games.** The root is the chain's own genesis output root and `l2SequenceNumber` is `0`, the L2 genesis
+  block number.
+- **Super root games.** The root is one [super root](./overview.md#super-root) over the whole dependency set and
+  `l2SequenceNumber` is that super root's timestamp. Every member chain is seeded with the same pair.
 
 #### Impact
 
@@ -155,22 +173,26 @@ genesis cannot be proven, and fault proofs are broken from block 0.
 
 ### iOPD-003: `absolutePrestate` matches the committed chain config
 
-The prestate hash written to the [state](#op-deployer-state) and carried into the enabled permissionless `disputeGameConfigs`
-entry MUST equal the hash reproduced from the committed `genesis.json`, `rollup.json`, and `depsets.json`. Re-running `prepare`
-with a different anchor MUST invalidate a stale prestate before `continue` proceeds.
+The prestate hash written to the [state](#op-deployer-state) and carried into the enabled permissionless
+`disputeGameConfigs` entry MUST equal the hash reproduced from the committed `genesis.json`, `rollup.json`, and
+`depsets.json`. Re-running `prepare` MUST invalidate a stale prestate before `continue` proceeds.
 
 #### Impact
 
 **Severity: Critical**
 
 A mismatched prestate makes the two sides of a dispute disagree on the starting state. Fault proofs are broken from
-block 0, with no on-chain guard to catch it at deploy time. Recovering from this is expensive. See
-[FM4](#failure-modes) and [FM6](#failure-modes).
+block 0. Recovering from this is expensive.
+
+OPCM rejects a **zero** prestate on an enabled Cannon-family game (see
+[OPCMv2 config validation](./contracts.md#opcmv2-config-validation)), so an unset prestate cannot reach L1. It cannot
+reject a wrong one, since any nonzero value passes. Reproducing the prestate before `continue` is the only thing that
+catches a prestate that is set but incorrect. See [FM4](#failure-modes) and [FM6](#failure-modes).
 
 ### iOPD-004: A permissionless deployment requires a committed prestate
 
-`continue` MUST halt any attempt to make a permissionless deployment when the prestate is unset. A permissioned-only
-deployment carries no prestate and MUST be able to proceed without one.
+`continue` MUST halt any attempt to make a permissionless deployment when the prestate is unset.
+A permissioned-only deployment carries no selected prestate and MUST be able to proceed without one.
 
 #### Impact
 
@@ -186,61 +208,116 @@ command can run.
 
 ### prepare
 
-Off-chain computation of the genesis block. Outputs `genesis.json`, `rollup.json`, and `depsets.json`.
+Off-chain computation of the genesis block and the starting anchor root. Everything it derives goes into
+[op-deployer state](#op-deployer-state).
+
+`prepare` predicts against an already-deployed OPCM rather than deploying one, so the intent MUST pin both
+`opcmAddress` and `superchainConfigProxy`. `prepare` reads the implementation set and the game mode
+(`SUPER_ROOT_GAMES_MIGRATION`) off that OPCM and records them, and rejects a chain whose requested game type belongs
+to the other mode before doing any further work.
 
 - **Pick the anchor block.** Choose an L1 anchor block at the `safe` tag or deeper to avoid reorg invalidation. Its
   hash is baked into `rollup.json` and the prestate.
-- **Fix the genesis timestamp.** Set `genesis_time = l1AnchorBlock.timestamp + X`, where `X` is a configured offset.
-  The genesis timestamp is a direct input to the genesis block header, `stateRoot`, output root, and prestate hash. A
-  different timestamp changes every downstream artifact.
+- **Fix the genesis timestamp.** Set `genesis_time = l1AnchorBlock.timestamp + X`, where `X` is the
+  [anchor offset](#anchor-offset-x). The genesis timestamp is a direct input to the genesis block header, `stateRoot`,
+  output root, and prestate hash. A different timestamp changes every downstream artifact.
 - **Predict the L1 addresses.** Call the [contracts prediction path](./contracts.md#address-prediction), using the
   same `from` address as the eventual `OPCM.deploy()` broadcast.
 - **Compute the L2 allocs.** Execute `L2Genesis.s.sol` with the predicted L1 addresses.
 - **Build the genesis block** from the allocs, chain config, and `genesis_time`.
-- **Compute the genesis [output root](./overview.md#output-root).**
-- **Generate `depsets.json`.**
+- **Compute the [starting anchor root](./overview.md#starting-anchor-root).**
+- **Build the dependency set.**
+
+`prepare` MUST pin each chain's anchor block and genesis time on its first run and reuse that pair on every later run,
+so re-runs stay idempotent. It MUST fail when a per-chain `l1StartBlockHash` override conflicts with an already-pinned
+anchor, and when the pinned genesis time has fallen outside the [deployment window](#deployment-window).
+
+Any `prepare` run MUST invalidate every artifact derived from the predicted addresses for the chains it re-prepares:
+the committed prestate, the starting anchor root, the L2 allocs, and the genesis block hash. A
+re-run that reuses the pinned anchor still clears them, so **every `prepare` re-run forces a `prestate` re-run** (see
+[FM6](#failure-modes)).
 
 ### prestate
 
 The prestate is built **externally** by the monorepo's `reproducible-prestate-kona` recipe, from the `genesis.json`,
-`rollup.json`, and `depsets.json` that `prepare` produces. The `prestate` command does not compile or hash anything
-itself. It only commits the built hash into op-deployer state, which `continue` reads.
+`rollup.json`, and `depsets.json` rendered from the prepared state. The `prestate` command does not compile or hash
+anything itself. It only commits the built hash into op-deployer state, which `continue` reads.
 
-- MUST write the prestate hash to op-deployer state from one of two sources, treated identically:
-  - a **command flag** that passes the hash directly, or
-  - an **intent override** declared in the intent, which the command resolves.
-- MUST fail if neither source is provided.
-- If both are provided, it MUST fail when the two hashes disagree.
-- Re-running `prepare` with a different anchor MUST invalidate a previously-committed prestate and force a rebuild
-  before `continue` (see [FM6](#failure-modes)).
+- MUST write the prestate hash to op-deployer state from any of three sources:
+  - the `--dispute-absolute-prestate` **command flag**, or the matching environment variable,
+  - a **global intent override**, `globalDeployOverrides.faultGameAbsolutePrestate`, or
+  - a **per-chain intent override**, the chain's `deployOverrides.faultGameAbsolutePrestate`.
+- MUST fail when two or more sources are set and disagree.
+- MUST fail if no source is provided for a chain whose game type requires a prestate.
+- MUST reject the reserved [fallback prestate](./overview.md#fallback-prestate) value as a selected prestate.
+- A permissioned-only chain MUST be left without a selected prestate.
 
 ### continue
 
-- MUST re-check the predicted addresses against current L1 state (pre-broadcast preflight) and abort on mismatch.
-- MUST submit `OPCM.deploy()` with the `startingAnchorRoot` (the genesis output root) and `absolutePrestate`.
-- MUST run post-deploy validation: deployed addresses match the committed genesis, the anchor is seeded with the
-  genesis output root at `l2SequenceNumber = 0`, and the guardian and system-config addresses match the intent.
-- The prestate gate is conditional on a permissionless game type. A permissionless deployment MUST halt if the
-  prestate is unset, while a **permissioned-only** deployment can continue without one.
+`continue` deploys from the frozen `preparedDeployment` snapshot. It validates every pending chain before broadcasting
+any of them, so a configuration error stops the run before it can produce a partial deployment.
+
+**Before broadcasting any transaction:**
+
+- MUST verify the current intent still agrees with the frozen snapshot, and that the dependency set still matches.
+- MUST re-download both artifact bundles by locator and verify their content digests against the frozen values.
+- MUST fail when the deployer or OPCM differs from the one recorded by `prepare`.
+- MUST halt a permissionless deployment when the prestate is unset or holds the reserved fallback value. The prestate
+  gate is conditional on a permissionless game type: a **permissioned-only** deployment carries no selected prestate
+  and proceeds without one.
+- MUST halt a permissionless deployment when the starting anchor root is unset or still holds the `0xdead` placeholder.
+- MUST re-check the predicted addresses by simulating the deployment against a fresh fork of L1 (pre-broadcast
+  preflight) and abort on mismatch.
+- MUST verify the simulated broadcast is exactly one call, to the pinned OPCM, from the pinned deployer.
+
+**Broadcasting:**
+
+- MUST re-validate the pinned anchor block immediately before each send (see
+  [aOPD-002](#aopd-002-the-anchor-block-is-not-reorgd-during-the-deployment-window)).
+- MUST submit `OPCM.deploy()` with the `startingAnchorRoot` and `absolutePrestate` committed in state.
+- MUST verify the deployment receipt's block is canonical.
+
+**After broadcasting:**
+
+- MUST run post-deploy validation against live L1 state. This covers the deployed addresses and their code, the
+  starting anchor root and its `l2SequenceNumber`, the enabled game configurations and the prestate of both the
+  respected game and its guardian fallback, the `SystemConfig` / `OptimismPortal` / `AnchorStateRegistry` wiring, the
+  proxy implementations against the OPCM's own `implementations()`, the proxy admin owner, and the `SuperchainConfig`
+  attachment and guardian.
 
 Carrying the real anchor root and the prestate into `OPCM.deploy()` requires two changes on the op-deployer side:
 
-- The Go input struct for the OP Chain deployment gains a `StartingAnchorRoot` field and a prestate-hash field for the
-  permissionless game.
+- The Go input struct for the OP Chain deployment gains a `StartingAnchorRoot` field and a second prestate field for
+  the guardian fallback game.
 - op-deployer's chain orchestration code wires those fields through into the `FullConfig` eventually passed to OPCM.
 
 The matching Solidity changes, the `DeployOPChain` script and the relaxation that accepts a permissionless game type at
 initial deployment, are specified in [Contracts](./contracts.md#change-specification).
 
+### Relationship to `apply`
+
+`apply` remains the path for permissioned-only deployments and
+still broadcasts the `0xdead` placeholder anchor. It MUST reject a permissionless game type and direct the operator to
+the `prepare` flow.
+
+The two flows MUST NOT be mixed on one working directory. `prepare` MUST refuse a state produced by `apply`, and
+`apply` MUST refuse a prepared state.
+
+A permissioned-only chain may still go through `prepare` / `prestate` / `continue`. It carries no selected prestate
+and broadcasts the same `0xdead` placeholder anchor that `apply` would. The real anchor root is substituted only for
+permissionless deployments.
+
 ## Deployment guards
 
-- **Anchor `BLOCKHASH` check.** The deploy transaction reverts before `OPCM.deploy()` runs if the anchor block hash is
-  no longer retrievable, catching an L1 reorg past the anchor (see [FM1](#failure-modes)).
-- **Preflight + post-deploy validation.** Predicted addresses are re-validated before broadcast and the real addresses
-  verified after, guarding against prediction drift and compromised RPCs.
-- **Alternate RPC cross-check.** The dry-run that produces the predicted addresses MAY be re-run against a second,
-  independent L1 RPC. A mismatch between the two flags a compromised endpoint before any transaction is broadcast (see
-  [FM3](#failure-modes)).
+- **Pre-broadcast anchor revalidation.** The pinned anchor is re-fetched and re-checked to be canonical immediately
+  before each send, and the deployment receipt's block is checked afterwards (see [FM1](#failure-modes)).
+- **Preflight + post-deploy validation.** Predicted addresses are re-validated against a fresh fork before broadcast
+  and the real addresses verified against live L1 after, guarding against prediction drift and compromised RPCs.
+- **Frozen artifact digests.** `continue` re-verifies the artifact bundles against the digests `prepare` recorded, so
+  a swapped bundle fails before broadcast.
+- **On-chain config validation.** OPCM rejects a zero anchor root on any initial deployment, and rejects the `0xdead`
+  placeholder root or a zero prestate once a permissionless game is enabled (see
+  [OPCMv2 config validation](./contracts.md#opcmv2-config-validation)).
 
 ## Genesis block header fields
 
@@ -252,13 +329,26 @@ initial deployment, are specified in [Contracts](./contracts.md#change-specifica
 | `gasLimit` | chain config |
 | `number` | `0` (L2 genesis block number) |
 | `baseFee` | 1 gwei |
+| `withdrawalsRoot` | `L2ToL1MessagePasser` storage root, required to compute the output root |
 | other | standard genesis values per hardfork |
+
+Isthmus MUST be active at genesis. The [output root](./overview.md#output-root) reads its
+`messagePasserStorageRoot` from the header's withdrawals root, and a pre-Isthmus header has none. The pipeline fails
+rather than computing an output root from an incomplete header.
 
 ## depsets.json
 
 Generation is **unchanged from the current pipeline**: a single-chain dependency set for standalone chains, and a
-multi-chain depset for shared-dependency-set deployments. Deploying a chain directly into a shared super dispute game
-is **not** supported at this time.
+multi-chain depset for shared-dependency-set deployments.
+
+`prepare` records the dependency set in the state under `interopDepSet`.
+
+A super root deployment adds one constraint. The [super root](./overview.md#super-root) commits to a timestamp, so
+every member of the dependency set MUST share the same L2 genesis timestamp. `prepare` MUST fail when members
+disagree, which in practice means a per-chain `l1StartBlockHash` override that moves one chain's anchor.
+
+`prestate` and `continue` MUST both re-validate that the intent's chain set still matches the dependency set recorded
+by `prepare`.
 
 ## Failure modes
 
@@ -267,16 +357,20 @@ Summarized from `fma.md`. See the design doc for full mitigation and recovery de
 
 | ID | Failure | Risk | Key mitigation |
 | --- | --- | --- | --- |
-| FM1 | L1 anchor reorg after selection | Low likelihood / high impact | `BLOCKHASH` check reverts deploy, abort and restart |
-| FM2 | Predicted ≠ deployed L1 addresses | Low / high | Same `from` for dry-run and broadcast, plus preflight and post-deploy validation |
-| FM3 | Compromised L1 RPC | Low / high | Trusted or self-hosted RPC, cross-check against a second RPC, post-deploy validation |
+| FM1 | L1 anchor reorg after selection | Low likelihood / high impact | Pre-broadcast anchor revalidation aborts the send, abort and restart |
+| FM2 | Predicted ≠ deployed L1 addresses | Low / high | Same `from` and salt mixer for dry-run and broadcast, plus preflight and post-deploy validation |
+| FM3 | Compromised L1 RPC | Low / high | Trusted or self-hosted RPC, preflight re-simulation, post-deploy validation |
 | FM4 | Wrong prestate hash | Low / high | Source override from reproducible build, reproduce and verify before `continue` |
-| FM5 | Genesis timestamp overrun | Low / low | Set `X` conservatively, chain fills the gap with empty blocks |
-| FM6 | Stale prestate after re-running `prepare` | Low / high | `prepare` invalidates prestate, forcing rebuild |
-| FM7 | Wrong `startingAnchorRoot` | Low / high | Recompute output root from committed genesis before `continue`, post-deploy anchor check |
+| FM5 | Genesis timestamp overrun | Low / low | Set `X` conservatively, `prepare` refuses an elapsed window, chain fills the gap with empty blocks |
+| FM6 | Stale prestate after re-running `prepare` | Low / high | Every `prepare` run invalidates the prestate, forcing a rebuild |
+| FM7 | Wrong `startingAnchorRoot` | Low / high | Recompute the anchor from committed genesis before `continue`, post-deploy anchor check |
 
 ## Developer experience
 
-- Permissionless deployments require a prestate, built externally and committed via the `prestate` command's flag or an
-  intent override. This adds the prestate build time to the deployment.
+- Permissionless deployments require a prestate, built externally and committed through
+  `--dispute-absolute-prestate` or a `faultGameAbsolutePrestate` intent override. This adds the prestate build time to
+  the deployment.
 - Permissioned-only deployments skip the prestate requirement.
+- Re-running `prepare` discards the committed prestate even when the anchor is unchanged, so `prestate` has to be
+  re-run before `continue`.
+- `prepare` needs an already-deployed OPCM pinned in the intent. It does not bootstrap one.

--- a/specs/experimental/predictive-chain-deployments/op-deployer.md
+++ b/specs/experimental/predictive-chain-deployments/op-deployer.md
@@ -29,6 +29,10 @@
     - [Impact](#impact-3)
   - [iOPD-005: The reserved fallback prestate is never a selected prestate](#iopd-005-the-reserved-fallback-prestate-is-never-a-selected-prestate)
     - [Impact](#impact-4)
+  - [iOPD-006: The artifact bundles never change between `prepare` and `continue`](#iopd-006-the-artifact-bundles-never-change-between-prepare-and-continue)
+    - [Impact](#impact-5)
+  - [iOPD-007: The deployment broadcast is exactly one call to the pinned OPCM](#iopd-007-the-deployment-broadcast-is-exactly-one-call-to-the-pinned-opcm)
+    - [Impact](#impact-6)
 - [Pipeline](#pipeline)
   - [prepare](#prepare)
   - [prestate](#prestate)
@@ -213,6 +217,45 @@ The respected game would be seeded with a prestate that commits to no real fault
 from block 0. Fault proofs are broken exactly as in
 [iOPD-003](#iopd-003-absoluteprestate-matches-the-committed-chain-config).
 
+### iOPD-006: The artifact bundles never change between `prepare` and `continue`
+
+The L1 and L2 artifact bundles resolved at `continue` MUST have the content digests that `prepare` recorded for the
+locators it froze. A digest covers every file path and file content in a bundle, so re-resolving the same locator to
+different contents MUST abort the run before any transaction is prepared.
+
+[aOPD-003](#aopd-003-op-deployer-state-is-trusted) covers the state file only. The bundles the state references are a
+separate trust surface, and this invariant is what covers them. Resolving a locator carries no integrity
+check of its own, so this comparison is the only thing that ties a locator to the contents it
+returns.
+
+#### Impact
+
+**Severity: Critical**
+
+The failure is different for both L1 and L2 bundles. The L1 bundle backs the forked simulation that
+enforces [iOPD-001](#iopd-001-the-deployed-l1-system-matches-the-committed-artifacts), so a 
+substituted bundle makes the preflight compare predicted addresses against code the operator never
+predicted against, and the check passes while proving nothing. The L2 bundle is what the committed
+genesis and [starting anchor root](./overview.md#starting-anchor-root) were derived from, so a
+substituted bundle leaves a genesis that no reviewed artifact set explains. Either way the chain is
+deployed from two different versions of the artifacts, which is the condition
+[iOPD-001](#iopd-001-the-deployed-l1-system-matches-the-committed-artifacts) exists to rule out.
+
+### iOPD-007: The deployment broadcast is exactly one call to the pinned OPCM
+
+Simulating the deployment MUST produce exactly one broadcast: a call, to the OPCM pinned by `prepare`, sent from the
+deployer pinned by `prepare`. A simulation that produces no broadcast, more than one, or one that differs in type,
+target, or sender MUST abort before anything is sent.
+
+#### Impact
+
+**Severity: Critical**
+
+Any broadcast beyond the single pinned call is a transaction the operator never reviewed, signed by the deployer key. A
+modified or compromised deploy script could deploy a contract of its own, call an address other than the pinned OPCM,
+or repeat `OPCM.deploy()`, and the deployed system would no longer be the one the frozen snapshot describes. Because
+the check runs against the simulation rather than the receipt, it aborts before the key signs anything.
+
 ## Pipeline
 
 The three commands run in order around the prestate boundary. Each command's output MUST be set before the next
@@ -274,7 +317,9 @@ any of them, so a configuration error stops the run before it can produce a part
 **Before broadcasting any transaction:**
 
 - MUST verify the current intent still agrees with the frozen snapshot, and that the dependency set still matches.
-- MUST re-download both artifact bundles by locator and verify their content digests against the frozen values.
+- MUST re-resolve both artifact locators recorded by `prepare` and verify the resolved bundles' content digests
+  against the frozen values (see
+  [iOPD-006](#iopd-006-the-artifact-bundles-never-change-between-prepare-and-continue)).
 - MUST fail when the deployer or OPCM differs from the one recorded by `prepare`.
 - MUST halt a permissionless deployment when the prestate is unset or holds the reserved fallback value (see
   [iOPD-005](#iopd-005-the-reserved-fallback-prestate-is-never-a-selected-prestate)). The prestate gate is conditional
@@ -283,7 +328,8 @@ any of them, so a configuration error stops the run before it can produce a part
 - MUST halt a permissionless deployment when the starting anchor root is unset or still holds the `0xdead` placeholder.
 - MUST re-check the predicted addresses by simulating the deployment against a fresh fork of L1 (pre-broadcast
   preflight) and abort on mismatch.
-- MUST verify the simulated broadcast is exactly one call, to the pinned OPCM, from the pinned deployer.
+- MUST verify the simulated broadcast is exactly one call, to the pinned OPCM, from the pinned deployer (see
+  [iOPD-007](#iopd-007-the-deployment-broadcast-is-exactly-one-call-to-the-pinned-opcm)).
 - SHOULD warn, without halting, when the committed genesis time has already elapsed against the L1 head. `prepare` is
   the only hard gate on the [deployment window](#deployment-window), and it compares against the safe head.
 

--- a/specs/experimental/predictive-chain-deployments/op-deployer.md
+++ b/specs/experimental/predictive-chain-deployments/op-deployer.md
@@ -233,7 +233,7 @@ returns.
 **Severity: Critical**
 
 The failure is different for both L1 and L2 bundles. The L1 bundle backs the forked simulation that
-enforces [iOPD-001](#iopd-001-the-deployed-l1-system-matches-the-committed-artifacts), so a 
+enforces [iOPD-001](#iopd-001-the-deployed-l1-system-matches-the-committed-artifacts), so a
 substituted bundle makes the preflight compare predicted addresses against code the operator never
 predicted against, and the check passes while proving nothing. The L2 bundle is what the committed
 genesis and [starting anchor root](./overview.md#starting-anchor-root) were derived from, so a
@@ -330,8 +330,9 @@ any of them, so a configuration error stops the run before it can produce a part
   preflight) and abort on mismatch.
 - MUST verify the simulated broadcast is exactly one call, to the pinned OPCM, from the pinned deployer (see
   [iOPD-007](#iopd-007-the-deployment-broadcast-is-exactly-one-call-to-the-pinned-opcm)).
-- SHOULD warn, without halting, when the committed genesis time has already elapsed against the L1 head. `prepare` is
-  the only hard gate on the [deployment window](#deployment-window), and it compares against the safe head.
+- SHOULD warn, without halting, when the committed genesis time has already elapsed against the L1 head. `prepare`
+  refuses an elapsed [deployment window](#deployment-window), measured against the safe head. Elapsing it later costs
+  empty blocks, not correctness (see [FM5](#failure-modes)).
 
 **Broadcasting:**
 

--- a/specs/experimental/predictive-chain-deployments/op-deployer.md
+++ b/specs/experimental/predictive-chain-deployments/op-deployer.md
@@ -298,11 +298,9 @@ The prestate is built **externally** by the monorepo's `reproducible-prestate-ko
 `rollup.json`, and `depsets.json` rendered from the prepared state. The `prestate` command does not compile or hash
 anything itself. It only commits the built hash into op-deployer state, which `continue` reads.
 
-- MUST write the prestate hash to op-deployer state from any of three sources:
-  - the `--dispute-absolute-prestate` **command flag**, or the matching environment variable,
-  - a **global intent override**, `globalDeployOverrides.faultGameAbsolutePrestate`, or
-  - a **per-chain intent override**, the chain's `deployOverrides.faultGameAbsolutePrestate`.
-- MUST fail when two or more sources are set and disagree.
+- MUST write the prestate hash to op-deployer state from one of three sources: a **command-line override**, in flag or
+  environment-variable form, a **global intent override**, or a **per-chain intent override**.
+- MUST resolve those sources to an unambiguous value, so two or more sources that disagree fail.
 - MUST fail if no source is provided for a chain whose game type requires a prestate.
 - MUST reject the reserved [fallback prestate](./overview.md#fallback-prestate) value as a selected prestate (see
   [iOPD-005](#iopd-005-the-reserved-fallback-prestate-is-never-a-selected-prestate)).

--- a/specs/experimental/predictive-chain-deployments/overview.md
+++ b/specs/experimental/predictive-chain-deployments/overview.md
@@ -101,11 +101,14 @@ Every chain keeps its own registry in all three cases. In a super root deploymen
 
 ### Selected Prestate
 
-The absolute prestate of the game type a chain deploys with. It is the Cannon hash of the initial MIPS machine state,
-produced by compiling the Kona fault-proof program with the embedded chain config. The hash is deterministic for a
-given chain config.
+The absolute prestate of the game type a chain deploys as its respected game.
 
-A permissioned-only deployment carries no selected prestate.
+For a permissionless deployment the pipeline commits it: the Cannon hash of the initial MIPS machine state, produced
+by compiling the Kona fault-proof program with the embedded chain config. The hash is deterministic for a given chain
+config.
+
+A permissioned-only deployment keeps the prestate the chain configuration already supplies. That value is required to
+be non-zero in every case, including the super root permissioned game, which never reads it.
 
 ### Fallback Prestate
 

--- a/specs/experimental/predictive-chain-deployments/overview.md
+++ b/specs/experimental/predictive-chain-deployments/overview.md
@@ -10,7 +10,10 @@
 - [Non-goals](#non-goals)
 - [Definitions](#definitions)
   - [Output Root](#output-root)
-  - [Prestate / Prestate Hash](#prestate--prestate-hash)
+  - [Super Root](#super-root)
+  - [Starting Anchor Root](#starting-anchor-root)
+  - [Selected Prestate](#selected-prestate)
+  - [Fallback Prestate](#fallback-prestate)
   - [Genesis Block](#genesis-block)
   - [L2 Allocs](#l2-allocs)
   - [Anchor Block](#anchor-block)
@@ -31,11 +34,11 @@ PCD removes the window by computing **every chain artifact off-chain before any 
 PCD has two parts, each specified on its own page:
 
 - [Contracts](./contracts.md): a Forge script that dry-runs `OPCM.deploy()` to **predict the L1 contract addresses**,
-  plus updates to `DeployOPChain.s.sol` and a minimal change to `OPContractsManagerV2` so a permissionless game type
-  can be enabled at initial deployment.
+  plus updates to `DeployOPChain.s.sol` and to `OPContractsManagerV2` so a permissionless game type can be enabled at
+  initial deployment.
 - [op-deployer Orchestration](./op-deployer.md): the pipeline that consumes the predicted addresses. Three new commands
-  (`prepare`, `prestate`, `continue`) build the L2 genesis and output root, commit the prestate, and submit the
-  deployment.
+  (`prepare`, `prestate`, `continue`) build the L2 genesis and the starting anchor root, commit the prestate, and
+  submit the deployment.
 
 ## Problem Statement
 
@@ -47,32 +50,70 @@ Deploying a new chain today has a cyclic dependency:
 
 The current workaround deploys with a placeholder `startingAnchorRoot` and defers permissionless proofs until a real
 dispute resolves the anchor (~7 days). PCD breaks the cycle by predicting the L1 addresses without writing any state.
-The prestate and the output root are then computed before the real deployment transaction is broadcast.
+The prestate and the starting anchor root are then computed before the real deployment transaction is broadcast.
 
 ## Goals
 
 - Permissionless dispute games valid from L2 block 0 on mainnets, testnets, and devnets.
-- Minimal on-chain change, limited to relaxing OPCM's initial-deployment game-type validation. Existing permissioned
-  deployments remain valid (see [iPCD-002](./contracts.md#ipcd-002-permissioned-deployments-remain-valid)).
-- Deterministic, reproducible artifacts (predicted addresses, genesis, output root, prestate) given the same inputs.
+- Support both game families: per-chain output root games (`CANNON_KONA`) and super root games (`SUPER_CANNON_KONA`).
+- Contain the on-chain change to OPCM's initial-deployment config validation. Permissioned deployments against an OPCM
+  in the same mode remain valid (see [iPCD-002](./contracts.md#ipcd-002-permissioned-deployments-remain-valid)).
+- Deterministic, reproducible artifacts (predicted addresses, genesis, anchor root, prestate) given the same inputs.
 
 ## Non-goals
 
-- Deploying a chain directly into a shared (multi-chain) super dispute game is out of scope for this milestone. A
-  chain can still join a multi-chain dependency set while keeping its own per-chain dispute game.
+- Permissionless deployment through `apply`. That command stays permissioned-only and keeps its placeholder anchor.
+  Permissionless chains go through `prepare` / `prestate` / `continue`.
+- Sharing one dispute game or one `AnchorStateRegistry` across chains. Every chain keeps its own registry and its own
+  `DisputeGameFactory`, including in a super root deployment where all chains share a single anchor **value**.
+- Enabling `ZK_DISPUTE_GAME` game type at initial deployment.
 
 ## Definitions
 
 ### Output Root
 
-A 32-byte commitment to L2 state:
-`keccak256(version || stateRoot || messagePasserStorageRoot || blockHash)`, where `version` is 32 zero bytes. The
-genesis output root is seeded into the `AnchorStateRegistry` at `l2SequenceNumber = 0`.
+A 32-byte commitment to a single chain's L2 state:
+`keccak256(version || stateRoot || messagePasserStorageRoot || blockHash)`, where `version` is 32 zero bytes.
 
-### Prestate / Prestate Hash
+The `messagePasserStorageRoot` is read from the genesis block header's withdrawals root, so computing a genesis output
+root requires Isthmus to be active at genesis. A chain whose genesis predates Isthmus fails the pipeline.
 
-The Cannon hash of the initial MIPS machine state, produced by compiling the Kona fault-proof program with the
-embedded chain config. The hash is deterministic for a given chain config.
+### Super Root
+
+A commitment to the L2 state of **every chain in a dependency set at one timestamp**, built from each member's
+[output root](#output-root). Super root games (`SUPER_CANNON_KONA`, `SUPER_PERMISSIONED`) dispute super roots rather
+than per-chain output roots.
+
+A super root commits to a timestamp, so every chain in the dependency set must share the same L2 genesis timestamp.
+
+### Starting Anchor Root
+
+The `Proposal` seeded into a chain's `AnchorStateRegistry` at deployment, a root paired with an `l2SequenceNumber`.
+What fills it depends on the game family:
+
+| Game family | Root | `l2SequenceNumber` |
+| --- | --- | --- |
+| Output root (`CANNON_KONA`) | the chain's own genesis [output root](#output-root) | `0`, the L2 genesis block number |
+| Super root (`SUPER_CANNON_KONA`) | one [super root](#super-root) shared by the dependency set | the super root's timestamp |
+| Permissioned only | a placeholder | `0` |
+
+Every chain keeps its own registry in all three cases. In a super root deployment the registries hold the same value.
+
+### Selected Prestate
+
+The absolute prestate of the game type a chain deploys with. It is the Cannon hash of the initial MIPS machine state,
+produced by compiling the Kona fault-proof program with the embedded chain config. The hash is deterministic for a
+given chain config.
+
+A permissioned-only deployment carries no selected prestate.
+
+### Fallback Prestate
+
+A `CANNON_KONA` deployment also enables `PERMISSIONED_CANNON` as a guardian fallback, and that game needs its own
+prestate. op-deployer fills it with a reserved placeholder rather than a real prestate, because the fallback is not
+meant to be played at deployment. The value is reserved and a [selected prestate](#selected-prestate) may not use it.
+
+**Super root deployments have no fallback prestate.**
 
 ### Genesis Block
 
@@ -92,10 +133,10 @@ The L1 block selected at the `safe` tag or deeper whose hash is baked into `roll
 
 The `saltMixer` string in [`FullConfig`](./contracts.md#fullconfig) that, together with `msg.sender`, derives the
 CREATE2 salt for OPCM proxy deployments. The predicted addresses match the deployed addresses only when **the same
-sender and config are used**.
+sender and salt mixer are used**.
 
 ## References
 
-- [Design doc (`pcd-design.md`)](https://github.com/ethereum-optimism/design-docs/pull/385)
-- [Failure modes analysis (`fma.md`)](https://github.com/ethereum-optimism/design-docs/pull/385)
+- [Design doc (`pcd-design.md`)](https://github.com/ethereum-optimism/design-docs/blob/main/ecosystem/op-deployer/predictive-chain-deployments/pcd-design.md)
+- [Failure modes analysis (`fma.md`)](https://github.com/ethereum-optimism/design-docs/blob/main/ecosystem/op-deployer/predictive-chain-deployments/fma.md)
 - [OP Contracts Manager](../op-contracts-manager.md)


### PR DESCRIPTION
## Context
The PCD spec pages landed before super root support and the `prepare` / `prestate` /
`continue` hardening merged. This updates all three against the code that shipped. Spec-only.

- Both game families are deployable at genesis. New definitions for Super Root, Starting Anchor
  Root, Selected Prestate and Fallback Prestate replace `Prestate / Prestate Hash`, and
  `iOPD-002` pins the root and its `l2SequenceNumber` per family.
- OPCM's game-type check is scoped to the `SUPER_ROOT_GAMES_MIGRATION` mode, plus the three
  value checks PCD added: non-zero anchor root, no `0xdead` placeholder, non-zero prestate.
- `DeployOPChainInput` gains `startingAnchorRoot` and `cannonAbsolutePrestate`. A permissionless
  deploy enables the respected game and its guardian fallback.
- Command behavior now matches the pipeline: anchor pinning, prestate invalidation on every
  `prepare`, and `continue`'s digest, fork-simulation, anchor and post-deploy checks.
- The `BLOCKHASH` and second-RPC guards never shipped and are replaced by what the code does.

Claims verified against `615b1c75dd` and `9714d4dd2c` on `develop` and op-deployer's three
commands.