### PR TITLE
docs(superchain-upgrades): disallow simultaneous upgrade activations

### DIFF
--- a/specs/protocol/superchain-upgrades.md
+++ b/specs/protocol/superchain-upgrades.md
@@ -262,6 +262,11 @@ Note that this constraint governs OP-Stack network upgrades only.
 It does not constrain an OP-Stack upgrade timestamp against an L1 fork timestamp
 configured on the same chain, which may coincide.
 
+The constraint is not retroactive: a small number of chains activated two upgrades
+in the same block before this rule was written down, and their activation history cannot be
+changed. Implementations must keep syncing those chains, so the rule is enforced on newly
+scheduled activations rather than on all historical configurations.
+
 ## OP-Stack Protocol versions
 
 - `v1.0.0`: 2021 Jan 16th - Mainnet Soft Launch, based on OVM.

--- a/specs/protocol/superchain-upgrades.md
+++ b/specs/protocol/superchain-upgrades.md
@@ -19,6 +19,7 @@
 - [Activation rules](#activation-rules)
   - [L2 Block-number based activation (deprecated)](#l2-block-number-based-activation-deprecated)
   - [L2 Block-timestamp based activation](#l2-block-timestamp-based-activation)
+  - [At most one network upgrade per activation timestamp](#at-most-one-network-upgrade-per-activation-timestamp)
 - [OP-Stack Protocol versions](#op-stack-protocol-versions)
 - [Post-Bedrock Network upgrades](#post-bedrock-network-upgrades)
   - [Activation Timestamps](#activation-timestamps)
@@ -235,6 +236,31 @@ because it can be planned in accordance with beacon-chain epochs and slots.
 Note that the L2 version is not limited to timestamps that match L1 beacon-chain slots or epochs.
 A timestamp may be chosen to be synchronous with a specific slot or epoch on L1,
 but the matching L1-origin information may not be present at the time of activation on L2.
+
+### At most one network upgrade per activation timestamp
+
+Two network upgrades MUST NOT be configured to activate at the same L2 block timestamp,
+unless that timestamp is at or before the L2 genesis block timestamp.
+Equivalently: the activation timestamps of all network upgrades that activate after genesis
+MUST be strictly increasing in upgrade order.
+
+Chains whose genesis is created after one or more upgrades have already been defined
+activate those upgrades in the genesis block itself, conventionally by setting their
+activation timestamps to `0`. No activation block processing happens for those upgrades,
+so they may — and usually do — share an activation timestamp.
+
+The restriction applies to the activation block of a post-genesis upgrade.
+Each upgrade defines its activation-block behavior — the upgrade transactions it deposits,
+the state changes it makes, and the way it derives that block's attributes —
+against a chain on which every preceding upgrade is already active and every succeeding
+upgrade is not. Two upgrades sharing an activation block break that assumption:
+their activation-block changes are applied together, and their interaction is not defined
+by either upgrade's specification. Supporting it would require specifying and testing every
+combination of upgrades that could activate together, so it is disallowed instead.
+
+Note that this constraint governs OP-Stack network upgrades only.
+It does not constrain an OP-Stack upgrade timestamp against an L1 fork timestamp
+configured on the same chain, which may coincide.
 
 ## OP-Stack Protocol versions
 


### PR DESCRIPTION
Adds a general activation rule: starting with Jovian, two network upgrades MUST NOT activate at the same L2 block timestamp, unless that timestamp is at or before genesis (where upgrades activate in the genesis block itself and conventionally share timestamp `0`).

The restriction was already real but undocumented — nothing in the specs constrained activation-time ordering, and [`checkFork`](https://github.com/ethereum-optimism/optimism/blob/develop/op-node/rollup/types.go#L465-L480) in op-node explicitly permits equality. [ethereum-optimism/optimism#22828](https://github.com/ethereum-optimism/optimism/issues/22828) is what surfaced it: Karst and Lagoon activating at the same non-genesis timestamp both add upgrade gas, but the reconstruction helpers only subtract Karst's allocation, so the inflated gas limit persists.

Per the thread discussion, the rule is stated once under "Activation rules" rather than repeated in each fork's own specification. The rationale — each upgrade's activation-block behavior is only defined against a chain where every prior upgrade is active and every later one is not, so supporting overlapping activations would mean specifying and testing every combination of upgrades that could activate together — is kept here rather than in the spec text, per review.

The wording is scoped to OP-Stack network upgrades — it deliberately does not constrain an OP-Stack upgrade timestamp against an L1 fork timestamp on the same chain (e.g. Upgrade 15 sets `pragueTime == isthmusTime`).

The rule starts at Jovian because six chains in the superchain registry already share a post-genesis activation timestamp between two upgrades: Celo mainnet activated Holocene and Isthmus at `1752073200` (genesis `1742957258`), and sepolia/boba, sepolia/lisk, sepolia/mode, sepolia/race and sepolia/soneium-minato each share a timestamp between two earlier upgrades. Every one of those pairs predates Jovian, so the rule binds newly scheduled activations without invalidating history that cannot be changed.

Companion monorepo PR — docs plus the strengthened rollup-config validation, enforcing from the same fork (`strictActivationOrderFrom = forks.Jovian`): [ethereum-optimism/optimism#22838](https://github.com/ethereum-optimism/optimism/pull/22838)

Prompted by: @sebastianst
