### PR TITLE
interop: Align expiry-boundary restatements with the normative invariant

### DIFF
--- a/specs/interop/derivation.md
+++ b/specs/interop/derivation.md
@@ -34,7 +34,7 @@ executing messages.
 - The timestamp `t` of the identifier MUST be:
   - `t <= execution_timestamp`, where `execution_timestamp` is the timestamp of the block
     that includes the executing message.
-  - `t > execution_timestamp - expiry_window`, where `expiry_window` is the expiry window in seconds.
+  - `t >= execution_timestamp - expiry_window`, where `expiry_window` is the expiry window in seconds.
 
 L2 blocks that produce invalid executing messages MUST not be allowed to be considered safe.
 They MAY optimistically exist as unsafe blocks for some period of time. An L2 block that is invalidated

--- a/specs/interop/messaging.md
+++ b/specs/interop/messaging.md
@@ -125,7 +125,8 @@ do not count as executing messages.
   be less than or equal to the timestamp of the executing message as well as greater than the Lagoon activation timestamp.
 - [ChainID Invariant](#chainid-invariant): The chain id of the initiating message MUST be in the dependency set
 - [Message Expiry Invariant](#message-expiry-invariant): The timestamp at the time of inclusion of the executing
-  message MUST be lower than the initiating message timestamp (as defined in the [`Identifier`]) + `EXPIRY_TIME`.
+  message MUST be lower than or equal to the initiating message timestamp
+  (as defined in the [`Identifier`]) + `EXPIRY_TIME`.
 
 ### Timestamp Invariant
 


### PR DESCRIPTION
The message-expiry boundary is stated three times in the interop specs. The two summary restatements are one second stricter than the normative Message Expiry Invariant, which invalidates only `id.timestamp + EXPIRY_TIME < executing_block.timestamp` — so a message executed exactly at the boundary is valid.

This aligns both summaries with the normative text:

- `messaging.md` invariants list: "lower than" becomes "lower than or equal to".
- `derivation.md` invariants list: `t > execution_timestamp - expiry_window` becomes `>=`.

Both consensus implementations (op-supernode and kona) already accept the boundary case, so no implementation change is needed.

Fixes ethereum-optimism/specs#931