### PR TITLE
protocol: specify sequencer-defined fees at Lagoon

### DIFF
--- a/specs/SUMMARY.md
+++ b/specs/SUMMARY.md
@@ -85,6 +85,7 @@
       - [Network upgrade transactions](./protocol/karst/derivation.md)
     - [Lagoon](./protocol/lagoon/overview.md)
       - [Post-Execution Transactions](./protocol/lagoon/post-exec.md)
+      - [Sequencer-Defined Fees](./protocol/sdf.md)
       - [Sequencer-Defined Metering](./protocol/lagoon/sdm.md)
       - [Interoperability](./interop/overview.md)
         - [Dependency Set](./interop/dependency-set.md)

--- a/specs/interop/derivation.md
+++ b/specs/interop/derivation.md
@@ -38,8 +38,10 @@ executing messages.
 
 L2 blocks that produce invalid executing messages MUST not be allowed to be considered safe.
 They MAY optimistically exist as unsafe blocks for some period of time. An L2 block that is invalidated
-because it includes invalid executing messages MUST be replaced by a deposits only block at the same
-block height. This guarantees progression of the chain, ensuring that an infinite loop of processing
+because it includes invalid executing messages MUST be replaced by a deposits-only block at the same
+block height. At and after Lagoon, the execution engine appends the mandatory trailing post-exec commitment after
+those deposits as specified by [Sequencer-Defined Fees](../protocol/sdf.md#deterministic-payload-building). This
+guarantees progression of the chain, ensuring that an infinite loop of processing
 the same block in the proof system is not possible.
 
 ## Activation Block
@@ -48,15 +50,17 @@ The activation block is the first block that has a timestamp higher or equal to 
 Lagoon activation timestamp.
 The activation block timestamp may not exactly match the Lagoon activation timestamp.
 
-The genesis block is not technically considered an activation-block, as forks are already active.
-However, the genesis block does not contain transactions, and thus also meets the activation criteria.
+The genesis block is not technically considered an activation block, as forks are already active.
+The genesis block does not contain transactions and is exempt from Lagoon's post-exec commitment requirement.
 
 The activation block has several special properties and constraints:
 
-- It MUST NOT include any non-deposit-type transactions.
-  Sequencers, when building the fork activation block, MUST set `noTxPool` to `true`
-  in the execution payload attributes for this block, instructing the builder to exclude user transactions.
-- Messages MUST NOT be executed in this block. This is implemented by only processing deposit-type transactions.
+- It MUST NOT include any user transactions. Its deposit transactions MUST be followed by the mandatory trailing
+  post-exec commitment. Sequencers, when building the fork activation block, MUST set `noTxPool` to `true` in the
+  execution payload attributes for this block, instructing the builder to exclude user transactions and apply the
+  deterministic SDF fallback.
+- Messages MUST NOT be executed in this block. This is implemented by processing only deposit transactions before
+  the non-executing post-exec commitment.
 - Any contract log events MUST NOT count as valid initiating messages.
   Verifiers may use the activation block as an anchor point, without indexing the block-contents.
 - The derivation pipeline MUST enforce that the sequencer has not included any user transactions in
@@ -71,8 +75,9 @@ The activation block has several special properties and constraints:
 When the [cross chain dependency resolution](./messaging.md#resolving-cross-chain-safety) determines
 that a block contains an [invalid message](./messaging.md#invalid-messages), the block is replaced
 using [Holocene Replacement](../protocol/holocene/derivation.md#engine-queue).
-The replacement block has the same attributes, except the transaction list is trimmed
-to include only deposit transactions.
+The replacement block has the same attributes, except the supplied transaction list is trimmed to include only
+deposit transactions. At and after Lagoon, deterministic payload building appends the mandatory trailing post-exec
+commitment after the trimmed list.
 
 ## Network Upgrade Transactions
 

--- a/specs/protocol/delta/span-batches.md
+++ b/specs/protocol/delta/span-batches.md
@@ -127,6 +127,10 @@ tx_sigs ++ tx_tos ++ tx_datas ++ tx_nonces ++ tx_gases ++ protected_bits`
     - `legacy`: `rlp_encode(value, gasPrice, data)`
     - `1`: ([EIP-2930]): `0x01 ++ rlp_encode(value, gasPrice, data, accessList)`
     - `2`: ([EIP-1559]): `0x02 ++ rlp_encode(value, max_priority_fee_per_gas, max_fee_per_gas, data, access_list)`
+    - `0x7D`: ([Lagoon post-exec](../lagoon/post-exec.md)), only at and after Lagoon:
+      `0x7D ++ rlp_encoded_payload`. Its `r` and `s` values, y-parity bit, `tx_nonces` value,
+      and `tx_gases` value are zero. Its `contract_creation_bits` value is one, so it has no
+      `tx_tos` entry. It has no `protected_bits` entry because it is not a legacy transaction.
   - `tx_nonces`: concatenated list of `uvarint` of `nonce` field.
   - `tx_gases`: concatenated list of `uvarint` of gas limits.
     - `legacy`: `gasLimit`
@@ -360,9 +364,10 @@ Span-batch rules, in validation order:
     that is invalid or derived by other means exclusively:
     - any transaction that is empty (zero length `tx_data`)
     - any [deposited transactions][g-deposit-tx-type] (identified by the transaction type prefix byte in `tx_data`)
-    - any transaction of a future type > 2 (note that
-      [Isthmus adds support](../isthmus/derivation.md#activation)
-      for `SetCode` transactions of type 4)
+    - any typed transaction other than:
+      - types 1 and 2;
+      - type 4 at and after [Isthmus activation](../isthmus/derivation.md#activation); or
+      - type `0x7D` at and after [Lagoon activation](../lagoon/overview.md#activation).
 - Overlapped blocks checks:
   - Note: If the span batch overlaps the current L2 safe chain, we must validate all overlapped blocks.
   - Variables:

--- a/specs/protocol/exec-engine.md
+++ b/specs/protocol/exec-engine.md
@@ -51,6 +51,8 @@ The formula for EIP-1559 is otherwise not modified.
 Starting with Holocene, the EIP-1559 parameters become [dynamically configurable](holocene/exec-engine.md#dynamic-eip-1559-parameters).
 
 Starting with Jovian, a [configurable minimum base fee](jovian/exec-engine.md#minimum-base-fee) is introduced.
+Starting with Lagoon, [Sequencer-Defined Fees](sdf.md) replaces parent-derived EIP-1559 base-fee selection while
+retaining the legacy parameters as compatibility metadata and optional producer-policy inputs.
 
 ## Extra Data
 
@@ -114,7 +116,8 @@ The block fee-recipient (a.k.a. coinbase address) is set to the Sequencer Fee Va
 ### Base fees (Base Fee Vault)
 
 Base fees largely follow the [eip-1559] specification, with the exception that base fees are not burned,
-but add up to the Base Fee Vault ETH account balance.
+but add up to the Base Fee Vault ETH account balance. Starting with Lagoon, the block base fee is selected and
+validated according to [Sequencer-Defined Fees](sdf.md); fee charging and vault accounting are otherwise unchanged.
 
 ### L1-Cost fees (L1 Fee Vault)
 

--- a/specs/protocol/exec-engine.md
+++ b/specs/protocol/exec-engine.md
@@ -258,7 +258,10 @@ The `noTxPool` is optional as well, and extends the `transactions` meaning:
 
 - If `false`, the execution engine is free to pack additional transactions from external sources like the tx pool
   into the payload, after any of the `transactions`. This is the default behavior a L1 node implements.
-- If `true`, the execution engine must not change anything about the given list of `transactions`.
+- If `true`, the execution engine must not change anything about the given list of `transactions`,
+  except that deterministic Lagoon execution synthesizes the canonical trailing post-exec
+  commitment when the list does not already contain one, as specified by
+  [Sequencer-Defined Fees](sdf.md#deterministic-payload-building).
 
 If the `transactions` field is present, the engine must execute the transactions in order and return `STATUS_INVALID`
 if there is an error processing the transactions. It must return `STATUS_VALID` if all of the transactions could

--- a/specs/protocol/jovian/exec-engine.md
+++ b/specs/protocol/jovian/exec-engine.md
@@ -44,8 +44,8 @@ Constraints:
 - `version` MUST be `1` (incremented from Holocene's `0`).
 - There MUST NOT be any data beyond these 17 bytes.
 
-The `minBaseFee` field is an absolute minimum expressed in wei. During base fee computation, if the
-computed `baseFee` is less than `minBaseFee`, it MUST be clamped to `minBaseFee`.
+The `minBaseFee` field is an absolute minimum expressed in wei. Before Lagoon, if the computed `baseFee` is less
+than `minBaseFee`, it MUST be clamped to `minBaseFee`.
 
 ```javascript
 if (baseFee < minBaseFee) {
@@ -82,10 +82,13 @@ The `minBaseFee` MUST be `null` prior to the Jovian fork, and MUST be non-`null`
 
 As with [Holocene's dynamic EIP-1559 parameters](../holocene/exec-engine.md#rationale), placing the
 minimum base fee in the block header allows us to avoid reaching into the state during block sealing.
-This retains the purity of the function that computes the next block's base fee from its parent block
-header, while still allowing them to be dynamically configured. Dynamic configuration is handled
-similarly to `gasLimit`, with the derivation pipeline providing the appropriate `SystemConfig`
-contract values to the block builder via `PayloadAttributesV3` parameters.
+Before Lagoon, this retains the purity of the function that computes the next block's base fee from its parent block
+header, while still allowing the parameters to be dynamically configured. Dynamic configuration is handled
+similarly to `gasLimit`, with the derivation pipeline providing the appropriate `SystemConfig` contract values to
+the block builder via `PayloadAttributesV3` parameters.
+
+At and after Lagoon, `minBaseFee` remains encoded and transported for compatibility but is not a consensus bound on
+the block base fee. A producer policy MAY use it as an input. See [Sequencer-Defined Fees](../sdf.md).
 
 ## DA Footprint Block Limit
 
@@ -125,9 +128,13 @@ During block building and header validation, it must be guaranteed and checked, 
 `daFootprint` stays below the `gasLimit`, just like the `gasUsed` property.
 Note that this implies that blocks may have no more than `gasLimit/daFootprintGasScalar` total estimated DA usage bytes.
 
-Furthermore, from Jovian, the base fee update calculation now uses `gasMetered := max(gasUsed, blobGasUsed)`
-in place of the `gasUsed` value used before.
-As a result, blocks with high DA usage may cause the base fee to increase in subsequent blocks.
+From Jovian until Lagoon, the base fee update calculation uses `gasMetered := max(gasUsed, blobGasUsed)` in place
+of the `gasUsed` value used before. As a result, blocks with high DA usage may cause the base fee to increase in
+subsequent blocks.
+
+At and after Lagoon, the sequencer selects the block base fee as specified by
+[Sequencer-Defined Fees](../sdf.md). The Jovian calculation MAY remain an input to the producer policy but is no
+longer a consensus rule.
 
 ### Scalar loading
 

--- a/specs/protocol/lagoon/overview.md
+++ b/specs/protocol/lagoon/overview.md
@@ -18,8 +18,8 @@ This document is not finalized and should be considered experimental.
 - [Sequencer-Defined Fees](../sdf.md)
 - [Sequencer-Defined Metering](./sdm.md)
 
-Lagoon activates the version-1 post-exec schema. Every Lagoon block contains exactly one post-exec transaction as
-its final transaction, including blocks with an empty SDM refund list. The payload commits the block's
+Lagoon activates the version-1 post-exec schema. Every non-genesis Lagoon block contains exactly one post-exec
+transaction as its final transaction, including blocks with an empty SDM refund list. The payload commits the block's
 `baseFeePerGas` selected under SDF and carries any SDM refunds. Before Lagoon, post-exec transactions are invalid
 and the parent-derived EIP-1559 base-fee rules remain active.
 

--- a/specs/protocol/lagoon/overview.md
+++ b/specs/protocol/lagoon/overview.md
@@ -15,11 +15,30 @@ This document is not finalized and should be considered experimental.
 ## Execution Layer
 
 - [Post-Execution Transactions](./post-exec.md)
+- [Sequencer-Defined Fees](../sdf.md)
 - [Sequencer-Defined Metering](./sdm.md)
+
+Lagoon activates the version-1 post-exec schema. Every Lagoon block contains exactly one post-exec transaction as
+its final transaction, including blocks with an empty SDM refund list. The payload commits the block's
+`baseFeePerGas` selected under SDF and carries any SDM refunds. Before Lagoon, post-exec transactions are invalid
+and the parent-derived EIP-1559 base-fee rules remain active.
+
+Lagoon uses a single per-chain activation timestamp for SDF and SDM. Neither feature has a separate activation flag
+or activation time.
+
 - Interop:
   - [Transaction Pool](../../interop/tx-pool.md)
 
 ## Consensus Layer
+
+Lagoon does not change singular batches, span batches, or Engine API payload-attribute schemas. The batcher includes
+the trailing post-exec transaction in batch data, and derivation transports its EIP-2718 encoding through the
+existing transaction list.
+
+Validators recover the selected base fee and optional SDM refunds from the post-exec payload. They do not execute a
+producer fee policy. Deterministic payload building follows the fallback specified in
+[Sequencer-Defined Fees](../sdf.md#deterministic-payload-building) when derived Lagoon attributes do not contain a
+post-exec transaction.
 
 - Interop:
   - [Dependency Set](../../interop/dependency-set.md)

--- a/specs/protocol/lagoon/post-exec.md
+++ b/specs/protocol/lagoon/post-exec.md
@@ -43,9 +43,9 @@ The post-exec transaction type is introduced by the [Lagoon network upgrade](./o
 first payload schema. Before the Lagoon activation timestamp a block MUST NOT contain a `0x7D` transaction.
 
 The post-exec transaction is a generic envelope: it carries a versioned [post-exec payload][g-post-exec-payload]
-whose interpretation is defined by separate policy specifications. Today only one schema is defined,
-[Sequencer-Defined Metering][g-sdm] (`version = 1`), specified in [sdm.md](./sdm.md). Future policies extend
-this document by defining additional [schema versions][g-post-exec-schema-version].
+whose interpretation is defined by separate policy specifications. Today only one schema is defined. Version 1
+commits [Sequencer-Defined Fees](../sdf.md) and carries optional [Sequencer-Defined Metering][g-sdm] refunds.
+Future policies extend this document by defining additional [schema versions][g-post-exec-schema-version].
 
 This document specifies the envelope: the transaction type, the encoding, and the structural invariants that hold
 regardless of the active schema. It does **not** specify what the payload fields mean — that is the responsibility
@@ -169,11 +169,11 @@ The normative rule that `blockNumber` equals the containing block's number is st
 
 ### Defined Schema Versions
 
-| `version` | Schema                                 |
-| --------- | -------------------------------------- |
-| `1`       | [Sequencer-Defined Metering](./sdm.md) |
+| `version` | Schema                                                                                   |
+| --------- | ---------------------------------------------------------------------------------------- |
+| `1`       | [Sequencer-Defined Fees](../sdf.md) and [Sequencer-Defined Metering](./sdm.md) |
 
-No other schema versions are currently defined. SDM (`version = 1`) is introduced by the
+No other schema versions are currently defined. Version 1 is introduced by the
 [Lagoon network upgrade](./overview.md); see [Overview](#overview).
 
 ## Block-Level Structural Rules
@@ -188,6 +188,8 @@ the block.
 4. **Recognized schema.** The payload's `version` MUST be a [defined schema version](#defined-schema-versions).
 5. **Schema must be active.** When no schema version is active for the block's timestamp, the block MUST NOT
    contain a `0x7D` transaction.
+6. **Lagoon commitment.** At and after the Lagoon activation timestamp, a block MUST contain exactly one `0x7D`
+   transaction with the version-1 payload defined by [Sequencer-Defined Fees](../sdf.md#commitment-format).
 
 Schema-specific validity rules (e.g. constraints on the trailing fields) are layered on top of these envelope rules
 and are specified by each schema's document. Both layers MUST hold for the block to be valid.

--- a/specs/protocol/lagoon/post-exec.md
+++ b/specs/protocol/lagoon/post-exec.md
@@ -188,8 +188,9 @@ the block.
 4. **Recognized schema.** The payload's `version` MUST be a [defined schema version](#defined-schema-versions).
 5. **Schema must be active.** When no schema version is active for the block's timestamp, the block MUST NOT
    contain a `0x7D` transaction.
-6. **Lagoon commitment.** At and after the Lagoon activation timestamp, a block MUST contain exactly one `0x7D`
-   transaction with the version-1 payload defined by [Sequencer-Defined Fees](../sdf.md#commitment-format).
+6. **Lagoon commitment.** At and after the Lagoon activation timestamp, every non-genesis block MUST contain
+   exactly one `0x7D` transaction with the version-1 payload defined by
+   [Sequencer-Defined Fees](../sdf.md#version-1-commitment).
 
 Schema-specific validity rules (e.g. constraints on the trailing fields) are layered on top of these envelope rules
 and are specified by each schema's document. Both layers MUST hold for the block to be valid.

--- a/specs/protocol/lagoon/sdm.md
+++ b/specs/protocol/lagoon/sdm.md
@@ -48,8 +48,8 @@ SDM activates with the [Lagoon network upgrade](./overview.md), together with
 [Sequencer-Defined Fees](../sdf.md). It uses Lagoon's per-chain timestamp activation and has no separate feature
 flag or activation time.
 
-Before Lagoon, a block MUST NOT contain a post-exec transaction. At and after Lagoon, every block MUST contain the
-version-1 post-exec commitment required by SDF, even when the sequencer assigns no gas refunds.
+Before Lagoon, a block MUST NOT contain a post-exec transaction. At and after Lagoon, every non-genesis block MUST
+contain the version-1 post-exec commitment required by SDF, even when the sequencer assigns no gas refunds.
 
 ## Payload Schema (Version 1)
 
@@ -174,8 +174,8 @@ honest execution.
 Under SDM:
 
 - The sequencer executes the block, chooses the non-zero `gasRefundEntries`, and appends the post-exec commitment
-  required for every Lagoon block. If local refund production is disabled or no refunds are selected, it commits an
-  empty list.
+  required for every non-genesis Lagoon block. If local refund production is disabled or no refunds are selected,
+  it commits an empty list.
 - A verifier enforces the post-exec envelope rules, SDF fee equality, and the SDM
   [validity rules](#validity-rules), then applies the refunds from the payload when computing canonical gas,
   settlement, receipts, and block gas usage.
@@ -203,8 +203,8 @@ specified SDM: no post-exec transactions appear, no canonical-gas adjustment is 
 
 From the Lagoon activation timestamp, two changes become observable:
 
-- A `0x7D` transaction appears at the end of every block, exposed through the same transaction-list interfaces used
-  today.
+- A `0x7D` transaction appears at the end of every non-genesis block, exposed through the same transaction-list
+  interfaces used today.
 - The receipts of standard Ethereum transactions in such blocks gain the `opGasRefund` field; clients that ignore unknown
   fields are unaffected.
 

--- a/specs/protocol/lagoon/sdm.md
+++ b/specs/protocol/lagoon/sdm.md
@@ -44,27 +44,27 @@ document specifies the version-1 payload and how clients apply the included refu
 
 ## Activation
 
-SDM activates with the [Lagoon network upgrade](./overview.md) and is gated by the Lagoon activation timestamp.
-When SDM is active for a block, the block MAY contain a post-exec transaction; when SDM is inactive, the block MUST
-NOT contain a post-exec transaction (see
-[post-exec.md § Block-Level Structural Rules](./post-exec.md#block-level-structural-rules)).
+SDM activates with the [Lagoon network upgrade](./overview.md), together with
+[Sequencer-Defined Fees](../sdf.md). It uses Lagoon's per-chain timestamp activation and has no separate feature
+flag or activation time.
 
-Before the Lagoon activation timestamp, every block MUST be produced and validated with SDM inactive, identically
-to a chain that has never specified SDM.
+Before Lagoon, a block MUST NOT contain a post-exec transaction. At and after Lagoon, every block MUST contain the
+version-1 post-exec commitment required by SDF, even when the sequencer assigns no gas refunds.
 
 ## Payload Schema (Version 1)
 
 When `version = 1`, the [post-exec payload][g-post-exec-payload] is RLP-encoded as:
 
 ```text
-[version, blockNumber, gasRefundEntries]
+[version, blockNumber, selectedBaseFeePerGas, gasRefundEntries]
 ```
 
-| Field              | Type                | Description                                                                                                   |
-| ------------------ | ------------------- | ------------------------------------------------------------------------------------------------------------- |
-| `version`          | `uint8`             | MUST be `1`.                                                                                                  |
-| `blockNumber`      | `uint64`            | The L2 block number containing this payload (see [post-exec.md § Block Number](./post-exec.md#block-number)). |
-| `gasRefundEntries` | `list<SDMGasEntry>` | Non-zero per-transaction gas refunds.                                                                         |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `version` | `uint8` | MUST be `1`. |
+| `blockNumber` | `uint64` | The L2 block number containing this payload (see [post-exec.md § Block Number](./post-exec.md#block-number)). |
+| `selectedBaseFeePerGas` | `uint64` | The block base fee committed by [Sequencer-Defined Fees](../sdf.md). |
+| `gasRefundEntries` | `list<SDMGasEntry>` | Possibly empty list of non-zero per-transaction gas refunds. |
 
 ### `SDMGasEntry`
 
@@ -79,14 +79,13 @@ Each entry in `gasRefundEntries` is an RLP list of two fields:
 
 A version-1 payload is invalid if any of the following hold:
 
-1. `gasRefundEntries` is empty.
-2. Any `SDMGasEntry` has `gasRefund == 0`.
-3. Entries are not ordered by strictly increasing `index`.
-4. Any entry's `index` does not refer to a standard Ethereum transaction in the block.
+1. Any `SDMGasEntry` has `gasRefund == 0`.
+2. Entries are not ordered by strictly increasing `index`.
+3. Any entry's `index` does not refer to a standard Ethereum transaction in the block.
 
-The envelope-level rules in [post-exec.md § Block-Level Structural Rules](./post-exec.md#block-level-structural-rules)
-apply in addition to the rules above. As long as SDM is the only active payload schema: if the sequencer assigns
-no gas refunds, the block has no post-exec transaction.
+An empty `gasRefundEntries` list is valid and means that no transaction receives an SDM refund. The envelope-level
+rules in [post-exec.md § Block-Level Structural Rules](./post-exec.md#block-level-structural-rules) and the SDF
+[selected-fee validation](../sdf.md#block-validation) apply in addition to the rules above.
 
 ## Transaction Classification
 
@@ -174,10 +173,12 @@ honest execution.
 
 Under SDM:
 
-- The sequencer executes the block, chooses the non-zero `gasRefundEntries`, and appends a post-exec transaction if
-  and only if the entry list is non-empty.
-- A verifier enforces the post-exec envelope rules and the SDM [validity rules](#validity-rules), then applies the
-  refunds from the payload when computing canonical gas, settlement, receipts, and block gas usage.
+- The sequencer executes the block, chooses the non-zero `gasRefundEntries`, and appends the post-exec commitment
+  required for every Lagoon block. If local refund production is disabled or no refunds are selected, it commits an
+  empty list.
+- A verifier enforces the post-exec envelope rules, SDF fee equality, and the SDM
+  [validity rules](#validity-rules), then applies the refunds from the payload when computing canonical gas,
+  settlement, receipts, and block gas usage.
 
 ## Receipt Extension
 
@@ -202,8 +203,8 @@ specified SDM: no post-exec transactions appear, no canonical-gas adjustment is 
 
 From the Lagoon activation timestamp, two changes become observable:
 
-- A `0x7D` transaction may appear at the end of any block produced after activation, exposed through the same
-  transaction-list interfaces used today.
+- A `0x7D` transaction appears at the end of every block, exposed through the same transaction-list interfaces used
+  today.
 - The receipts of standard Ethereum transactions in such blocks gain the `opGasRefund` field; clients that ignore unknown
   fields are unaffected.
 

--- a/specs/protocol/sdf.md
+++ b/specs/protocol/sdf.md
@@ -32,7 +32,9 @@ block base fee. L1 data fees and operator fees are unchanged.
 ## Activation
 
 SDF activates with the [Lagoon network upgrade](./lagoon/overview.md). It uses Lagoon's per-chain
-timestamp activation and has no separate feature flag or activation time.
+timestamp activation and has no separate feature flag or activation time. A block is at or after
+Lagoon exactly when its L2 block timestamp is greater than or equal to the configured Lagoon
+timestamp.
 
 Before Lagoon, the block base fee MUST be derived from the parent according to the active EIP-1559
 rules, including the Jovian DA-footprint input and minimum-base-fee clamp. A post-exec transaction
@@ -57,8 +59,13 @@ At Lagoon, the version-1 post-exec payload is RLP-encoded as:
 | `selectedBaseFeePerGas`     | `uint64`             | Base fee selected for the containing block, in wei. |
 | `gasRefundEntries`          | `list<SDMGasEntry>`  | Possibly empty [Sequencer-Defined Metering](./lagoon/sdm.md) refund list. |
 
+The payload MUST be one canonical RLP list containing exactly these four elements. Integer fields
+MUST use canonical minimal RLP integer encodings and values outside their declared widths MUST be
+rejected.
+
 `selectedBaseFeePerGas` MAY be zero. Its value is not constrained by the parent block's base fee,
-the EIP-1559 update formula, or the configured Jovian minimum base fee.
+the EIP-1559 update formula, or the configured Jovian minimum base fee. Its maximum value is the
+`uint64` maximum implied by the commitment field type.
 
 The post-exec transaction hash commits to `selectedBaseFeePerGas` because the field is part of the
 RLP payload covered by the [transaction hash](./lagoon/post-exec.md#transaction-hash).

--- a/specs/protocol/sdf.md
+++ b/specs/protocol/sdf.md
@@ -1,0 +1,174 @@
+# Sequencer-Defined Fees
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**
+
+- [Overview](#overview)
+- [Activation](#activation)
+- [Version-1 Commitment](#version-1-commitment)
+- [Block Production](#block-production)
+- [Block Validation](#block-validation)
+- [Deterministic Payload Building](#deterministic-payload-building)
+- [Fee Accounting and EVM Semantics](#fee-accounting-and-evm-semantics)
+- [Legacy Fee Parameters](#legacy-fee-parameters)
+- [Engine API and Derivation](#engine-api-and-derivation)
+- [Transaction Pool and Fee RPCs](#transaction-pool-and-fee-rpcs)
+- [Security Considerations](#security-considerations)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Overview
+
+Sequencer-Defined Fees (SDF) allows the sequencer to select the `baseFeePerGas` of each L2 block.
+The selected value is committed in the block's trailing
+[post-execution transaction](./lagoon/post-exec.md) (`0x7D`). Validators recover the selected value from that
+commitment and verify that it equals the block header's `baseFeePerGas`.
+
+SDF changes only how the block base fee is selected. Transaction base-fee checks, priority-fee
+accounting, the `BASEFEE` opcode, and deposits into the `BaseFeeVault` continue to use the selected
+block base fee. L1 data fees and operator fees are unchanged.
+
+## Activation
+
+SDF activates with the [Lagoon network upgrade](./lagoon/overview.md). It uses Lagoon's per-chain
+timestamp activation and has no separate feature flag or activation time.
+
+Before Lagoon, the block base fee MUST be derived from the parent according to the active EIP-1559
+rules, including the Jovian DA-footprint input and minimum-base-fee clamp. A post-exec transaction
+MUST NOT appear.
+
+At and after Lagoon, every block MUST contain exactly one post-exec transaction satisfying the
+[block-level structural rules](./lagoon/post-exec.md#block-level-structural-rules). The post-exec transaction
+MUST be the final transaction in the block and MUST use payload schema version 1.
+
+## Version-1 Commitment
+
+At Lagoon, the version-1 post-exec payload is RLP-encoded as:
+
+```text
+[version, blockNumber, selectedBaseFeePerGas, gasRefundEntries]
+```
+
+| Field                       | Type                 | Description |
+| --------------------------- | -------------------- | ----------- |
+| `version`                   | `uint8`              | MUST be `1`. |
+| `blockNumber`               | `uint64`             | MUST equal the number of the containing L2 block. |
+| `selectedBaseFeePerGas`     | `uint64`             | Base fee selected for the containing block, in wei. |
+| `gasRefundEntries`          | `list<SDMGasEntry>`  | Possibly empty [Sequencer-Defined Metering](./lagoon/sdm.md) refund list. |
+
+`selectedBaseFeePerGas` MAY be zero. Its value is not constrained by the parent block's base fee,
+the EIP-1559 update formula, or the configured Jovian minimum base fee.
+
+The post-exec transaction hash commits to `selectedBaseFeePerGas` because the field is part of the
+RLP payload covered by the [transaction hash](./lagoon/post-exec.md#transaction-hash).
+
+## Block Production
+
+For a locally sequenced Lagoon block, the execution engine MUST:
+
+1. Ask its configured producer policy to select one base fee for the payload job.
+2. Resolve that value exactly once for the job.
+3. Use the resolved value as the EVM block base fee while executing every transaction.
+4. Append a version-1 post-exec transaction committing the same value.
+
+Failure of the producer policy MUST abort block production. An implementation MUST NOT silently
+substitute another fee after policy failure.
+
+The policy is an operator choice and is not consensus-critical. Changing or reconfiguring the policy
+after Lagoon does not require a hardfork. A conforming implementation MAY use the pre-Lagoon Jovian
+EIP-1559 result as its policy for backwards-compatible behavior.
+
+A locally sequenced payload-attributes request MUST NOT supply a post-exec transaction. Post-exec is
+sequencer-generated validator data and MUST NOT be accepted from the transaction pool or public
+transaction-submission RPCs.
+
+## Block Validation
+
+For a Lagoon block, a validator MUST:
+
+1. Decode and validate the trailing version-1 post-exec payload.
+2. Read `selectedBaseFeePerGas` before constructing the block's EVM environment.
+3. Require the header's `baseFeePerGas` to be present.
+4. Require `header.baseFeePerGas == selectedBaseFeePerGas`.
+5. Execute all transactions using `selectedBaseFeePerGas` as the EVM block base fee.
+
+The validator MUST NOT invoke the sequencer's producer policy and MUST NOT apply the parent-derived
+EIP-1559 base-fee check. A Lagoon block with a missing post-exec transaction, a missing header base
+fee, or unequal committed and header fees is invalid.
+
+Before Lagoon, validators continue to enforce the parent-derived EIP-1559 base-fee check and reject
+all post-exec transactions.
+
+## Deterministic Payload Building
+
+When the rollup node requests deterministic execution with `noTxPool = true`, an embedded post-exec
+transaction is validator data. The execution engine MUST use its committed fee and MUST NOT invoke a
+local producer policy.
+
+If deterministic Lagoon payload attributes contain no post-exec transaction, the execution engine
+MUST carry forward the parent block's base fee and synthesize the canonical version-1 post-exec
+transaction with:
+
+```text
+selectedBaseFeePerGas = parent.baseFeePerGas
+gasRefundEntries = []
+```
+
+The synthesized transaction participates in the transaction and receipt roots exactly like an
+embedded post-exec transaction. This fallback is deterministic and therefore reproducible by fault
+proof implementations.
+
+## Fee Accounting and EVM Semantics
+
+For every regular transaction in a Lagoon block:
+
+- the normal validity check against the block base fee remains active;
+- the effective priority fee is computed relative to the selected block base fee;
+- `BASEFEE` returns the selected block base fee;
+- the base-fee portion is credited to the `BaseFeeVault`; and
+- receipts and fee accounting use the selected block base fee.
+
+SDF does not alter L1 data-fee or operator-fee formulas. SDM settlement, when present, uses the same
+selected block base fee as described in [sdm.md](./lagoon/sdm.md#settlement).
+
+## Legacy Fee Parameters
+
+Lagoon does not remove the existing `eip1559Params`, `minBaseFee`, or block-header `extraData`
+encodings. Derivation and block production continue to populate them for compatibility.
+
+At and after Lagoon these values are not consensus inputs to base-fee selection or validation. They
+MAY be used as inputs to a producer policy, including a compatibility policy that selects the legacy
+Jovian result.
+
+## Engine API and Derivation
+
+SDF does not add a field to `PayloadAttributesV3`, change an Engine API method version, or modify the
+singular or span batch formats. The selected fee is transported by the existing transaction list as
+the trailing post-exec transaction.
+
+The batcher includes the post-exec transaction in L2 batch data like any other L2 transaction.
+Derivation passes the encoded transaction through to deterministic payload attributes unchanged.
+Unsafe/safe consolidation therefore compares payloads that include the selected-fee commitment.
+
+## Transaction Pool and Fee RPCs
+
+On a producer node, the policy's provisional next-block quote SHOULD be used for transaction-pool
+base-fee classification, pending execution environments, gas estimation, transaction filling,
+`eth_gasPrice`, base-fee suggestions, and the final next-block entry returned by `eth_feeHistory`.
+The actual fee is resolved again and held immutable when a payload job starts.
+
+A replica cannot in general reproduce a private sequencer policy before receiving a block. It SHOULD
+proxy fee suggestions to the sequencer or use a documented conservative fallback, such as the latest
+observed base fee.
+
+## Security Considerations
+
+**Commitment equality.** The selected fee is authenticated by the block because it is committed by
+both the header and the transaction root. Validators require those two commitments to agree.
+
+**Policy isolation.** Producer policy code is never a validator input. A policy failure can stop
+sequencing but cannot make validators compute a different fee.
+
+**Immutable job selection.** Resolving the selected fee once prevents a runtime policy update from
+changing the EVM environment and post-exec commitment to different values within one payload job.

--- a/specs/protocol/sdf.md
+++ b/specs/protocol/sdf.md
@@ -40,9 +40,10 @@ Before Lagoon, the block base fee MUST be derived from the parent according to t
 rules, including the Jovian DA-footprint input and minimum-base-fee clamp. A post-exec transaction
 MUST NOT appear.
 
-At and after Lagoon, every block MUST contain exactly one post-exec transaction satisfying the
+At and after Lagoon, every non-genesis block MUST contain exactly one post-exec transaction satisfying the
 [block-level structural rules](./lagoon/post-exec.md#block-level-structural-rules). The post-exec transaction
-MUST be the final transaction in the block and MUST use payload schema version 1.
+MUST be the final transaction in the block and MUST use payload schema version 1. Genesis contains no transactions
+and is exempt when Lagoon is configured active from genesis.
 
 ## Version-1 Commitment
 
@@ -111,7 +112,8 @@ all post-exec transactions.
 
 When the rollup node requests deterministic execution with `noTxPool = true`, an embedded post-exec
 transaction is validator data. The execution engine MUST use its committed fee and MUST NOT invoke a
-local producer policy.
+local producer policy. This deterministic rule takes precedence over [Block Production](#block-production),
+including when a sequencer locally builds the Lagoon activation block or an invalid-message replacement block.
 
 If deterministic Lagoon payload attributes contain no post-exec transaction, the execution engine
 MUST carry forward the parent block's base fee and synthesize the canonical version-1 post-exec
@@ -151,8 +153,13 @@ Jovian result.
 ## Engine API and Derivation
 
 SDF does not add a field to `PayloadAttributesV3`, change an Engine API method version, or modify the
-singular or span batch formats. The selected fee is transported by the existing transaction list as
-the trailing post-exec transaction.
+singular or span batch layouts. The selected fee is transported by the existing transaction list as
+the trailing post-exec transaction. Singular batches carry its complete EIP-2718 bytes.
+
+Span batches use the existing transposed transaction fields: `tx_types` contains `0x7D`, `tx_datas` contains the
+opaque RLP payload, the signature, nonce, and gas fields are zero, and the contract-creation bit represents the
+absence of a recipient. This projection is valid only at and after Lagoon and reconstructs the same canonical
+EIP-2718 bytes without adding a span-batch version or field.
 
 The batcher includes the post-exec transaction in L2 batch data like any other L2 transaction.
 Derivation passes the encoded transaction through to deterministic payload attributes unchanged.

--- a/specs/protocol/sdf.md
+++ b/specs/protocol/sdf.md
@@ -93,7 +93,7 @@ transaction-submission RPCs.
 
 ## Block Validation
 
-For a Lagoon block, a validator MUST:
+For a non-genesis Lagoon block, a validator MUST:
 
 1. Decode and validate the trailing version-1 post-exec payload.
 2. Read `selectedBaseFeePerGas` before constructing the block's EVM environment.
@@ -102,8 +102,9 @@ For a Lagoon block, a validator MUST:
 5. Execute all transactions using `selectedBaseFeePerGas` as the EVM block base fee.
 
 The validator MUST NOT invoke the sequencer's producer policy and MUST NOT apply the parent-derived
-EIP-1559 base-fee check. A Lagoon block with a missing post-exec transaction, a missing header base
-fee, or unequal committed and header fees is invalid.
+EIP-1559 base-fee check. A non-genesis Lagoon block with a missing post-exec transaction, a missing
+header base fee, or unequal committed and header fees is invalid. A genesis block with no
+transactions remains exempt when Lagoon is active from genesis.
 
 Before Lagoon, validators continue to enforce the parent-derived EIP-1559 base-fee check and reject
 all post-exec transactions.
@@ -156,10 +157,13 @@ SDF does not add a field to `PayloadAttributesV3`, change an Engine API method v
 singular or span batch layouts. The selected fee is transported by the existing transaction list as
 the trailing post-exec transaction. Singular batches carry its complete EIP-2718 bytes.
 
-Span batches use the existing transposed transaction fields: `tx_types` contains `0x7D`, `tx_datas` contains the
-opaque RLP payload, the signature, nonce, and gas fields are zero, and the contract-creation bit represents the
-absence of a recipient. This projection is valid only at and after Lagoon and reconstructs the same canonical
-EIP-2718 bytes without adding a span-batch version or field.
+Span batches use the existing transposed transaction fields. The post-exec entry in `tx_datas` is the
+complete `0x7D || rlp_encoded_payload` encoding. Its `r`, `s`, y-parity, nonce, and gas placeholders
+are zero, and its contract-creation bit is one so no recipient is encoded. The protected bitlist has
+no entry because post-exec is not a legacy transaction. This projection is valid only at and after
+Lagoon and reconstructs the same canonical EIP-2718 bytes without adding a span-batch version or
+field. The normative span-batch encoding and type-activation rules are specified in
+[span-batches.md](./delta/span-batches.md#span-batch-format).
 
 The batcher includes the post-exec transaction in L2 batch data like any other L2 transaction.
 Derivation passes the encoded transaction through to deterministic payload attributes unchanged.


### PR DESCRIPTION
## Description

Specify Sequencer-Defined Fees (SDF) for Lagoon:

- the sequencer selects the L2 `baseFeePerGas`
- every Lagoon block commits the selected fee in its trailing version-1 `PostExec` transaction
- validators recover the committed fee before execution and verify the resulting block
- deterministic payload building synthesizes an empty commitment when needed
- the commitment uses a canonical four-element RLP payload with a `uint64` selected fee

The proposal does not change L1 data fees, operator fees, batch formats, or Engine API payload-attribute schemas.

## Dependencies

- Implementation draft: ethereum-optimism/optimism#22666
- Generic reth hooks: ethereum-optimism/reth#8

The branch is based on current `main` and extends the merged Lagoon PostExec/SDM documents.

## Validation

- Markdown lint passed
- table-of-contents check passed
- spelling check passed
- mdBook HTML and internal-link build passed
- external link checking is left to CI because the local Docker daemon was unavailable

## Review status

Draft: final review and CI follow-up are still in progress.
